### PR TITLE
Url Parser Fixes

### DIFF
--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -287,9 +287,12 @@ _.extend(Url, /** @lends Url */ {
         _.isString(p.port) && (url = url.substr(p.port.length + 1));
 
         // extract the path
-        p.path = url.match(/.*?(?=\?|#|$)/);
-        p.path = _.get(p.path, '[0]');
-        _.isString(p.path) && ((url = url.substr(p.path.length)), (p.path = p.path.split('/')));
+        p.path = _.get(url.match(/.*?(?=\?|#|$)/), '[0]');
+        if (_.isString(p.path)) {
+            url = url.substr(p.path.length);
+            // if path is blank string, we set it to undefined, if '/' then single blank string array
+            p.path = !p.path ? undefined : (p.path === '/' ? [''] : p.path.split('/'));
+        }
 
         // extract the query string
         p.query = url.match(/^\?([^#$]+)/);

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -283,8 +283,7 @@ _.extend(Url, /** @lends Url */ {
         _.isString(p.host) && ((url = url.substr(p.host.length)), (p.host = _.trim(p.host, '.').split('.')));
 
         // get the port
-        p.port = url.match(/^:(\d+|{{.+}})(\/|\?|^)/);
-        p.port = _.get(p.port, '[1]');
+        p.port = _.get(url.match(/^:(.+?)(\/|\?|$)/), '[1]');
         _.isString(p.port) && (url = url.substr(p.port.length + 1));
 
         // extract the path

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -265,23 +265,28 @@ _.extend(Url, /** @lends Url */ {
         p.protocol = _.get(url.match(/^([^:]+):\/\/([^\?#\/:]+|$)/), '[1]');
         _.isString(p.protocol) && (url = url.substr(p.protocol.length + 3)); // remove that damn protocol from url
 
-        // extract authentication information
-        p.auth = url.match(/^(([^:]+):?([^@]*))@([^\?#\/:]+|$)/);
-        // remove the auth part from url
-        _.isString(_.get(p.auth, '[1]')) && (url = url.substr(_.get(p.auth, '[1]').length + 1));
-        p.auth = {
-            user: _.get(p.auth, '[2]'),
-            password: _.get(p.auth, '[3]')
-        };
-        (p.auth.user === undefined && p.auth.password === undefined) && (p.auth = undefined); // remove emoty auth
-
         // extract the host
-        p.host = _.get(url.match(/^([^\?#\/:]+)/), '[1]');
-        _.isString(p.host) && ((url = url.substr(p.host.length)), (p.host = _.trim(p.host, '.').split('.')));
+        p.host = _.get(url.match(/^([^\?#\/]+)/), '[1]');
 
-        // get the port
-        p.port = _.get(url.match(/^:(.+?)(\/|\?|$)/), '[1]');
-        _.isString(p.port) && (url = url.substr(p.port.length + 1));
+        // if host exists there are a lot you can extract from it
+        if (_.isString(p.host)) {
+            url = url.substr(p.host.length); // remove host from url
+
+            if (p.auth = _.get(p.host.match(/^([^@]+)@/), '[1]')) {
+                p.host = p.host.substr(p.auth.length + 1); // remove auth from host
+                p.auth = p.auth.split(':');
+                p.auth = {
+                    user: p.auth[0],
+                    password: p.auth[1]
+                };
+            }
+
+            // extract the port from the host
+            p.port = _.get(p.host.match(/:([^:]*)$/), '[1]');
+            p.port && (p.host = p.host.substring(0, p.host.length - p.port.length - 1)); // remove port from url
+
+            p.host = _.trim(p.host, '.').split('.'); // split host by subdomains
+        }
 
         // extract the path
         p.path = _.get(url.match(/.*?(?=\?|#|$)/), '[0]');
@@ -290,7 +295,6 @@ _.extend(Url, /** @lends Url */ {
             p.path && (p.path = p.path.replace(/^\/((.+))$/, '$1')); // remove leading slash for valid path
             // if path is blank string, we set it to undefined, if '/' then single blank string array
             p.path = !p.path ? undefined : (p.path === '/' ? [''] : p.path.split('/'));
-
         }
 
         // extract the query string
@@ -299,7 +303,6 @@ _.extend(Url, /** @lends Url */ {
 
         // extract the hash
         p.hash = _.get(url.match(/#(.+)$/), '[1]');
-
         return p;
     }
 });

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -287,8 +287,10 @@ _.extend(Url, /** @lends Url */ {
         p.path = _.get(url.match(/.*?(?=\?|#|$)/), '[0]');
         if (_.isString(p.path)) {
             url = url.substr(p.path.length);
+            p.path && (p.path = p.path.replace(/^\/((.+))$/, '$1')); // remove leading slash for valid path
             // if path is blank string, we set it to undefined, if '/' then single blank string array
             p.path = !p.path ? undefined : (p.path === '/' ? [''] : p.path.split('/'));
+
         }
 
         // extract the query string

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -262,10 +262,8 @@ _.extend(Url, /** @lends Url */ {
         };
 
         // extract the protocol
-        p.protocol = url.match(/^([^:]+):\/\/([^\?#\/:]+|$)/);
-        p.protocol = _.get(p.protocol, '[1]');
-        // remove that damn protocol from url
-        _.isString(p.protocol) && (url = url.substr(p.protocol.length + 3));
+        p.protocol = _.get(url.match(/^([^:]+):\/\/([^\?#\/:]+|$)/), '[1]');
+        _.isString(p.protocol) && (url = url.substr(p.protocol.length + 3)); // remove that damn protocol from url
 
         // extract authentication information
         p.auth = url.match(/^(([^:]+):?([^@]*))@([^\?#\/:]+|$)/);
@@ -278,8 +276,7 @@ _.extend(Url, /** @lends Url */ {
         (p.auth.user === undefined && p.auth.password === undefined) && (p.auth = undefined); // remove emoty auth
 
         // extract the host
-        p.host = url.match(/^([^\?#\/:]+)/);
-        p.host = _.get(p.host, '[1]');
+        p.host = _.get(url.match(/^([^\?#\/:]+)/), '[1]');
         _.isString(p.host) && ((url = url.substr(p.host.length)), (p.host = _.trim(p.host, '.').split('.')));
 
         // get the port
@@ -295,13 +292,11 @@ _.extend(Url, /** @lends Url */ {
         }
 
         // extract the query string
-        p.query = url.match(/^\?([^#$]+)/);
-        p.query = _.get(p.query, '[1]');
+        p.query = _.get(url.match(/^\?([^#$]+)/), '[1]');
         _.isString(p.query) && ((url = url.substr(p.query.length + 1)), (p.query = QueryParam.parse(p.query)));
 
         // extract the hash
-        p.hash = url.match(/#(.+)$/);
-        p.hash = _.get(p.hash, '[1]');
+        p.hash = _.get(url.match(/#(.+)$/), '[1]');
 
         return p;
     }

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -275,6 +275,7 @@ _.extend(Url, /** @lends Url */ {
             user: _.get(p.auth, '[2]'),
             password: _.get(p.auth, '[3]')
         };
+        (p.auth.user === undefined && p.auth.password === undefined) && (p.auth = undefined); // remove emoty auth
 
         // extract the host
         p.host = url.match(/^([^\?#\/:]+)/);

--- a/test/functional/url.test.js
+++ b/test/functional/url.test.js
@@ -5,6 +5,238 @@ var expect = require('expect.js'),
 
 /* global describe, it */
 describe('Url', function () {
+    describe('.parse()', function () {
+        it('must parse bare ipv4 addresses', function () {
+            var subject = Url.parse('127.0.0.1');
+            expect(subject.protocol).to.be(undefined);
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
+            expect(subject.port).to.be(undefined);
+            expect(subject.path).to.be(undefined);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse bare ipv4 addresses with variables', function () {
+            var subject = Url.parse('127.0.{{subnet}}.1');
+            expect(subject.protocol).to.be(undefined);
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['127', '0', '{{subnet}}', '1']);
+            expect(subject.port).to.be(undefined);
+            expect(subject.path).to.be(undefined);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse bare ipv4 addresses with protocol', function () {
+            var subject = Url.parse('http://127.0.0.1');
+            expect(subject.protocol).to.be('http');
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
+            expect(subject.port).to.be(undefined);
+            expect(subject.path).to.be(undefined);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse bare ipv4 addresses with non standard protocol', function () {
+            var subject = Url.parse('{{my-protocol}}://127.0.0.1');
+            expect(subject.protocol).to.be('{{my-protocol}}');
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
+            expect(subject.port).to.be(undefined);
+            expect(subject.path).to.be(undefined);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse bare ipv4 addresses with port', function () {
+            var subject = Url.parse('127.0.0.1:80');
+            expect(subject.protocol).to.be(undefined);
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
+            expect(subject.port).to.be('80');
+            expect(subject.path).to.be(undefined);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse invalid port of bare ipv4 addresses', function () {
+            var subject = Url.parse('127.0.0.1:{{my-port}}');
+            expect(subject.protocol).to.be(undefined);
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
+            expect(subject.port).to.be('{{my-port}}');
+            expect(subject.path).to.be(undefined);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse bare ipv4 addresses with protocol and port', function () {
+            var subject = Url.parse('http://127.0.0.1:80');
+            expect(subject.protocol).to.be('http');
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
+            expect(subject.port).to.be('80');
+            expect(subject.path).to.be(undefined);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+        it('must parse bare ipv4 addresses with protocol and port as variables', function () {
+            var subject = Url.parse('{{my-protocol}}://127.0.0.1:{{my-port}}');
+            expect(subject.protocol).to.be('{{my-protocol}}');
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
+            expect(subject.port).to.be('{{my-port}}');
+            expect(subject.path).to.be(undefined);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+        it('must parse variable as host with protocol and port as variables', function () {
+            var subject = Url.parse('{{my-protocol}}://{{my-host}}:{{my-port}}');
+            expect(subject.protocol).to.be('{{my-protocol}}');
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['{{my-host}}']);
+            expect(subject.port).to.be('{{my-port}}');
+            expect(subject.path).to.be(undefined);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse trailing path backslash in ipv4 address', function () {
+            var subject = Url.parse('http://127.0.0.1/');
+            expect(subject.protocol).to.be('http');
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
+            expect(subject.port).to.eql(undefined);
+            expect(subject.path).to.eql(['']);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse trailing path backslash in ipv4 address and port', function () {
+            var subject = Url.parse('http://127.0.0.1:8080/');
+            expect(subject.protocol).to.be('http');
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
+            expect(subject.port).to.be('8080');
+            expect(subject.path).to.eql(['']);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse path backslash in ipv4 address and port', function () {
+            var subject = Url.parse('http://127.0.0.1:8080/hello/world');
+            expect(subject.protocol).to.be('http');
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
+            expect(subject.port).to.be('8080');
+            expect(subject.path).to.eql(['hello', 'world']);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse path backslash in ipv4 address and port and retan trailing slash marker', function () {
+            var subject = Url.parse('http://127.0.0.1:8080/hello/world/');
+            expect(subject.protocol).to.be('http');
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
+            expect(subject.port).to.be('8080');
+            expect(subject.path).to.eql(['hello', 'world', '']);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse path where entire host is a variable', function () {
+            var subject = Url.parse('{{my-url}}/hello/world/');
+            expect(subject.protocol).to.be(undefined);
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['{{my-url}}']);
+            expect(subject.port).to.be(undefined);
+            expect(subject.path).to.eql(['hello', 'world', '']);
+            expect(subject.query).to.be(undefined);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse path where entire host is a variable and query param provided', function () {
+            var subject = Url.parse('{{my-url}}/hello/world/?query=param');
+            expect(subject.protocol).to.be(undefined);
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['{{my-url}}']);
+            expect(subject.port).to.be(undefined);
+            expect(subject.path).to.eql(['hello', 'world', '']);
+            expect(subject.query).to.eql([{
+                key: 'query',
+                value: 'param'
+            }]);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse path where entire host is a variable and query param provided with hash', function () {
+            var subject = Url.parse('{{my-url}}/hello/world/?query=param#test-api');
+            expect(subject.protocol).to.be(undefined);
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['{{my-url}}']);
+            expect(subject.port).to.be(undefined);
+            expect(subject.path).to.eql(['hello', 'world', '']);
+            expect(subject.query).to.eql([{
+                key: 'query',
+                value: 'param'
+            }]);
+            expect(subject.hash).to.be('test-api');
+        });
+
+        it('must parse url query-param even if `?` is present in the URL hash', function () {
+            var subject = Url.parse('{{my-url}}/hello/world/?query=param#?test-api=true');
+            expect(subject.protocol).to.be(undefined);
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['{{my-url}}']);
+            expect(subject.port).to.be(undefined);
+            expect(subject.path).to.eql(['hello', 'world', '']);
+            expect(subject.query).to.eql([{
+                key: 'query',
+                value: 'param'
+            }]);
+            expect(subject.hash).to.be('?test-api=true');
+        });
+
+        it('must parse url even if dulicate `?` is present in query-param', function () {
+            var subject = Url.parse('{{my-url}}/hello/world/?query=param&err?ng=v_l?e@!');
+            expect(subject.protocol).to.be(undefined);
+            expect(subject.auth).to.be(undefined);
+            expect(subject.host).to.eql(['{{my-url}}']);
+            expect(subject.port).to.be(undefined);
+            expect(subject.path).to.eql(['hello', 'world', '']);
+            expect(subject.query).to.eql([{
+                key: 'query',
+                value: 'param'
+            }, {
+                key: 'err?ng',
+                value: 'v_l?e@!'
+            }]);
+            expect(subject.hash).to.be(undefined);
+        });
+
+        it('must parse url having auth even if dulicate `@` is present in query-param', function () {
+            var subject = Url.parse('username:password@{{my-url}}/hello/world/?query=param&err?ng=v_l?e@!');
+            expect(subject.protocol).to.be(undefined);
+            expect(subject.auth).to.eql({
+                user: 'username',
+                password: 'password'
+            });
+            expect(subject.host).to.eql(['{{my-url}}']);
+            expect(subject.port).to.be(undefined);
+            expect(subject.path).to.eql(['hello', 'world', '']);
+            expect(subject.query).to.eql([{
+                key: 'query',
+                value: 'param'
+            }, {
+                key: 'err?ng',
+                value: 'v_l?e@!'
+            }]);
+            expect(subject.hash).to.be(undefined);
+        });
+    });
     describe('unparsing', function () {
         rawUrls.forEach(function (rawUrl) {
             _.isString(rawUrl) && describe(rawUrl, function () {

--- a/test/functional/url.test.js
+++ b/test/functional/url.test.js
@@ -147,22 +147,11 @@ describe('Url', function () {
             expect(subject.hash).to.be(undefined);
         });
 
-        it('must parse path where entire host is a variable', function () {
-            var subject = Url.parse('{{my-url}}/hello/world/');
+        it('must parse path and query in ipv4 address and port and retan trailing slash marker', function () {
+            var subject = Url.parse('127.0.0.1/hello/world/?query=param');
             expect(subject.protocol).to.be(undefined);
             expect(subject.auth).to.be(undefined);
-            expect(subject.host).to.eql(['{{my-url}}']);
-            expect(subject.port).to.be(undefined);
-            expect(subject.path).to.eql(['hello', 'world', '']);
-            expect(subject.query).to.be(undefined);
-            expect(subject.hash).to.be(undefined);
-        });
-
-        it('must parse path where entire host is a variable and query param provided', function () {
-            var subject = Url.parse('{{my-url}}/hello/world/?query=param');
-            expect(subject.protocol).to.be(undefined);
-            expect(subject.auth).to.be(undefined);
-            expect(subject.host).to.eql(['{{my-url}}']);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
             expect(subject.port).to.be(undefined);
             expect(subject.path).to.eql(['hello', 'world', '']);
             expect(subject.query).to.eql([{
@@ -172,11 +161,11 @@ describe('Url', function () {
             expect(subject.hash).to.be(undefined);
         });
 
-        it('must parse path where entire host is a variable and query param provided with hash', function () {
-            var subject = Url.parse('{{my-url}}/hello/world/?query=param#test-api');
+        it('must parse ip address host with query param and hash', function () {
+            var subject = Url.parse('127.0.0.1/hello/world/?query=param#test-api');
             expect(subject.protocol).to.be(undefined);
             expect(subject.auth).to.be(undefined);
-            expect(subject.host).to.eql(['{{my-url}}']);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
             expect(subject.port).to.be(undefined);
             expect(subject.path).to.eql(['hello', 'world', '']);
             expect(subject.query).to.eql([{
@@ -187,10 +176,10 @@ describe('Url', function () {
         });
 
         it('must parse url query-param even if `?` is present in the URL hash', function () {
-            var subject = Url.parse('{{my-url}}/hello/world/?query=param#?test-api=true');
+            var subject = Url.parse('127.0.0.1/hello/world/?query=param#?test-api=true');
             expect(subject.protocol).to.be(undefined);
             expect(subject.auth).to.be(undefined);
-            expect(subject.host).to.eql(['{{my-url}}']);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
             expect(subject.port).to.be(undefined);
             expect(subject.path).to.eql(['hello', 'world', '']);
             expect(subject.query).to.eql([{
@@ -201,10 +190,10 @@ describe('Url', function () {
         });
 
         it('must parse url even if dulicate `?` is present in query-param', function () {
-            var subject = Url.parse('{{my-url}}/hello/world/?query=param&err?ng=v_l?e@!');
+            var subject = Url.parse('127.0.0.1/hello/world/?query=param&err?ng=v_l?e@!');
             expect(subject.protocol).to.be(undefined);
             expect(subject.auth).to.be(undefined);
-            expect(subject.host).to.eql(['{{my-url}}']);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
             expect(subject.port).to.be(undefined);
             expect(subject.path).to.eql(['hello', 'world', '']);
             expect(subject.query).to.eql([{
@@ -218,13 +207,13 @@ describe('Url', function () {
         });
 
         it('must parse url having auth even if dulicate `@` is present in query-param', function () {
-            var subject = Url.parse('username:password@{{my-url}}/hello/world/?query=param&err?ng=v_l?e@!');
+            var subject = Url.parse('username:password@127.0.0.1/hello/world/?query=param&err?ng=v_l?e@!');
             expect(subject.protocol).to.be(undefined);
             expect(subject.auth).to.eql({
                 user: 'username',
                 password: 'password'
             });
-            expect(subject.host).to.eql(['{{my-url}}']);
+            expect(subject.host).to.eql(['127', '0', '0', '1']);
             expect(subject.port).to.be(undefined);
             expect(subject.path).to.eql(['hello', 'world', '']);
             expect(subject.query).to.eql([{

--- a/test/unit/request.test.js
+++ b/test/unit/request.test.js
@@ -36,20 +36,9 @@ describe('Request', function () {
 
             describe('has property', function () {
                 describe('auth', function () {
-                    it('an object', function () {
+                    it('is undefined', function () {
                         expect(request.url).to.have.property('auth');
-                        expect(request.url.auth).to.be.an('object');
-                        expect(request.url.auth).to.not.be.empty();
-                    });
-
-                    describe('has property', function () {
-                        it('user', function () {
-                            expect(request.url.auth).to.have.property('user', undefined);
-                        });
-
-                        it('password', function () {
-                            expect(request.url.auth).to.have.property('password', undefined);
-                        });
+                        expect(request.url.auth).to.be(undefined);
                     });
                 });
 


### PR DESCRIPTION
This PR simplifies the code of URL parser and also fixes a few bugs as mentioned in the commits. It also improves the handling of path segments.

It also adds a bunch of unit tests on the `Url.parse` function that are primarily in and around IP address type URLs