### PR TITLE
Added draft and private `Property#toObjectResolved` to procure an Obj…

### DIFF
--- a/lib/collection/property.js
+++ b/lib/collection/property.js
@@ -96,6 +96,35 @@ _.extend(Property.prototype, /** @lends Property.prototype */ {
     describe: function (content, type) {
         (Description.isDescription(this.description) ? this.description : (this.description = new Description()))
             .update(content, type);
+    },
+
+    /**
+     * Returns an object representation of the Property with its variable references substituted.
+     * @private
+     * @draft
+     *
+     * @param {VariableList=} [variables] - One can specifically provide a VariableList for doing the substitution. In
+     * the event one is not provided, the variables are taken from this object or one from the parent tree.
+     * @returns {Object|undefined}
+     *
+     * @throws {Error} If `variables` cannot be resolved up the parent chain.
+     */
+    toObjectResolved: function (variables) {
+        var variableSourceObj = this;
+
+        // We see if variables can be found in this object itself.
+        !variables && (variables = variableSourceObj.variables);
+
+        // We then check if variables can be procured from the parent tree
+        while ((variableSourceObj = variableSourceObj.__parent)) {
+            variables = variableSourceObj.variables;
+        }
+
+        if (!variables) { // worst case = no variable param and none detected in tree or object
+            throw Error('Unable to resolve variables. Require a List type property for variable auto resolution.');
+        }
+
+        return variables ? variables.substitute(this.toJSON()) : undefined;
     }
 });
 


### PR DESCRIPTION
Added draft and private `Property#toObjectResolved` to procure an Object representation of a property with its variables resolved.

Calling `.toObjectResolved()` on any Property causes it to traverse the parent tree and procure the list of variables that it would substitute with.

This is a draft + private function