### PR TITLE
Added ability of Property.toObjectResolved to accept additional override sources

### DIFF
--- a/lib/collection/property-base.js
+++ b/lib/collection/property-base.js
@@ -49,7 +49,7 @@ _.extend(PropertyBase.prototype, /** @lends PropertyBase.prototype */ {
 
             // Handle plurality of PropertyLists in the SDK vs the exported JSON.
             // Basically, removes the trailing "s" from key if the value is a property list.
-            if (value && value._postman_isGroup && _.endsWith(key, 's')) {
+            if (value && value._postman_propertyIsList && _.endsWith(key, 's')) {
                 key = key.slice(0, -1);
             }
 

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -50,7 +50,7 @@ _.extend(PropertyList.prototype, /** @lends PropertyList.prototype */ {
      * Indicates that this element contains a number of other elements.
      * @private
      */
-    _postman_isGroup: true,
+    _postman_propertyIsList: true,
 
     /**
      * Insert an element at the end of this list. When a reference member specified via second parameter is found, the
@@ -296,7 +296,7 @@ _.extend(PropertyList.prototype, /** @lends PropertyList.prototype */ {
 
                 // Handle plurality of PropertyLists in the SDK vs the exported JSON.
                 // Basically, removes the trailing "s" from key if the value is a property list.
-                if (value && value._postman_isGroup && _.endsWith(key, 's')) {
+                if (value && value._postman_propertyIsList && _.endsWith(key, 's')) {
                     key = key.slice(0, -1);
                 }
 

--- a/lib/collection/property.js
+++ b/lib/collection/property.js
@@ -103,13 +103,14 @@ _.extend(Property.prototype, /** @lends Property.prototype */ {
      * @private
      * @draft
      *
-     * @param {VariableList=} [variables] - One can specifically provide a VariableList for doing the substitution. In
+     * @param {?VariableList=} [variables] - One can specifically provide a VariableList for doing the substitution. In
      * the event one is not provided, the variables are taken from this object or one from the parent tree.
+     * @param {Array<Object>} overrides - additional objects to lookup for variable values
      * @returns {Object|undefined}
      *
      * @throws {Error} If `variables` cannot be resolved up the parent chain.
      */
-    toObjectResolved: function (variables) {
+    toObjectResolved: function (variables, overrides) {
         var variableSourceObj = this;
 
         // We see if variables can be found in this object itself.
@@ -124,7 +125,7 @@ _.extend(Property.prototype, /** @lends Property.prototype */ {
             throw Error('Unable to resolve variables. Require a List type property for variable auto resolution.');
         }
 
-        return variables ? variables.substitute(this.toJSON()) : undefined;
+        return variables ? variables.substitute(this.toJSON(), overrides) : undefined;
     }
 });
 

--- a/lib/collection/variable-list.js
+++ b/lib/collection/variable-list.js
@@ -60,30 +60,33 @@ _.inherit((
 
 _.extend(VariableList.prototype, /** @lends VariableList.prototype */ {
     /**
-     * Replaces the variable tokens inside a string with its actual values
+     * Replaces the variable tokens inside a string with its actual values.
      *
      * @param {String} str
+     * @param {Array<Object>=} [overrides] - additional objects to lookup for variable values
      * @returns {String}
      */
-    replace: function (str) {
+    replace: function (str, overrides) {
         var self = this;
         return str.replace ? str.replace(VariableList.REGEX_EXTRACT_VARS, function (a, b) {
-            var r = self.one(b) && self.one(b).toString();
+            var r = self.has(b) ? self.one(b) : _.findValue(overrides, b);
+            r && _.isFunction(r.toString) && (r = r.toString());
             return nativeTypes[(typeof r)] ? r : a;
         }) : str;
     },
 
     /**
      * Recursively replace strings in an object with instances of variables. Note that it clones the original object. If
-     * the `mutate` param is set to true, then it replaces the same object instead of creatinbg a new one.
+     * the `mutate` param is set to true, then it replaces the same object instead of creating a new one.
      *
      * @param {Array|Object} obj
+     * @param {?Array<Object>=} [overrides] - additional objects to lookup for variable values
      * @param {Boolean=} [mutate=false]
      * @returns {Array|Object}
      */
-    substitute: function (obj, mutate) {
+    substitute: function (obj, overrides, mutate) {
         return _.isObject(obj) ? _.merge(mutate ? obj : {}, obj, function (objectValue, sourceValue) {
-            return _.isString(sourceValue) ?  this.replace(sourceValue) : undefined;
+            return _.isString(sourceValue) ?  this.replace(sourceValue, overrides) : undefined;
         }, this) : obj;
     },
 

--- a/lib/collection/variable-list.js
+++ b/lib/collection/variable-list.js
@@ -103,7 +103,7 @@ _.extend(VariableList.prototype, /** @lends VariableList.prototype */ {
      * @example
      * myCollection.variables.env(); // gets all environments as array
      * myCollection.variables.env(1); // gets the second environment as Object
-     * myCollection.variables.env(0, null, true); // cleares the first environment (does not delete the layer though)
+     * myCollection.variables.env(0, null, true); // clears the first environment (does not delete the layer though)
      * myCollection.variables.env(0, {
      *     var1: "variable-value"
      * }); // assigns `var1` variable to the first environment layer

--- a/lib/util.js
+++ b/lib/util.js
@@ -129,6 +129,25 @@ _.mixin(/** @lends util */{
      */
     inSuperChain: function (obj, key, value) {
         return obj ? ((obj[key] === value) || _.inSuperChain(obj.super_, key, value)) : false;
+    },
+
+    /**
+     * Similar to _.find, except that it returns the value if it is present
+     * @param {Array} arr
+     * @param {String} key
+     * @returns {*}
+     */
+    findValue: function (arr, key) {
+        if (!_.isArray(arr) || !arr.length) { return; }
+
+        var i,
+            ii;
+
+        for (i = 0, ii = arr.length; i < ii; i++) {
+            if (_.isObject(arr[i]) && _.has(arr[i], key)) {
+                return arr[i][key];
+            }
+        }
     }
 });
 


### PR DESCRIPTION
This PR adds the functionality to provide additional set of objects to be used for variable resolution in `Property#toObjectResolved`. This can hypothetically allow the use case where environment and global variables are NOT sent to the SDK and instead managed externally and sent to the resolution function.

Usage: 
```
myPropertyInstance.toObjectResolved(null, [{var1: "value1"}]);
```

Out of context: This PR also changes the internal flag `_postman_isGroup` to `_postman_propertyIsList` for keeping them in line with `_postman_propertyXYZ` flags