### PR TITLE
fix url param stringification

### DIFF
--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -85,8 +85,8 @@ _.extend(QueryParam, /** @lends QueryParam */ {
         }, '');
 
         // Special handling to ensure "{{" and "}}" are not URL encoded in the final query-string.
-        qs = qs.replace('%7B%7B', '{{');
-        qs = qs.replace('%7D%7D', '}}');
+        qs = qs.replace(/%7B%7B/g, '{{');
+        qs = qs.replace(/%7D%7D/g, '}}');
         return qs;
     }
 });

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -54,7 +54,8 @@ module.exports = {
         }
     ],
     rawQueryStrings: [
-        'asdf=abab&yo=true&akshay={{something}}&something=bald'
+        'asdf=abab&yo=true&akshay={{something}}&something=bald',
+        'this={{ensures}}&{{multiple}}replacements=work-{{fine}}&one=1&two=2'
     ],
     queryParams: [
         {


### PR DESCRIPTION
This fix ensures that if a URL contains multiple variables, the query param stringification should work properly.

`string.replace()` by default only replaces the first occurrence.