### PR TITLE
The description tag now allows markdown to have HTML

### DIFF
--- a/lib/collection/description.js
+++ b/lib/collection/description.js
@@ -10,16 +10,19 @@ var _ = require('../util').lodash,
         tables: true,
         breaks: false,
         pedantic: false,
-        sanitize: true,
+        sanitize: false,
         smartLists: true,
         smartypants: false
     },
     HTML_DEFAULT_OPTIONS = {
         allowedTags: ['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'blockquote', 'p', 'a', 'ul', 'ol', 'nl', 'li', 'b', 'i',
             'strong', 'em', 'strike', 'code', 'hr', 'br', 'div', 'table', 'thead', 'caption', 'tbody', 'tr', 'th', 'td',
-            'pre'],
+            'pre', 'img', 'abbr', 'address', 'section', 'article', 'aside', 'dd', 'dl', 'dt', 'tfoot'],
         allowedAttributes: {
-            a: ['href']
+            a: ['href'],
+            img: ['src', 'width', 'height', 'alt'],
+            td: ['align'],
+            th: ['align']
         }
     },
 
@@ -152,7 +155,7 @@ _.extend(Description, /** @lends Description */ {
          * @returns {String}
          */
         'text/markdown': function (content) {
-            return marked(content); // it is sanitised html anyway!
+            return sanitizeHtml(marked(content));
         },
 
         /**


### PR DESCRIPTION
This PR turns off markdown parsers sanitiser and allows HTML to pass through description. However, it routes this HTML via the html sanitisation function that has a known subset of allowed HTML tags.