### PR TITLE
Added ability to populate from an object

### DIFF
--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -23,8 +23,11 @@ _.inherit((
      * @constructor
      * @extends {Property}
      *
-     * @param {Header~definition|String} options Pass the initial definition of the header (key, value) as the options
-     * parameter. In case a string is given, it is parsed to extract the header key and value.
+     * @param {Header~definition|String} [value] - Pass the header definition as an object or the value of the header.
+     * If the value is passed as a string, it should either be in `name:value` format or the second "name" parameter
+     * should be used to pass the name as string
+     * @param {String} [name] - optional override the header name or use when the first parameter is the header value as
+     * string.
      *
      * @example <caption>Parse a string of headers into an array of Header objects</caption>
      * var Header = require('postman-collection').Header,
@@ -39,13 +42,18 @@ _.inherit((
      *
      * assert headerString === Header.unparse(headers);
      */
-    Header = function PostmanHeader (options) {
-        // this constructor is intended to inherit and as such the super constructor is required to be excuted
-        Header.super_.apply(this, arguments);
-
+    Header = function PostmanHeader (options, name) {
         if (_.isString(options)) {
             options = Header.parseSingle(options);
         }
+
+        if (options && _.isString(name)) {
+            options.value = options.key;
+            options.key = name;
+        }
+
+        // this constructor is intended to inherit and as such the super constructor is required to be excuted
+        Header.super_.apply(this, arguments);
 
         /**
          * The header Key
@@ -133,6 +141,22 @@ _.extend(Header, /** @lends Header */ {
         return headers.map(function (header) {
             return header.key + ': ' + header.value;
         }).join('\n');
+    },
+
+    /**
+     * Create a new header instance
+     *
+     * @param {Header~definition|String} [value] - Pass the header definition as an object or the value of the header.
+     * If the value is passed as a string, it should either be in `name:value` format or the second "name" parameter
+     * should be used to pass the name as string
+     * @param {String} [name] - optional override the header name or use when the first parameter is the header value as
+     * string.
+     * @returns {Header}
+     */
+    create: function () {
+        var args = Array.prototype.slice.call(arguments);
+        args.unshift(Header);
+        return new (Header.bind.apply(Header, args))();
     }
 });
 

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -118,7 +118,9 @@ _.extend(PropertyList.prototype, /** @lends PropertyList.prototype */ {
     add: function (item) {
         if (!item) { return; } // do not proceed on empty param
         // create new instance of the item based on the type specified if it is not already
-        this.insert((item.constructor === this.Type) ? item : new this.Type(item));
+        this.insert((item.constructor === this.Type) ? item :
+            // if the prperty has acreate static function, use it.
+            (_.has(this.Type, 'create') ? this.Type.create.apply(this.Type, arguments) : new this.Type(item)));
     },
 
     /**

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -166,7 +166,10 @@ _.extend(PropertyList.prototype, /** @lends PropertyList.prototype */ {
         // if Type supports parsing of string headers then do it before adding it.
         _.isString(items) && _.isFunction(this.Type.parse) && (items = this.Type.parse(items));
         // add a single item or an array of items.
-        _.each(_.isArray(items) ? items : [items], this.add, this);
+        _.each(_.isArray(items) ? items :
+            // if population is not an array, we send this as single item in an array or send each property separately
+            // if the core Type supports Type.create
+            ((_.isPlainObject(items) && _.has(this.Type, 'create')) ? items : [items]), this.add, this);
     },
 
     /**

--- a/test/functional/header.test.js
+++ b/test/functional/header.test.js
@@ -1,0 +1,73 @@
+var expect = require('expect.js'),
+    Header = require('../../lib/index.js').Header,
+    PropertyList = require('../../lib/index.js').PropertyList;
+
+/* global describe, it */
+describe('Header', function () {
+    it('must have a .create to create new instamce', function () {
+        expect(Header.create('value', 'name')).to.eql({
+            key: 'name',
+            value: 'value'
+        });
+        expect(Header.create('name:value')).to.eql({
+            key: 'name',
+            value: 'value'
+        });
+        expect(Header.create({ key: 'name', value: 'value' })).to.eql({
+            key: 'name',
+            value: 'value'
+        });
+    });
+
+    describe('inside PropertyList', function () {
+        it('must load a header string', function () {
+            var list = new PropertyList(Header, {}, 'name1:value1\r\nname2:value2');
+            expect(list.all()).to.eql([{
+                key: 'name1',
+                value: 'value1'
+            }, {
+                key: 'name2',
+                value: 'value2'
+            }]);
+        });
+        it('must load an array of strings', function () {
+            var list = new PropertyList(Header, {}, ['name1:value1', 'name2:value2']);
+            expect(list.all()).to.eql([{
+                key: 'name1',
+                value: 'value1'
+            }, {
+                key: 'name2',
+                value: 'value2'
+            }]);
+        });
+        it('must load an array of objects', function () {
+            var list = new PropertyList(Header, {}, [{
+                key: 'name1',
+                value: 'value1'
+            }, {
+                key: 'name2',
+                value: 'value2'
+            }]);
+            expect(list.all()).to.eql([{
+                key: 'name1',
+                value: 'value1'
+            }, {
+                key: 'name2',
+                value: 'value2'
+            }]);
+        });
+        it('must load a plain header key:value object', function () {
+            var list = new PropertyList(Header, {}, {
+                name1: 'value1',
+                name2: 'value2'
+            });
+            expect(list.all()).to.eql([{
+                key: 'name1',
+                value: 'value1'
+            }, {
+                key: 'name2',
+                value: 'value2'
+            }]);
+        });
+    });
+});


### PR DESCRIPTION
- Update PropertyList#add function to be a bit more intelligent and use the source Type.create function to add a new item whenever one is available.
- Updated PropertyList#populate function to accept an object as well and treat individual keys in them as separate items to be sent to PropertyList.add(). This allows simple object to be used as propertylist source for properties that support Property.create
- Added Header.create and updated the constructor to accept value, key as construction parameter

All these together allow headers to be now sent as object to `.populate` of PropertyList of headers

Caveat: tests pass, but not extensively tested whether it affects populates of other types. less likely though since `Property.create` is checked before treating it differently