### PR TITLE
Added _postman_propertyIndexKey key in Properties

### DIFF
--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -80,6 +80,14 @@ _.extend(Header, /** @lends Header */ {
     _postman_propertyName: 'Header',
 
     /**
+     * Specify the key to be used while indexing this object
+     * @private
+     * @readOnly
+     * @type {String}
+     */
+    _postman_propertyIndexKey: 'key',
+
+    /**
      * Parses a multi line header string into an array of {@link Header~definition}.
      *
      * @param headerString

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -37,7 +37,7 @@ _.inherit((
              * @private
              * @type {function}
              */
-            indexBy: (options && options.indexBy) || DEFAULT_INDEX_ATTR
+            indexBy: (options && options.indexBy) || (type && type._postman_propertyIndexKey) || DEFAULT_INDEX_ATTR
         });
 
         // prepopulate


### PR DESCRIPTION
Added _postman_propertyIndexKey key in Properties to be used for reading in PropertyList to decide the indexing key name.

This allows things like Headers, etc to be treated with right values while doing `List.one(id)` and prevent bugs where user has forgotten to configure the list.

TODO: remove all usage of `options.indexBy` in property list and use this method instead