### PR TITLE
Response body conversion sugar function

### DIFF
--- a/lib/collection/response.js
+++ b/lib/collection/response.js
@@ -4,6 +4,7 @@ var util = require('../util'),
     mimeType = require('mime-types'),
     mimeFormat = require('mime-format'),
     httpReasons = require('http-reasons'),
+    parseJSON = require('parse-json'),
     Property = require('./property').Property,
     Request = require('./request').Request,
     Header = require('./header').Header,
@@ -118,6 +119,28 @@ _.extend(Response.prototype, /** @lends Response.prototype */ {
      */
     text: function () {
         return (this.stream ? util.bufferOrArrayBufferToString(this.stream) : this.body);
+    },
+
+    /**
+     * Get the response body as a JavaScript object. Note that it throws an error if the response is not a valid JSON
+     *
+     * @example
+     * // assuming that the response is stored in a collection instance `myCollection`
+     * var response = myCollection.items.one('some request').responses.idx(0),
+     *     jsonBody;
+     * try {
+     *     jsonBody = response.json();
+     * }
+     * catch (e) {
+     *     console.log("There was an error parsing JSON ", e);
+     * }
+     * // log the root-level keys in the response JSON.
+     * console.log('All keys in json response: ' + Object.keys(json));
+     *
+     * @returns {Object}
+     */
+    json: function () {
+        return parseJSON(this.text(), DEFAULT_RESPONSE_FILENAME);
     },
 
     /**

--- a/lib/collection/response.js
+++ b/lib/collection/response.js
@@ -113,6 +113,14 @@ _.extend(Response.prototype, /** @lends Response.prototype */ {
     },
 
     /**
+     * Get the response body as a string/text.
+     * @returns {String|undefined}
+     */
+    text: function () {
+        return (this.stream ? util.bufferOrArrayBufferToString(this.stream) : this.body);
+    },
+
+    /**
      * @private
      *
      * @param {String} contentType

--- a/lib/util.js
+++ b/lib/util.js
@@ -201,6 +201,16 @@ util = {
         return str;
     },
 
+    bufferOrArrayBufferToString: function (buffer) {
+        if (!buffer || _.isString(buffer)) {
+            return buffer || '';
+        }
+
+        var str = buffer.toString('utf8') || E;
+        (str === '[object ArrayBuffer]') && (str = util.arrayBufferToString(buffer));
+        return str;
+    },
+
     bufferOrArrayBufferToBase64: function (buffer) {
         if (!buffer) {
             return '';

--- a/lib/util.js
+++ b/lib/util.js
@@ -206,7 +206,7 @@ util = {
             return buffer || '';
         }
 
-        var str = buffer.toString('utf8') || E;
+        var str = buffer.toString('utf8') || '';
         (str === '[object ArrayBuffer]') && (str = util.arrayBufferToString(buffer));
         return str;
     },

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "mime-types": "^2.1.11",
     "node-oauth1": "^1.1.1",
     "node-uuid": "^1.4.7",
+    "parse-json": "^2.2.0",
     "sanitize-html": "^1.11.2",
     "schema-compiler": "^0.0.3",
     "semver": "^5.1.0"

--- a/test/functional/response.test.js
+++ b/test/functional/response.test.js
@@ -42,5 +42,36 @@ describe('Response', function () {
                 stream: new Buffer([0x62,0x75,0x66,0x66,0x65,0x72])
             })).text()).to.be('buffer');
         });
+
+        it('should parse response as JSON', function () {
+            expect((new Response({
+                body: '{ \"hello\": \"world\" }'
+            })).json()).to.eql({
+                hello: 'world'
+            });
+        });
+
+        it('should throw friendly error while failing to parse json body', function () {
+            var response = new Response({
+                    body: '{ \"hello: \"world\" }'
+                }),
+                json,
+                error;
+
+            try {
+                json = response.json();
+            }
+            catch (e) {
+                error = e;
+            }
+
+            expect(json).not.be.ok();
+            expect(error).be.ok();
+            expect(error.toString()).be(
+                'JSONError: Unexpected token \'w\' at 1:12 in response\n' +
+                '{ "hello: "world" }\n' +
+                '           ^'
+            );
+        });
     });
 });

--- a/test/functional/response.test.js
+++ b/test/functional/response.test.js
@@ -35,4 +35,12 @@ describe('Response', function () {
             expect(jsonified).to.have.property('cookie');
         });
     });
+
+    describe('body', function () {
+        it('should parse response stream as text', function () {
+            expect((new Response({
+                stream: new Buffer([0x62,0x75,0x66,0x66,0x65,0x72])
+            })).text()).to.be('buffer');
+        });
+    });
 });


### PR DESCRIPTION
Adds `text()` and `json()` to `Response` prototype.

> This PR also cobtains code from #56. As such, please merge that and sync this branch before merging.