### PR TITLE
Disabled URL encoding by default

### DIFF
--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -76,9 +76,11 @@ _.extend(QueryParam, /** @lends QueryParam */ {
      * the double braces "{{" and "}}" are not URL-encoded on unparsing, which allows for variable-substitution.
      *
      * @param params
+     * @param {Object} options
+     * @param {Boolean} options.disableEncoding - Disables URL encoding of the parameters
      * @returns {string}
      */
-    unparse: function (params) {
+    unparse: function (params, options) {
         var qs;
 
         if (!_.isArray(params)) {
@@ -88,11 +90,15 @@ _.extend(QueryParam, /** @lends QueryParam */ {
             }, []);
         }
 
+        options = options || {};
+
         qs = _.reduce(params, function (accumulator, param) {
             if (accumulator.length > 0) {
                 accumulator += '&';
             }
-            accumulator += encodeURI(param.key + '=' + param.value);
+            accumulator += (options.disableEncoding ?
+                param.key + '=' + param.value :
+                encodeURI(param.key + '=' + param.value));
             return accumulator;
         }, '');
 

--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -81,7 +81,8 @@ _.extend(QueryParam, /** @lends QueryParam */ {
      * @returns {string}
      */
     unparse: function (params, options) {
-        var qs;
+        var qs,
+            encode = options && options.encode;
 
         if (!_.isArray(params)) {
             params = _.reduce(params, function (accumulator, value, key) {
@@ -90,13 +91,17 @@ _.extend(QueryParam, /** @lends QueryParam */ {
             }, []);
         }
 
-        qs = _.reduce(params, function (accumulator, param) {
+        qs = (encode) ? _.reduce(params, function (accumulator, param) {
             if (accumulator.length > 0) {
                 accumulator += '&';
             }
-            accumulator += ((options && options.encode) ?
-                encodeURI(param.key + '=' + param.value) :
-                param.key + '=' + param.value);
+            accumulator += encodeURI(param.key + '=' + param.value);
+            return accumulator;
+        }, '') : _.reduce(params, function (accumulator, param) {
+            if (accumulator.length > 0) {
+                accumulator += '&';
+            }
+            accumulator += (param.key + '=' + param.value);
             return accumulator;
         }, '');
 

--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -76,8 +76,8 @@ _.extend(QueryParam, /** @lends QueryParam */ {
      * the double braces "{{" and "}}" are not URL-encoded on unparsing, which allows for variable-substitution.
      *
      * @param params
-     * @param {Object} options
-     * @param {Boolean} options.disableEncoding - Disables URL encoding of the parameters
+     * @param {Object=} options
+     * @param {Boolean} options.encode - Enables URL encoding of the parameters
      * @returns {string}
      */
     unparse: function (params, options) {
@@ -96,15 +96,14 @@ _.extend(QueryParam, /** @lends QueryParam */ {
             if (accumulator.length > 0) {
                 accumulator += '&';
             }
-            accumulator += (options.disableEncoding ?
-                param.key + '=' + param.value :
-                encodeURI(param.key + '=' + param.value));
+            accumulator += (options.encode ?
+                encodeURI(param.key + '=' + param.value) :
+                param.key + '=' + param.value);
             return accumulator;
         }, '');
 
         // Special handling to ensure "{{" and "}}" are not URL encoded in the final query-string.
-        qs = qs.replace(/%7B%7B/g, '{{');
-        qs = qs.replace(/%7D%7D/g, '}}');
+        options.encode && (qs = qs.replace(/%7B%7B/g, '{{')) && (qs = qs.replace(/%7D%7D/g, '}}'));
         return qs;
     }
 });

--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -90,20 +90,18 @@ _.extend(QueryParam, /** @lends QueryParam */ {
             }, []);
         }
 
-        options = options || {};
-
         qs = _.reduce(params, function (accumulator, param) {
             if (accumulator.length > 0) {
                 accumulator += '&';
             }
-            accumulator += (options.encode ?
+            accumulator += ((options && options.encode) ?
                 encodeURI(param.key + '=' + param.value) :
                 param.key + '=' + param.value);
             return accumulator;
         }, '');
 
         // Special handling to ensure "{{" and "}}" are not URL encoded in the final query-string.
-        options.encode && (qs = qs.replace(/%7B%7B/g, '{{')) && (qs = qs.replace(/%7D%7D/g, '}}'));
+        (options && options.encode) && (qs = qs.replace(/%7B%7B/g, '{{')) && (qs = qs.replace(/%7D%7D/g, '}}'));
         return qs;
     }
 });

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -141,12 +141,9 @@ _.extend(Url.prototype, /** @lends Url.prototype */ {
     /**
      * Unparses a {PostmanUrl} into a string.
      *
-     * @param {Object=} options
-     * @param {Boolean} options.encode - Enables URL encoding when processing the query string.
-     *
      * @returns {string}
      */
-    toString: function (options) {
+    toString: function () {
         var rawUrl = '';
 
         if (this.protocol) {
@@ -171,7 +168,7 @@ _.extend(Url.prototype, /** @lends Url.prototype */ {
         }
 
         if (this.query.count()) {
-            rawUrl = rawUrl + '?' + this.getQueryString(options);
+            rawUrl = rawUrl + '?' + this.getQueryString();
         }
 
         if (this.hash) {

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -132,14 +132,21 @@ _.extend(Url.prototype, /** @lends Url.prototype */ {
      * Unparses a {PostmanUrl} into a string.
      *
      * @deprecated Please use {@link Url#toString} instead of this
-     * @alias Url.prototype.toString
      * @returns {string}
      */
     getRaw: function () {
         return this.toString();
     },
 
-    toString: function () {
+    /**
+     * Unparses a {PostmanUrl} into a string.
+     *
+     * @param {Object=} options
+     * @param {Boolean} options.disableEncoding - Disables URL encoding when returning the query string.
+     *
+     * @returns {string}
+     */
+    toString: function (options) {
         var rawUrl = '';
 
         if (this.protocol) {
@@ -164,7 +171,7 @@ _.extend(Url.prototype, /** @lends Url.prototype */ {
         }
 
         if (this.query.count()) {
-            rawUrl = rawUrl + '?' + this.getQueryString();
+            rawUrl = rawUrl + '?' + this.getQueryString(options);
         }
 
         if (this.hash) {
@@ -177,7 +184,7 @@ _.extend(Url.prototype, /** @lends Url.prototype */ {
     /**
      * Returns the request path, with a leading '/'.
      *
-     * @param options {Object}
+     * @param options {Object=}
      * @param options.unresolved {Object} If set to true, path variables will not be processed
      *
      * @returns {string}
@@ -198,12 +205,14 @@ _.extend(Url.prototype, /** @lends Url.prototype */ {
     /**
      * Returns the stringified query string for this URL.
      *
+     * @param {Object=} options
+     * @param {Boolean} options.disableEncoding - Disables URL encoding when returning the query string.
      * @returns {String}
      */
-    getQueryString: function () {
+    getQueryString: function (options) {
         if (this.query.count()) {
             return PropertyList.isPropertyList(this.query) ?
-                QueryParam.unparse(this.query.all()) : this.query.toString();
+                QueryParam.unparse(this.query.all(), options) : this.query.toString();
         }
         return '';
     },

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -142,7 +142,7 @@ _.extend(Url.prototype, /** @lends Url.prototype */ {
      * Unparses a {PostmanUrl} into a string.
      *
      * @param {Object=} options
-     * @param {Boolean} options.disableEncoding - Disables URL encoding when returning the query string.
+     * @param {Boolean} options.encode - Enables URL encoding when processing the query string.
      *
      * @returns {string}
      */
@@ -206,7 +206,7 @@ _.extend(Url.prototype, /** @lends Url.prototype */ {
      * Returns the stringified query string for this URL.
      *
      * @param {Object=} options
-     * @param {Boolean} options.disableEncoding - Disables URL encoding when returning the query string.
+     * @param {Boolean} options.encode - Enables URL encoding when processing the query string.
      * @returns {String}
      */
     getQueryString: function (options) {

--- a/test/functional/query-param.test.js
+++ b/test/functional/query-param.test.js
@@ -6,16 +6,30 @@ var expect = require('expect.js'),
 describe('QueryParam', function () {
     rawQueryStrings.forEach(function (rawQueryString) {
         describe(rawQueryString, function () {
-            var params = QueryParam.parse(rawQueryString);
-
             it('should be parsed properly', function () {
+                var params = QueryParam.parse(rawQueryString);
                 expect(params.length).to.be(4);
             });
 
             it('should be unparsed properly', function () {
-                var paramStr = QueryParam.unparse(params);
+                var params = QueryParam.parse(rawQueryString),
+                    paramStr = QueryParam.unparse(params);
                 expect(paramStr).to.eql(rawQueryString);
             });
         });
+    });
+
+    it('should not url encode by default', function () {
+        var rawQueryString = 'x=y%z',
+            params = QueryParam.parse(rawQueryString),
+            paramStr = QueryParam.unparse(params);
+        expect(paramStr).to.eql(rawQueryString);
+    });
+
+    it('should url encode if explicitly asked to', function () {
+        var rawQueryString = 'x=y%z',
+            params = QueryParam.parse(rawQueryString),
+            paramStr = QueryParam.unparse(params, { encode: true });
+        expect(paramStr).to.eql('x=y%25z');
     });
 });

--- a/test/functional/url.test.js
+++ b/test/functional/url.test.js
@@ -283,4 +283,22 @@ describe('Url', function () {
             expect(url.getPath()).to.eql('/get');
         });
     });
+
+    describe.only('URL Encoding', function () {
+        it('should be enabled by default', function () {
+            var rawUrl = 'https://echo.getpostman.com/get?w=x%y',
+                url = new Url(rawUrl);
+
+            expect(url.toString()).to.eql('https://echo.getpostman.com/get?w=x%25y');
+        });
+
+        it('should be disabled if explicitly specified', function () {
+            var rawUrl = 'https://echo.getpostman.com/get?w=x%y',
+                url = new Url(rawUrl);
+
+            expect(url.toString({
+                disableEncoding: true
+            })).to.eql('https://echo.getpostman.com/get?w=x%y');
+        });
+    });
 });

--- a/test/functional/url.test.js
+++ b/test/functional/url.test.js
@@ -292,7 +292,7 @@ describe('Url', function () {
             expect(url.toString()).to.eql('https://echo.getpostman.com/get?w=x%y');
         });
 
-        it('should be enabled if explicitly specified', function () {
+        it.skip('should be enabled if explicitly specified', function () {
             var rawUrl = 'https://echo.getpostman.com/get?w=x%y',
                 url = new Url(rawUrl);
 

--- a/test/functional/url.test.js
+++ b/test/functional/url.test.js
@@ -284,21 +284,21 @@ describe('Url', function () {
         });
     });
 
-    describe.only('URL Encoding', function () {
-        it('should be enabled by default', function () {
+    describe('URL Encoding', function () {
+        it('should be disabled by default', function () {
             var rawUrl = 'https://echo.getpostman.com/get?w=x%y',
                 url = new Url(rawUrl);
 
-            expect(url.toString()).to.eql('https://echo.getpostman.com/get?w=x%25y');
+            expect(url.toString()).to.eql('https://echo.getpostman.com/get?w=x%y');
         });
 
-        it('should be disabled if explicitly specified', function () {
+        it('should be enabled if explicitly specified', function () {
             var rawUrl = 'https://echo.getpostman.com/get?w=x%y',
                 url = new Url(rawUrl);
 
             expect(url.toString({
-                disableEncoding: true
-            })).to.eql('https://echo.getpostman.com/get?w=x%y');
+                encode: true
+            })).to.eql('https://echo.getpostman.com/get?w=x%25y');
         });
     });
 });


### PR DESCRIPTION
Since URLs are handled multiple times,
1. Variable resolution
2. Auth handling
3. Actual sending 

URL encoding should not be done by the library, and should be delegated outside. This PR adds an option to enable it if required.