### PR TITLE
No overriding of nonce/timestamp for OAuth1

### DIFF
--- a/lib/collection/request-auth/oauth1.js
+++ b/lib/collection/request-auth/oauth1.js
@@ -57,8 +57,8 @@ module.exports = {
         });
 
         // Generate a new nonce and timestamp
-        helperParams.nonce = oAuth1.nonce(11).toString();
-        helperParams.timeStamp = oAuth1.timestamp().toString();
+        helperParams.nonce = helperParams.nonce || oAuth1.nonce(11).toString();
+        helperParams.timeStamp = helperParams.timeStamp || oAuth1.timestamp().toString();
 
         // Generate a list of parameters associated with the signature.
         signatureParams = self.sign({


### PR DESCRIPTION
updated the oauth1 helper to not forcibly override the nonce and timestamp.