### PR TITLE
Mutate the helperParameters when authorizing a cloned request

### DIFF
--- a/lib/collection/request-auth/hawk.js
+++ b/lib/collection/request-auth/hawk.js
@@ -33,6 +33,10 @@ module.exports = {
             return request; // Nothing to do if no parameters are present.
         }
 
+        params.nonce = params.nonce || _.randomString(6);
+        // the hawk library will generate a correct one if this is NaN.
+        params.timestamp = _.parseInt(params.timestamp);
+
         request.removeHeader('Authorization', { ignoreCase: true });
         result = this.sign({
             credentials: {
@@ -40,7 +44,8 @@ module.exports = {
                 key: params.authKey,
                 algorithm: params.algorithm
             },
-            nonce: params.nonce || _.randomString(6),
+            nonce: params.nonce,
+            timestamp: params.timestamp,
             ext: params.extraData,
             app: params.app,
             dlg: params.delegation,


### PR DESCRIPTION
ensure that the helper params are mutated, so they can be shown on the UI