### PR TITLE
fixed parsing of headers containing colons

### DIFF
--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -132,16 +132,21 @@ _.extend(Header, /** @lends Header */ {
 
     /**
      * Parses a single Header.
-     * @param header
+     * @param {String} header
      * @returns {{key: string, value: string}}
      */
     parseSingle: function (header) {
-        var parsed,
+        if (!_.isString(header)) { return { key: '', value: '' }; }
+
+        var index = header.indexOf(':'),
             key,
             value;
-        parsed = header.split(':');
-        key = parsed.shift();
-        value = parsed.join(':');
+
+        (index < 0) && (index = header.length);
+
+        key = header.substr(0, index);
+        value = header.substr(index + 1);
+
         return {
             key: _.trim(key),
             value: _.trim(value)

--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -157,16 +157,18 @@ _.extend(Header, /** @lends Header */ {
      * Stringifies an Array or {@link PropertyList} of Headers into a single string.
      *
      * @param {Array|PropertyList<Header>} headers
+     * @param {String=} separator - Specify a string for separating each header, by default, '\n', but sometimes,
+     * it might be more useful to use a carriage return ('\r\n')
      * @returns {string}
      */
-    unparse: function (headers) {
+    unparse: function (headers, separator) {
         if (!_.isArray(headers) && !PropertyList.isPropertyList(headers)) {
             return '';
         }
 
         return headers.map(function (header) {
             return header.key + ': ' + header.value;
-        }).join('\n');
+        }).join(separator ? separator : '\n');
     },
 
     /**

--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -44,12 +44,7 @@ _.inherit((
      */
     Header = function PostmanHeader (options, name) {
         if (_.isString(options)) {
-            options = Header.parseSingle(options);
-        }
-
-        if (options && _.isString(name)) {
-            options.value = options.key;
-            options.key = name;
+            options = _.isString(name) ? { key: name, value: options } : Header.parseSingle(options);
         }
 
         // this constructor is intended to inherit and as such the super constructor is required to be excuted
@@ -161,7 +156,7 @@ _.extend(Header, /** @lends Header */ {
      */
     unparse: function (headers) {
         if (!_.isArray(headers) && !PropertyList.isPropertyList(headers)) {
-            throw new Error('It is only possible to unparse PropertyList or Array of headers.');
+            return '';
         }
 
         return headers.map(function (header) {

--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -141,11 +141,15 @@ _.extend(Header, /** @lends Header */ {
      * @returns {{key: string, value: string}}
      */
     parseSingle: function (header) {
-        var parsed;
+        var parsed,
+            key,
+            value;
         parsed = header.split(':');
+        key = parsed.shift();
+        value = parsed.join(':');
         return {
-            key: _.trim(parsed[0]),
-            value: _.trim(parsed[1])
+            key: _.trim(key),
+            value: _.trim(value)
         };
     },
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "atob": "^2.0.0",
-    "aws4": "^1.2.1",
+    "aws4": "^1.4.1",
     "btoa": "^1.1.2",
     "crypto-js": "^3.1.6",
     "escape-html": "^1.0.3",

--- a/test/functional/header.test.js
+++ b/test/functional/header.test.js
@@ -61,7 +61,7 @@ describe('Header', function () {
                 key: 'name2',
                 value: 'value2'
             }]);
-            expect(Header.unparse(list)).to.eql('name1: value1\nname2: value2')
+            expect(Header.unparse(list)).to.be('name1: value1\nname2: value2')
         });
 
         it('should honor the given separator "\\r\\n"', function () {
@@ -74,7 +74,7 @@ describe('Header', function () {
                 key: 'name2',
                 value: 'value2'
             }]);
-            expect(Header.unparse(list, '\r\n')).to.eql(raw)
+            expect(Header.unparse(list, '\r\n')).to.be(raw)
         });
     });
 

--- a/test/functional/header.test.js
+++ b/test/functional/header.test.js
@@ -17,6 +17,10 @@ describe('Header', function () {
             key: 'name',
             value: 'value'
         });
+        expect(Header.create('name: my: value:is this')).to.eql({
+            key: 'name',
+            value: 'my: value:is this'
+        });
     });
 
     describe('inside PropertyList', function () {

--- a/test/functional/header.test.js
+++ b/test/functional/header.test.js
@@ -61,7 +61,7 @@ describe('Header', function () {
                 key: 'name2',
                 value: 'value2'
             }]);
-            expect(Header.unparse(list)).to.be('name1: value1\nname2: value2')
+            expect(Header.unparse(list)).to.be('name1: value1\nname2: value2');
         });
 
         it('should honor the given separator "\\r\\n"', function () {
@@ -74,7 +74,7 @@ describe('Header', function () {
                 key: 'name2',
                 value: 'value2'
             }]);
-            expect(Header.unparse(list, '\r\n')).to.be(raw)
+            expect(Header.unparse(list, '\r\n')).to.be(raw);
         });
     });
 

--- a/test/functional/header.test.js
+++ b/test/functional/header.test.js
@@ -42,7 +42,7 @@ describe('Header', function () {
             });
         });
 
-        it('should string whitespace and return the header', function () {
+        it('should strip whitespace and return the header', function () {
             expect(Header.parseSingle('\tDate: Mon, 25 Jul 2016 13:11:41 GMT\n\n')).to.eql({
                 key: 'Date',
                 value: 'Mon, 25 Jul 2016 13:11:41 GMT'

--- a/test/functional/header.test.js
+++ b/test/functional/header.test.js
@@ -5,6 +5,10 @@ var expect = require('expect.js'),
 /* global describe, it */
 describe('Header', function () {
     it('must have a .create to create new instamce', function () {
+        expect(Header.create('Mon, 25 Jul 2016 13:11:41 GMT', 'Date')).to.eql({
+            key: 'Date',
+            value: 'Mon, 25 Jul 2016 13:11:41 GMT'
+        });
         expect(Header.create('value', 'name')).to.eql({
             key: 'name',
             value: 'value'

--- a/test/functional/header.test.js
+++ b/test/functional/header.test.js
@@ -50,6 +50,34 @@ describe('Header', function () {
         });
     });
 
+    describe('unparse', function () {
+        it('should unparse headers to a string', function () {
+            var raw = 'name1: value1\r\nname2: value2',
+                list = new PropertyList(Header, {}, raw);
+            expect(list.all()).to.eql([{
+                key: 'name1',
+                value: 'value1'
+            }, {
+                key: 'name2',
+                value: 'value2'
+            }]);
+            expect(Header.unparse(list)).to.eql('name1: value1\nname2: value2')
+        });
+
+        it('should honor the given separator "\\r\\n"', function () {
+            var raw = 'name1: value1\r\nname2: value2',
+                list = new PropertyList(Header, {}, raw);
+            expect(list.all()).to.eql([{
+                key: 'name1',
+                value: 'value1'
+            }, {
+                key: 'name2',
+                value: 'value2'
+            }]);
+            expect(Header.unparse(list, '\r\n')).to.eql(raw)
+        });
+    });
+
     describe('inside PropertyList', function () {
         it('must load a header string', function () {
             var list = new PropertyList(Header, {}, 'name1:value1\r\nname2:value2');

--- a/test/functional/header.test.js
+++ b/test/functional/header.test.js
@@ -27,6 +27,29 @@ describe('Header', function () {
         });
     });
 
+    describe('parseSingle', function () {
+        it('should return an empty header on invalid input', function () {
+            expect(Header.parseSingle({})).to.eql({
+                key: '',
+                value: ''
+            });
+        });
+
+        it('should create an empty header on invalid input', function () {
+            expect(Header.parseSingle('novalue')).to.eql({
+                key: 'novalue',
+                value: ''
+            });
+        });
+
+        it('should string whitespace and return the header', function () {
+            expect(Header.parseSingle('\tDate: Mon, 25 Jul 2016 13:11:41 GMT\n\n')).to.eql({
+                key: 'Date',
+                value: 'Mon, 25 Jul 2016 13:11:41 GMT'
+            });
+        });
+    });
+
     describe('inside PropertyList', function () {
         it('must load a header string', function () {
             var list = new PropertyList(Header, {}, 'name1:value1\r\nname2:value2');


### PR DESCRIPTION
Header parsing now happens only at the first occurance of `:`