### PR TITLE
ensure that aws auth does not add duplicate host header

### DIFF
--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -63,11 +63,18 @@ _.extend(QueryParam, /** @lends QueryParam */ {
      * @returns {{key: string, value: string}}
      */
     parseSingle: function (param) {
-        var parsed;
-        parsed = param.split('=');
+        var index = param.indexOf('='),
+            key,
+            value;
+
+        (index < 0) && (index = param.length);
+
+        key = param.substr(0, index);
+        value = param.substr(index + 1);
+
         return {
-            key: _.trim(parsed[0]),
-            value: _.trim(parsed[1])
+            key: _.trim(key),
+            value: _.trim(value)
         };
     },
 

--- a/lib/collection/request-auth/awsv4.js
+++ b/lib/collection/request-auth/awsv4.js
@@ -67,7 +67,7 @@ module.exports = {
 
         _.map(signedData.headers, function (value, key) {
             // TODO: figure out a better way of handling errors.
-            if (!_.contains(['content-length', 'content-type'], key.toLowerCase())) {
+            if (!_.contains(['content-length', 'content-type', 'host'], key.toLowerCase())) {
                 request.addHeader({
                     key: key,
                     value: value,

--- a/test/functional/url.test.js
+++ b/test/functional/url.test.js
@@ -235,6 +235,12 @@ describe('Url', function () {
                 });
             });
         });
+
+        it('should unparse urls containing parameters with equals sign properly', function () {
+            var rawUrl = 'https://localhost:1234/get?param=(key==value)',
+                url = new Url(rawUrl);
+            expect(url.toString()).to.eql(rawUrl);
+        });
     });
 
     describe('OAuth1 Base Url', function () {


### PR DESCRIPTION
Since the request module will already add it, there's no point adding it again.