### PR TITLE
Updated to use mime-format for guessing mime type

### DIFF
--- a/lib/collection/response.js
+++ b/lib/collection/response.js
@@ -153,11 +153,15 @@ _.extend(Response.prototype, /** @lends Response.prototype */ {
      * @note example object returned
      * {
      *   source: string // 'header', 'content', 'default' or 'forced'
-     *   type: string // the content type of response
-     *   ext: string // extension of file that stores this type of data
-     *   name: string // file name
-     *   format: string // 'text', 'audio', 'video', 'image' ...
-     *   syntax: string // 'ecmascript', 'json', 'xml', 'raw', ...
+     *   type: normalised.type, // sanitised mime type base
+     *   format: normalised.format, // format specific to the type returned
+     *   name: DEFAULT_RESPONSE_FILENAME, // @todo - get from disposition
+     *   ext: mimeType.extension(normalised.source) || E, // file extension from sanitised content type
+     *   filename: name + ext,
+     *   // also storing some meta info for possible debugging
+     *   _originalContentType: type, // the user provided mime type
+     *   _sanitisedContentType: normalised.source, // sanitised mime type
+     *   _accuratelyDetected: !normalised.orphan // this being true implies worse case (raw render)
      *   detected: {} // same as root object, but based on what is detected from content
      * }
      *
@@ -181,7 +185,7 @@ _.extend(Response.prototype, /** @lends Response.prototype */ {
             source = 'content';
         }
 
-        // if styill not found, then we use default text
+        // if still not found, then we use default text
         if (!contentType) {
             contentType = 'text/plain';
             source = 'default';
@@ -209,7 +213,7 @@ _.extend(Response.prototype, /** @lends Response.prototype */ {
         }
 
         // we create the body string first from stream and then fallback to body
-        return 'data:' + mime.type + ';base64, ' + (((this.stream != null) &&
+        return 'data:' + mime._sanitisedContentType + ';base64, ' + (((this.stream != null) &&
             util.bufferOrArrayBufferToBase64(this.stream)) || ((this.body != null) && util.btoa(this.body)) || E);
     },
 
@@ -260,16 +264,23 @@ _.extend(Response, /** @lends Response */ {
         Header.isHeader(type) && (type = type.value);
         Header.isHeader(disposition) && (disposition = disposition.value);
 
+        // validate that the content type exists
         if (!(type && _.isString(type))) { return; }
 
-        var info = {},
-            format = mimeFormat.lookup(type);
+        var normalised = mimeFormat.lookup(type),
+            info = {};
 
-        info.type = type;
-        info.ext = mimeType.extension(type) || E;
-        info.name = DEFAULT_RESPONSE_FILENAME; // @todo  return file name from disposition
-        info.format = format.type;
-        info.syntax = format.format;
+        _.assign(info, {
+            type: normalised.type, // sanitised mime type base
+            format: normalised.format, // format specific to the type returned
+            name: DEFAULT_RESPONSE_FILENAME, // @todo - get from disposition
+            ext: mimeType.extension(normalised.source) || E, // file extension from sanitised content type
+
+            // also storing some meta info for possible debugging
+            _originalContentType: type, // the user provided mime type
+            _sanitisedContentType: normalised.source, // sanitised mime type
+            _accuratelyDetected: !normalised.orphan // this being true implies worse case (raw render)
+        });
 
         // build the file name from extension
         info.filename = info.name;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "http-reasons": "^0.1.0",
     "lodash": "^3.10.1",
     "marked": "^0.3.5",
-    "mime-format": "^0.1.0",
+    "mime-format": "^1.0.0",
     "mime-types": "^2.1.11",
     "node-oauth1": "^1.1.1",
     "node-uuid": "^1.4.7",

--- a/test/unit/response-mime.test.js
+++ b/test/unit/response-mime.test.js
@@ -103,6 +103,46 @@ describe('response mime', function () {
         });
     });
 
+    it('must be greedy in assuming xml types', function () {
+        var response = new Response({
+            header: [{
+                key: 'content-type',
+                // customer reported
+                value: 'application/vnd.yamaha.openscoreformat.osfpvg+xml'
+            }]
+        });
+
+        expect(response.mime()).be.eql({
+            type: 'text',
+            format: 'xml',
+            name: 'response',
+            ext: 'osfpvg',
+            _originalContentType: 'application/vnd.yamaha.openscoreformat.osfpvg+xml',
+            _sanitisedContentType: 'application/vnd.yamaha.openscoreformat.osfpvg+xml',
+            _accuratelyDetected: true,
+            filename: 'response.osfpvg',
+            source: 'header',
+            detected: null
+        });
+
+        // customer reported
+        // reusing the same response object
+        response.headers.one('content-type').value = 'application/vnd.route66.link66+xml';
+
+        expect(response.mime()).be.eql({
+            type: 'text',
+            format: 'xml',
+            name: 'response',
+            ext: 'link66',
+            _originalContentType: 'application/vnd.route66.link66+xml',
+            _sanitisedContentType: 'application/vnd.route66.link66+xml',
+            _accuratelyDetected: true,
+            filename: 'response.link66',
+            source: 'header',
+            detected: null
+        });
+    });
+
     it('must gracefully handle extremely deviant content type', function () {
         var response = new Response({
             header: [{

--- a/test/unit/response-mime.test.js
+++ b/test/unit/response-mime.test.js
@@ -1,0 +1,154 @@
+var expect = require('expect.js'),
+    Response = require('../../lib/index.js').Response;
+
+/* global describe, it */
+describe('response mime', function () {
+    it('must treat lack of information as plain text', function () {
+        var response = new Response();
+        expect(response.mime()).be.eql({
+            type: 'text',
+            format: 'plain',
+            name: 'response',
+            ext: 'txt',
+            _originalContentType: 'text/plain',
+            _sanitisedContentType: 'text/plain',
+            _accuratelyDetected: true,
+            filename: 'response.txt',
+            source: 'default',
+            detected: null
+        });
+    });
+
+    it('must translate ambiguous content type', function () {
+        var response = new Response({
+            header: [{
+                key: 'content-type',
+                value: 'application/json'
+            }]
+        });
+        expect(response.mime()).be.eql({
+            type: 'text',
+            format: 'json',
+            name: 'response',
+            ext: 'json',
+            _originalContentType: 'application/json',
+            _sanitisedContentType: 'application/json',
+            _accuratelyDetected: true,
+            filename: 'response.json',
+            source: 'header',
+            detected: null
+        });
+    });
+
+    it('must translate malformed content type', function () {
+        var response = new Response({
+            header: [{
+                key: 'content-type',
+                value: '  application  / hal+ json '
+            }]
+        });
+        expect(response.mime()).be.eql({
+            type: 'text',
+            format: 'json',
+            name: 'response',
+            ext: '',
+            _originalContentType: '  application  / hal+ json ',
+            _sanitisedContentType: 'application/hal+json',
+            _accuratelyDetected: true,
+            filename: 'response',
+            source: 'header',
+            detected: null
+        });
+    });
+
+    it('must translate content type with charset', function () {
+        var response = new Response({
+            header: [{
+                key: 'content-type',
+                value: 'application/ogg; charset=utf8'
+            }]
+        });
+        expect(response.mime()).be.eql({
+            type: 'audio',
+            format: 'ogg',
+            name: 'response',
+            ext: 'ogx',
+            _originalContentType: 'application/ogg; charset=utf8',
+            _sanitisedContentType: 'application/ogg',
+            _accuratelyDetected: true,
+            filename: 'response.ogx',
+            source: 'header',
+            detected: null
+        });
+    });
+
+    it('must be greedy in assuming script types', function () {
+        var response = new Response({
+            header: [{
+                key: 'content-type',
+                value: 'application/x-ecmascript'
+            }]
+        });
+        expect(response.mime()).be.eql({
+            type: 'text',
+            format: 'script',
+            name: 'response',
+            ext: '',
+            _originalContentType: 'application/x-ecmascript',
+            _sanitisedContentType: 'application/x-ecmascript',
+            _accuratelyDetected: true,
+            filename: 'response',
+            source: 'header',
+            detected: null
+        });
+    });
+
+    it('must gracefully handle extremely deviant content type', function () {
+        var response = new Response({
+            header: [{
+                key: 'content-type',
+                value: 'machine/samaritan'
+            }]
+        });
+        expect(response.mime()).be.eql({
+            type: 'unknown',
+            format: 'raw',
+            name: 'response',
+            ext: '',
+            _originalContentType: 'machine/samaritan',
+            _sanitisedContentType: 'machine/samaritan',
+            _accuratelyDetected: false,
+            filename: 'response',
+            source: 'header',
+            detected: null
+        });
+    });
+
+    it.skip('must detect mime from body', function () {
+        var response = new Response({
+            header: [{
+                key: 'content-type',
+                value: 'machine/samaritan'
+            }],
+
+            // todo load real file content here (maybe 1x1 px bmp)
+            stream: Buffer.from ?
+                Buffer.from([0x62,0x75,0x66,0x66,0x65,0x72]) : new Buffer([0x62,0x75,0x66,0x66,0x65,0x72])
+        });
+
+        expect(response.mime()).be.eql({
+            type: 'unknown',
+            format: 'raw',
+            name: 'response',
+            ext: '',
+            _originalContentType: 'machine/samaritan',
+            _sanitisedContentType: 'machine/samaritan',
+            _accuratelyDetected: false,
+            filename: 'response',
+            source: 'header',
+            detected: {
+                type: 'image'
+            }
+        });
+    });
+});


### PR DESCRIPTION
- response.mime() now returns content type detected base after a lot of sanitisation

> note that the structure of mime()-> return object has changed. It now returns 

mime() now returns
```
source: string // 'header', 'content', 'default' or 'forced'
type: string, // sanitised mime type base from mime-fromats module
format: string, // secondary format helper from mime-format module
name: DEFAULT_RESPONSE_FILENAME, // @todo - get from disposition
ext: string // file extension from sanitised content type using mimeType.extension module
filename: string // name + ext,

// also storing some meta info for possible debugging
_originalContentType: string, // the user provided mime type
_sanitisedContentType: string, // sanitised mime type as done by mime-formats module
_accuratelyDetected: boolean // this being true implies worse case (raw render)
detected: {}|null // same as root object, but based on what is detected from content
```

@numaanashraf