### PR TITLE
Fix collection constructor `info` block description parsing

### DIFF
--- a/lib/collection/property-base.js
+++ b/lib/collection/property-base.js
@@ -23,8 +23,8 @@ PropertyBase = function PropertyBase (definition) {
     // call the meta extraction functions to create the object where all keys that are prefixed with underscore can be
     // stored. more details on that can be retrieved from the propertyExtractMeta function itself.
     // @todo: make this a closed function to do getter and setter which is non enumerable
-    var meta = _(definition && definition.info || definition)
-        .pick(PropertyBase.propertyIsMeta).mapKeys(PropertyBase.propertyUnprefixMeta).value();
+    var src = definition && definition.info || definition,
+        meta = _(src).pick(PropertyBase.propertyIsMeta).mapKeys(PropertyBase.propertyUnprefixMeta).value();
 
     _.merge(this, /** @lends PropertyBase.prototype */ {
         /**
@@ -49,7 +49,7 @@ PropertyBase = function PropertyBase (definition) {
          *     item.description && console.log(item.description.toString());
          * });
          */
-        description: _.createDefined(definition, 'description', Description)
+        description: _.createDefined(src, 'description', Description, this.description)
     });
 
     _.keys(meta).length && (this._ = meta);

--- a/lib/collection/property-base.js
+++ b/lib/collection/property-base.js
@@ -52,7 +52,9 @@ PropertyBase = function PropertyBase (definition) {
         description: _.createDefined(src, 'description', Description, this.description)
     });
 
-    _.keys(meta).length && (this._ = meta);
+    if (_.keys(meta).length) {
+        this._ = _.isObject(this._) ? _.merge(this._, meta) : meta;
+    }
 };
 
 _.extend(PropertyBase.prototype, /** @lends PropertyBase.prototype */ {

--- a/lib/util.js
+++ b/lib/util.js
@@ -101,13 +101,14 @@ _.mixin( /** @lends util */ {
     /**
      * Creates a property on an object, with the given type.
      *
-     * @param obj
-     * @param name
-     * @param Prop
+     * @param {Object} obj
+     * @param {String} name
+     * @param {Property} Prop
+     * @param {*} [fallback]
      * @returns {Prop|undefined}
      */
-    createDefined: function (obj, name, Prop) {
-        return _.has(obj, name) ? (new Prop(obj[name])) : undefined;
+    createDefined: function (obj, name, Prop, fallback) {
+        return _.has(obj, name) ? (new Prop(obj[name])) : fallback;
     },
 
     /**

--- a/test/unit/collection.test.js
+++ b/test/unit/collection.test.js
@@ -39,4 +39,28 @@ describe('Collection', function () {
             expect(collection.forEachItem).to.be.a('function');
         });
     });
+
+    describe('info block parsing', function () {
+        it('must parse description', function () {
+            var collection = new Collection({
+                info: {
+                    name: 'test',
+                    description: 'this is test description'
+                }
+            });
+
+            expect(collection.description).be.ok();
+            expect(collection.description.toString()).be('this is test description');
+        });
+
+        it('must parse description from outside info block if info is absent', function () {
+            var collection = new Collection({
+                name: 'test',
+                description: 'this is test description'
+            });
+
+            expect(collection.description).be.ok();
+            expect(collection.description.toString()).be('this is test description');
+        });
+    });
 });


### PR DESCRIPTION
- PropertyBase should honour `info` block for loading description
- Also updated PropertyBase to be non-destructive if the constructor is re-run on an instance