### PR TITLE
AWSv4 session token support

### DIFF
--- a/lib/collection/request-auth/awsv4.js
+++ b/lib/collection/request-auth/awsv4.js
@@ -14,6 +14,7 @@ module.exports = {
         _.extend(this, {
             accessKey: options.accessKey,
             secretKey: options.secretKey,
+            sessionToken: options.sessionToken,
             region: options.region,
             service: options.service
         });
@@ -50,7 +51,8 @@ module.exports = {
         signedData = self.sign({
             credentials: {
                 accessKeyId: params.accessKey,
-                secretAccessKey: params.secretKey
+                secretAccessKey: params.secretKey,
+                sessionToken: params.sessionToken
             },
             host: request.url.getHost(),
             path: request.url.getPathWithQuery(),

--- a/test/fixtures/index.js
+++ b/test/fixtures/index.js
@@ -155,6 +155,7 @@ module.exports = {
                     // Fake Credentials
                     accessKey: 'AKIAI53QRL',
                     secretKey: 'cr2RAfsY4IIVweutTBoBzR',
+                    sessionToken: '33Dhtnwf0RVHCFttmMPYt3dxx9zi8I07CBwTXaqupHQ=',
                     region: 'eu-west-1',
                     service: '',
                     auto: true,

--- a/test/functional/request-auth.test.js
+++ b/test/functional/request-auth.test.js
@@ -71,6 +71,7 @@ describe('RequestAuth', function () {
             expect(headers).to.have.property('authorization');
             expect(headers).to.have.property('content-type', request.getHeaders({ ignoreCase: true })['content-type']);
             expect(headers).to.have.property('x-amz-date');
+            expect(headers).to.have.property('x-amz-security-token');
         });
     });
 


### PR DESCRIPTION
The AWS library used supports temporary IAM credentials that require the additional parameter of `sessionToken` (https://github.com/mhart/aws4).

This PR solves https://github.com/postmanlabs/newman/issues/353 and https://github.com/postmanlabs/postman-app-support/issues/1663 where adding the session token manually in a header is being handled incorrectly by newman/postman/aws4 library.

Now instead of doing something like this (that doesnt work):
```
"request": {
         "auth": {
                 "type": "awsv4",
                 "awsv4": {
                         "accessKey": "{{accessKey}}",
                         "secretKey": "{{secretKey}}",
                         "region": "{{awsRegion}}",
                         "service": "execute-api",
                         "saveToRequest": true
                 }
         },
         "header": [
                 { "key": "Content-Type", "value": "application/json" },
                 { "key": "X-Amz-Security-Token", "value": "{{sessionToken}}"
         ],
```

you can do something like this, that does work:

```
"request": {
         "auth": {
                 "type": "awsv4",
                 "awsv4": {
                         "accessKey": "{{accessKey}}",
                         "secretKey": "{{secretKey}}",
                         "sessionToken": "{{sessionToken}}",
                         "region": "{{awsRegion}}",
                         "service": "execute-api",
                         "saveToRequest": false
                 }
         },
         "header": [
                 { "key": "Content-Type", "value": "application/json" }
         ],
```