### PR TITLE
Feature/oauth1 empty parameters

### DIFF
--- a/lib/collection/request-auth/oauth1.js
+++ b/lib/collection/request-auth/oauth1.js
@@ -2,6 +2,7 @@ var _ = require('../../util').lodash,
     RequestBody = require('../request-body').RequestBody,
     oAuth1 = require('node-oauth1'),
 
+    EMPTY = '',
     OAUTH1 = 'oauth1',
 
     OAUTH1_PARAMS = {
@@ -59,6 +60,17 @@ module.exports = {
         // Generate a new nonce and timestamp
         helperParams.nonce = helperParams.nonce || oAuth1.nonce(11).toString();
         helperParams.timeStamp = helperParams.timeStamp || oAuth1.timestamp().toString();
+
+        // Ensure that empty parameters are not added to the signature
+        if (!helperParams.addEmptyParamsToSign) {
+            helperParams = _.reduce(helperParams, function (accumulator, value, key) {
+                if (_.isString(value) && (value.trim() === EMPTY)) {
+                    return accumulator;
+                }
+                accumulator[key] = value;
+                return accumulator;
+            }, {});
+        }
 
         // Generate a list of parameters associated with the signature.
         signatureParams = self.sign({
@@ -148,6 +160,10 @@ module.exports = {
             { key: OAUTH1_PARAMS.oauthNonce, value: helperParams.nonce },
             { key: OAUTH1_PARAMS.oauthVersion, value: helperParams.version }
         ];
+
+        signatureParams = _.filter(signatureParams, function (param) {
+            return helperParams.addEmptyParamsToSign || param.value;
+        });
 
         allParams = [].concat(signatureParams, queryParams, bodyParams);
         message = {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "marked": "0.3.5",
     "mime-format": "1.0.0",
     "mime-types": "2.1.11",
-    "node-oauth1": "1.1.3",
+    "node-oauth1": "1.2.0",
     "node-uuid": "1.4.7",
     "sanitize-html": "1.13.0",
     "schema-compiler": "0.0.3",


### PR DESCRIPTION
The parameter that controls the behavior of empty parameters in OAuth 1.0 signing was not being respected previously. Now it is. 