### PR TITLE
Added X-Amz-Content-Sha256 to the set of removed AWS Auth headers

### DIFF
--- a/lib/collection/request-auth/awsv4.js
+++ b/lib/collection/request-auth/awsv4.js
@@ -39,6 +39,7 @@ module.exports = {
         request.removeHeader('Authorization', { ignoreCase: true });
         request.removeHeader('X-Amz-Date', { ignoreCase: true });
         request.removeHeader('X-Amz-Security-Token', { ignoreCase: true });
+        request.removeHeader('X-Amz-Content-Sha256', { ignoreCase: true });
         if (!request.getHeaders({ ignoreCase: true })['content-type']) {
             // Since AWS v4 requires a content type header to be set, add one.
             mode = _.get(request, 'body.mode');


### PR DESCRIPTION
Context: While making AWS API calls, the `X-Amz-Content-Sha256` header is not explicitly removed before every request, resulting in cases like the one below: 

Expected header value: Long arbitrary alphanumeric string
```
GET
<file-name-with-extension>

content-type:application/x-www-form-urlencoded
host:<bucket-name>.s3.amazonaws.com
x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
x-amz-date:20160920T130518Z

content-type;host;x-amz-content-sha256;x-amz-date
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```
Actual header value: Two instances of the same string, separated by a comma.
```
GET
<file-name-with-extension>

content-type:application/x-www-form-urlencoded
host:<bucket-name>.s3.amazonaws.com
x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855,e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
x-amz-date:20160920T130518Z

content-type;host;x-amz-content-sha256;x-amz-date
e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
```