### PR TITLE
Proxy support added in the sdk level

### DIFF
--- a/lib/collection/proxy.js
+++ b/lib/collection/proxy.js
@@ -1,0 +1,206 @@
+var _ = require('../util').lodash,
+    Property = require('./property').Property,
+    Url = require('./url').Url,
+
+    E = '',
+    SELECTALL = '*',
+    HTTPS = 'https',
+    HTTP = 'http',
+    DEFAULT_PORT = '80',
+    regexes = {
+        proxyStringSanitizer: /(PROXY)|(DIRECT)|\[|\]|\s/g
+    },
+
+    Proxy;
+
+
+/**
+* You can either provide the options object alone to the constructor or the ProxyString and the UrlString
+*
+* The following is the object structure accepted as constructor parameter while calling `new Proxy(...)`. It is
+* also the structure exported when {@link Property#toJSON} or {@link Property#toObjectResolved} is called on a
+* Proxy instance.
+* @typedef Proxy~definition
+*
+* @property {String=} [url] The url for which the proxy needs to be configured @default would '*' means select all url.
+* @property {String=} [protocol] The proxy server protocol by @default it will be taken as 'http'
+* @property {String=} [host] The proxy server host name @default would be '' [Empty String] represents no proxy
+* @property {String=} [port] The proxy server port @default would be '80'
+* @property {Boolean=} [tunnel] The option to provide whether tunneling needs to be done while proxying the request,
+* @default would be true.
+*
+* @example <caption>JSON definition of an example proxy object</caption>
+* {
+*     url: 'https://example.com',
+*     protocol: 'http',
+*     host: 'proxy.com',
+*     port: 88,
+*     tunnel: true
+* }
+*
+* Incase of ProxyString format
+* @param {String=} [options] supported formats return by the PAC files as provided here
+* (https://web.archive.org/web/20070602031929/http://wp.netscape.com/eng/mozilla/2.0/relnotes/demo/proxy-live.html)
+* @param {String=} [url] The url for which the proxy needs to be configured @default would '*' means select all url.
+
+* @example
+* var proxyObj = new Proxy('PROXY [https://proxy.com]:88', 'http://example.com')
+* {
+*     url: 'http://example.com',
+*     protocol: 'http',
+*     host: 'proxy.com',
+*     port: '88',
+*     tunnel: true
+* }
+*/
+_.inherit((
+    Proxy = function PostmanProxy (options, url) {
+        // this constructor is intended to inherit and as such the super constructor is required to be executed
+        Proxy.super_.call(this, options);
+
+        // Assign defaults before proceeding
+        _.assign(this, /** @lends Variable.prototype */ {
+            /**
+             * The url for which the proxy has been associated with.
+             * @type {String}
+             */
+            url: SELECTALL,
+
+            /**
+             * @type {String}
+             * @default 'http'
+             */
+            protocol: HTTP,
+
+            /**
+             * @type {String}
+             * @default ''
+             */
+            host: E,
+
+            /**
+             * @type {String}
+             * @default '80'
+             */
+            port: DEFAULT_PORT,
+
+            /**
+             * @type {Boolean}
+             * @default true
+             */
+            tunnel: true
+        });
+
+        if (!options) { return; } // in case definition object is missing, there is no point moving forward
+
+        /**
+        * If the options and url is a string then we need to parse the input and update it.
+        */
+        _.isString(options) && (options = Proxy.parse(options, url));
+
+        /**
+        * Make sure the 'url' key property is available in the options provided or generated
+        */
+        this.update(options);
+
+    }), Property);
+
+_.assign(Proxy.prototype, /** @lends Proxy.prototype */ {
+    update: function (options) {
+        if (!_.isObject(options)) {
+            return;
+        }
+        _.assign(this, {
+            /**
+             * The url for which the proxy has been associated with.
+             * @type {String}
+             */
+            url: options.url || SELECTALL,
+
+            /**
+             * @type {String}
+             * @default 'http'
+             */
+            protocol: options.protocol || HTTP,
+
+            /**
+             * @type {String}
+             * @default ''
+             */
+            host: options.host || E,
+
+            /**
+             * @type {String}
+             * @default 80
+             */
+            port: options.port || DEFAULT_PORT,
+
+            /**
+             * @type {Boolean}
+             * @default true
+             */
+            tunnel: options.tunnel || true
+        });
+    }
+});
+
+_.assign(Proxy, /** @lends Proxy */ {
+    /**
+     * Defines the name of this property for internal use.
+     * @private
+     * @readOnly
+     * @type {String}
+     */
+    _postman_propertyName: 'Proxy',
+
+    /**
+     * Specify the key to be used while indexing this object
+     * @private
+     * @readOnly
+     * @type {String}
+     */
+    _postman_propertyIndexKey: 'url',
+
+    /**
+    * Parse the proxy string to postman proxy object
+    * @public
+    * @param {String} url
+    * @param {String} proxyString
+    * @returns {*} A plain proxy object
+    * @example
+    * var postmanProxy = parseProxyString('PROXY http://proxy.com:8080', 'example.com');
+    *
+    *    {
+    *       url: 'http://example.com',
+    *       protocol: 'http',
+    *       host: 'proxy.com',
+    *       port: '8080'
+    *    }
+    *
+    */
+    parse: function(proxyString, url) {
+        // If the Url is not available it must be taken as the '*' wild card
+        url = url || SELECTALL;
+
+        /**
+        * proxyString can be DIRECT || PROXY [url]:port
+        * Using the regex /(PROXY)|(DIRECT)|\[|\]|\s/g to replace the unwanted values with ''
+        * For Proxy Load balancing the pac scripts will return the Proxy with two URLs seperated by ';'
+        * We by default will be considering only the first proxy URL
+        */
+        var proxyUrl = proxyString.replace(regexes.proxyStringSanitizer, '').split(';'),
+            proxyUrlObj = new Url(proxyUrl[0]);
+        return {
+            url: url,
+            protocol: proxyUrlObj.protocol || HTTP,
+            host: proxyUrlObj.host ? proxyUrlObj.getHost() : E,
+            port: proxyUrlObj.port || DEFAULT_PORT,
+            tunnel: _.startsWith(url, HTTPS)
+        };
+    }
+
+});
+
+module.exports = {
+    Proxy: Proxy
+};

--- a/lib/collection/proxy.js
+++ b/lib/collection/proxy.js
@@ -3,13 +3,16 @@ var _ = require('../util').lodash,
     Url = require('./url').Url,
 
     E = '',
-    SELECTALL = '*',
+    SEMICOLON = ';',
+    MATCH_ALL = '*',
     HTTPS = 'https',
     HTTP = 'http',
-    DEFAULT_PORT = '80',
+    PROTOCOL_SEPARATOR = '://',
     regexes = {
-        proxyStringSanitizer: /(PROXY)|(DIRECT)|\[|\]|\s/g
+        sanitize: /(PROXY)|(DIRECT)|\[|\]|\s/g
     },
+
+    HTTPS_PROTOCOL = HTTPS + PROTOCOL_SEPARATOR,
 
     Proxy;
 
@@ -22,38 +25,49 @@ var _ = require('../util').lodash,
 * Proxy instance.
 * @typedef Proxy~definition
 *
-* @property {String=} [url] The url for which the proxy needs to be configured @default would '*' means select all url.
-* @property {String=} [protocol] The proxy server protocol by @default it will be taken as 'http'
-* @property {String=} [host] The proxy server host name @default would be '' [Empty String] represents no proxy
-* @property {String=} [port] The proxy server port @default would be '80'
-* @property {Boolean=} [tunnel] The option to provide whether tunneling needs to be done while proxying the request,
-* @default would be true.
+* @property {String=} [url = *] The url for which the proxy needs to be configured. `*` represents select all.
+* @property {String=} [protocol = http] The proxy server protocol.
+* @property {String=} [host = ''] The proxy server host name.
+* @property {String=} [port = ''] The proxy server port.
 *
 * @example <caption>JSON definition of an example proxy object</caption>
 * {
 *     url: 'https://example.com',
 *     protocol: 'http',
 *     host: 'proxy.com',
-*     port: 88,
-*     tunnel: true
+*     port: 88
 * }
 *
-* Incase of ProxyString format
-* @param {String=} [options] supported formats return by the PAC files as provided here
-* (https://web.archive.org/web/20070602031929/http://wp.netscape.com/eng/mozilla/2.0/relnotes/demo/proxy-live.html)
-* @param {String=} [url] The url for which the proxy needs to be configured @default would '*' means select all url.
-
-* @example
-* var proxyObj = new Proxy('PROXY [https://proxy.com]:88', 'http://example.com')
-* {
-*     url: 'http://example.com',
-*     protocol: 'http',
-*     host: 'proxy.com',
-*     port: '88',
-*     tunnel: true
-* }
 */
 _.inherit((
+
+/**
+ * A Postman Proxy definition that represents the proxy configuration for an url.
+ *
+ * Properties can then use the `.toObjectResolved` function to procure an object representation of the property with
+ * all the variable references replaced by corresponding values.
+ * @constructor
+ * @extends {Property}
+ *
+ * @param {Proxy~definition=} [options] - Specify the object structure of proxy or the proxyString to be parsed
+ * or supported formats returns by the PAC files as provided {@link
+ * https://web.archive.org/web/20070602031929/http://wp.netscape.com/eng/mozilla/2.0/relnotes/demo/proxy-live.html
+ * here.}
+ * @param {String=} [url = *] - The url for which the proxy needs to be used (Wild cards are also supported).
+ *
+ * @example <caption>Create a new Proxy</caption>
+ * var Proxy = require('postman-collection').Proxy,
+ *     myProxy = new Proxy({
+ *         url: 'https://example.com',
+ *         protocol: 'http',
+ *         host: 'proxy.com',
+ *         port: 88
+ *     });
+ *
+ * @example <caption>Parse a proxyString</caption>
+ * var Proxy = require('postman-collection').Proxy,
+ *     myProxy = new Proxy('PROXY [https://proxy.com]:88', 'http://example.com');
+ */
     Proxy = function PostmanProxy (options, url) {
         // this constructor is intended to inherit and as such the super constructor is required to be executed
         Proxy.super_.call(this, options);
@@ -64,83 +78,55 @@ _.inherit((
              * The url for which the proxy has been associated with.
              * @type {String}
              */
-            url: SELECTALL,
+            url: MATCH_ALL,
 
             /**
              * @type {String}
-             * @default 'http'
              */
             protocol: HTTP,
 
             /**
-             * @type {String}
-             * @default ''
-             */
-            host: E,
-
-            /**
-             * @type {String}
-             * @default '80'
-             */
-            port: DEFAULT_PORT,
-
-            /**
              * @type {Boolean}
-             * @default true
              */
-            tunnel: true
+            direct: !_.isEmpty(options) && _.isEmpty(options.host)
+
         });
 
-        if (!options) { return; } // in case definition object is missing, there is no point moving forward
-
-        /**
-        * If the options and url is a string then we need to parse the input and update it.
-        */
+        // If the options and url is a string then we need to parse the input and update it.
         _.isString(options) && (options = Proxy.parse(options, url));
 
-        /**
-        * Make sure the 'url' key property is available in the options provided or generated
-        */
+        // Make sure the 'url' key property is available in the options provided or generated
         this.update(options);
-
     }), Property);
 
 _.assign(Proxy.prototype, /** @lends Proxy.prototype */ {
+    /**
+     * Updates the properties of the proxy object based on the options provided.
+     *
+     * @param {Proxy~definition} options The proxy object structure.
+     */
     update: function (options) {
-        if (!_.isObject(options)) {
-            return;
-        }
-        _.assign(this, {
-            /**
-             * The url for which the proxy has been associated with.
-             * @type {String}
-             */
-            url: options.url || SELECTALL,
+        _.isObject(options) && _.mergeDefined(this, options);
+    },
 
-            /**
-             * @type {String}
-             * @default 'http'
-             */
-            protocol: options.protocol || HTTP,
+    /**
+     * This provides whether the tunneling needs to be done while proxying the request.
+     * @public
+     * @returns {Boolean}
+     * @type {Function}
+     */
+    tunnel: function () {
+        return _.startsWith(this.url, HTTPS_PROTOCOL);
+    },
 
-            /**
-             * @type {String}
-             * @default ''
-             */
-            host: options.host || E,
-
-            /**
-             * @type {String}
-             * @default 80
-             */
-            port: options.port || DEFAULT_PORT,
-
-            /**
-             * @type {Boolean}
-             * @default true
-             */
-            tunnel: options.tunnel || true
-        });
+    /**
+     * direct determines whether the request is to be proxied or by-passing the proxy.
+     * @public
+     * @returns {Boolean}
+     * @type {Function}
+     */
+    direct: function () {
+        return _.isEmpty(this.host);
     }
 });
 
@@ -162,40 +148,35 @@ _.assign(Proxy, /** @lends Proxy */ {
     _postman_propertyIndexKey: 'url',
 
     /**
-    * Parse the proxy string to postman proxy object
-    * @public
-    * @param {String} url
-    * @param {String} proxyString
-    * @returns {*} A plain proxy object
-    * @example
-    * var postmanProxy = parseProxyString('PROXY http://proxy.com:8080', 'example.com');
-    *
-    *    {
-    *       url: 'http://example.com',
-    *       protocol: 'http',
-    *       host: 'proxy.com',
-    *       port: '8080'
-    *    }
-    *
-    */
+     * Parse the proxy string to postman proxy object
+     * @public
+     * @param {String=} [proxyString] Supports formats returns by the PAC files as provided {@link
+     * https://web.archive.org/web/20070602031929/http://wp.netscape.com/eng/mozilla/2.0/relnotes/demo/proxy-live.html
+     * here.}
+     * @param {String=} [url = *] The url for which the proxy needs to be used (Wild cards are also supported).
+     * @returns {Proxy~definition=} A plain proxy object
+     * @example
+     * var postmanProxy = parseProxyString('PROXY http://proxy.com:8080', 'example.com');
+     */
     parse: function(proxyString, url) {
         // If the Url is not available it must be taken as the '*' wild card
-        url = url || SELECTALL;
+        url = url || MATCH_ALL;
 
-        /**
+        /*
         * proxyString can be DIRECT || PROXY [url]:port
         * Using the regex /(PROXY)|(DIRECT)|\[|\]|\s/g to replace the unwanted values with ''
         * For Proxy Load balancing the pac scripts will return the Proxy with two URLs seperated by ';'
         * We by default will be considering only the first proxy URL
         */
-        var proxyUrl = proxyString.replace(regexes.proxyStringSanitizer, '').split(';'),
+        var proxyUrl = proxyString.replace(regexes.sanitize, E).split(SEMICOLON),
             proxyUrlObj = new Url(proxyUrl[0]);
         return {
             url: url,
             protocol: proxyUrlObj.protocol || HTTP,
             host: proxyUrlObj.host ? proxyUrlObj.getHost() : E,
-            port: proxyUrlObj.port || DEFAULT_PORT,
-            tunnel: _.startsWith(url, HTTPS)
+            port: proxyUrlObj.port,
+            tunnel: _.startsWith(url, HTTPS_PROTOCOL),
+            direct: _.isEmpty(proxyUrlObj.host)
         };
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,5 +21,6 @@ module.exports = {
     Variable: require('./collection/variable').Variable,
     VariableList: require('./collection/variable-list').VariableList,
     VariableScope: require('./collection/variable-scope').VariableScope,
+    Proxy: require('./collection/proxy').Proxy,
     Version: require('./collection/version').Version
 };

--- a/lib/schema/proxy.json
+++ b/lib/schema/proxy.json
@@ -1,0 +1,27 @@
+{
+    "id": "#/definitions/proxy",
+    "title": "Proxy",
+    "description": "Using the Proxy, you can configure your custom proxy into the postman for particular url",
+    "type": "object",
+    "properties": {
+        "url": {
+            "description": "The Url for which the pariticular proxy needs to be taken care, Wild cards are also supported",
+            "type": "string"
+        },
+        "protocol": {
+            "description": "The protocol of the proxy server connecting to"
+        },
+        "host": {
+            "description": "The host of the proxy server",
+            "type": "string"
+        },
+        "port": {
+            "description": "The port to the proxy server",
+            "type": "string"
+        },
+        "tunnel": {
+          "description": "This ensures whether the tunneling need to be done while applying the proxy",
+          "type": "boolean"
+        }
+    }
+}

--- a/lib/schema/proxy.json
+++ b/lib/schema/proxy.json
@@ -22,6 +22,10 @@
         "tunnel": {
           "description": "This ensures whether the tunneling need to be done while applying the proxy",
           "type": "boolean"
+        },
+        "direct": {
+          "description": "This ensures there won't be any proxy applied to the url",
+          "type": "boolean"
         }
     }
 }

--- a/test/integration/proxy.test.js
+++ b/test/integration/proxy.test.js
@@ -2,15 +2,12 @@ var expect = require('expect.js'),
     Proxy = require('../../lib/index.js').Proxy;
 
 /* global describe, it */
-describe('Proxy', function () {
+describe.only('Proxy', function () {
     it('should initialize the values to their defaults', function () {
         var p = new Proxy();
-
         expect(p.url).to.be('*');
         expect(p.protocol).to.be('http');
-        expect(p.host).to.be('');
-        expect(p.port).to.be('80');
-        expect(p.tunnel).to.be(true);
+        expect(p.direct).to.be(false);
     });
 
     it('should prepopulate the values when pass through the constructor', function () {
@@ -25,7 +22,7 @@ describe('Proxy', function () {
         expect(p.protocol).to.be('http');
         expect(p.host).to.be('proxy.com');
         expect(p.port).to.be('8080');
-        expect(p.tunnel).to.be(true);
+        expect(p.direct).to.be(false);
     });
 
     it('Should parse the proxy string provided', function () {
@@ -35,13 +32,15 @@ describe('Proxy', function () {
         expect(p.protocol).to.be('http');
         expect(p.host).to.be('proxy.com');
         expect(p.port).to.be('8080');
-        expect(p.tunnel).to.be(true);
+        expect(p.direct).to.be(false);
     });
 
     it('Should parse the proxy string provided With DIRECT value where the host must be empty', function () {
         var p = new Proxy('DIRECT', 'http://example.com');
 
         expect(p.host).to.be('');
+        expect(p.direct).to.be(true);
+        expect(p.tunnel).to.be(false);
     });
 
 

--- a/test/integration/proxy.test.js
+++ b/test/integration/proxy.test.js
@@ -1,0 +1,53 @@
+var expect = require('expect.js'),
+    Proxy = require('../../lib/index.js').Proxy;
+
+/* global describe, it */
+describe('Proxy', function () {
+    it('should initialize the values to their defaults', function () {
+        var p = new Proxy();
+
+        expect(p.url).to.be('*');
+        expect(p.protocol).to.be('http');
+        expect(p.host).to.be('');
+        expect(p.port).to.be('80');
+        expect(p.tunnel).to.be(true);
+    });
+
+    it('should prepopulate the values when pass through the constructor', function () {
+        var p = new Proxy({
+            url: 'http://example.com',
+            protocol: 'http',
+            host: 'proxy.com',
+            port: '8080'
+        });
+
+        expect(p.url).to.be('http://example.com');
+        expect(p.protocol).to.be('http');
+        expect(p.host).to.be('proxy.com');
+        expect(p.port).to.be('8080');
+        expect(p.tunnel).to.be(true);
+    });
+
+    it('Should parse the proxy string provided', function () {
+        var p = new Proxy('PROXY http://proxy.com:8080', 'http://example.com');
+
+        expect(p.url).to.be('http://example.com');
+        expect(p.protocol).to.be('http');
+        expect(p.host).to.be('proxy.com');
+        expect(p.port).to.be('8080');
+        expect(p.tunnel).to.be(true);
+    });
+
+    it('Should parse the proxy string provided With DIRECT value where the host must be empty', function () {
+        var p = new Proxy('DIRECT', 'http://example.com');
+
+        expect(p.host).to.be('');
+    });
+
+
+    it('If the url is not provided it should take the * wildcard', function () {
+        var p = new Proxy('PROXY http://proxy.com:8080');
+
+        expect(p.url).to.be('*');
+    });
+});


### PR DESCRIPTION
With this PR we are now supporting the proxy in the sdk,

The proxy would be a simple object similar to this.
```
{
            url: 'http://example.com',
            protocol: 'http',
            host: 'proxy.com',
            port: '8080',
            tunnel: true
}
```

And this can be achieved in two ways

By providing the object directly into the constructor
```
var Proxy =  require('postman-collection').Proxy,
    p = new Proxy({
      url: 'http://getpostman.com',
      host: 'proxy.com'
    });
```
**PostmanProxy**
```
 {
  url: 'http://getpostman.com',
  protocol: 'http',
  host: 'proxy.com',
  port: '80',
  tunnel: true
}
```


By providing the proxy string to the constructor
```
var Proxy =  require('postman-collection').Proxy,
    p = new Proxy('PROXY [https://proxy.com]:8443', 'gmail.com');
```
**PostmanProxy**
```
{
  url: 'gmail.com',
  protocol: 'https',
  host: 'proxy.com',
  port: '8443',
  tunnel: true 
}

```
