### PR TITLE
The proxy list matching logic has been revisited and standardised

### DIFF
--- a/lib/collection/proxy-config-list.js
+++ b/lib/collection/proxy-config-list.js
@@ -2,11 +2,6 @@ var _ = require('../util').lodash,
     PropertyList = require('./property-list').PropertyList,
     ProxyConfig = require('./proxy-config').ProxyConfig,
 
-    MATCH_ALL = '*',
-    MATCH_ALL_REGEX = '.*',
-    PREFIX_DELIMITER = '^',
-    POSTFIX_DELIMITER = '$',
-
     ProxyConfigList;
 
 _.inherit((
@@ -44,10 +39,7 @@ _.assign(ProxyConfigList.prototype, /** @lends ProxyConfigList.prototype */ {
 
         // @todo - use a fixed-length cacheing of regexes in future
         return this.find(function(proxyConfig) {
-            var matchRegex = new RegExp(PREFIX_DELIMITER +
-                                        proxyConfig.match.replace(MATCH_ALL, MATCH_ALL_REGEX) +
-                                        POSTFIX_DELIMITER);
-            return !_.isEmpty(url.match(matchRegex));
+            return proxyConfig.test(url);
         });
 
     }

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -2,8 +2,22 @@ var _ = require('../util').lodash,
     Property = require('./property').Property,
     Url = require('./url').Url,
 
-    E = '',
     MATCH_ALL = '*',
+    PREFIX_DELIMITER = '^',
+    POSTFIX_DELIMITER = '$',
+    MATCH_ALL_URLS = '<all_urls>',
+    ALLOWED_PROTOCOLS = ['http', 'https'],
+    ALLOWED_PROTOCOLS_REGEX = ALLOWED_PROTOCOLS.join('|'),
+
+    regexes = {
+        escapeMatcher: /[.+^${}()|[\]\\]/g,
+        escapeMatchReplacement: '\\$&',
+        questionmarkMatcher: /\?/g,
+        questionmarkReplacment: '.',
+        starMatcher: '*',
+        starReplacement: '.*',
+        patternSplit: '^(' + ALLOWED_PROTOCOLS_REGEX + '|\\*)*://(\\*|\\*\\.[^*/]+|[^*/]+|)(/.*)$'
+    },
 
     ProxyConfig;
 
@@ -59,13 +73,13 @@ _.inherit((
              * The url mach for which the proxy has been associated with.
              * @type {String}
              */
-            match: MATCH_ALL,
+            match: MATCH_ALL_URLS,
 
             /**
              * The server url or the proxy url.
              * @type {Url}
              */
-            server: new Url(E),
+            server: new Url(),
 
             /**
              * This represents whether the tunneling needs to done while proxying this request.
@@ -90,6 +104,105 @@ _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
         _.has(options, 'server') && this.server.update(options.server);
         _.isString(options.match) && (this.match = options.match);
         _.has(options, 'server') && (this.tunnel = _.isBoolean(options.tunnel) ? options.tunnel : false);
+    },
+
+    /**
+     * Tests the url string with the match provided.
+     * Follows the https://developer.chrome.com/extensions/match_patterns pattern for pattern validation and matching
+     *
+     * @param {String=} [urlStr] The url string for which the proxy match needs to be done.
+     */
+
+    test: function(urlStr) {
+        /*
+        * This function executes the code in the following sequence for early return avoiding the costly regex matches.
+        * To avoid most of the memory consuming code.
+        * 1. It check whether the match string is <all_urls> in that case, it return immediately without any further
+        *    processing.
+        * 2. Checks whether the matchPattern follows the rules, https://developer.chrome.com/extensions/match_patterns,
+        *    If not then, dont process it. It is a Regex match process which is slower, @todo needs to be cached in
+        *    future.
+        * 3. Check for the protocol, as it is a normal array check.
+        * 4. Checks the host, as it doesn't involve only string comparisons.
+        * 5. Finally, checks for the path, which actually involves the Regex matching, the slow process.
+        */
+        var matchRegexObject = {},
+            match = null,
+            url,
+            hostSuffix = '';
+
+        // If the matchPattern is <all_urls> then there is no need for any validations.
+        if (this.match === MATCH_ALL_URLS) {
+            return true;
+        }
+
+        // Check the match pattern of sanity and split it into protocol, host and path
+        match = this.match.match(regexes.patternSplit);
+
+        if (!match) {
+            // This ensures it is a invalid match pattern
+            return false;
+        }
+
+        // If the protocol retuns '*' we are going to assign ['https', 'http'] array to it.
+        matchRegexObject.protocol = match[1] === MATCH_ALL ? ALLOWED_PROTOCOLS : [match[1]];
+
+        matchRegexObject.host = match[2];
+
+        if (match[3]) {
+            matchRegexObject.path = this.globPatternToRegexp(match[3]);
+        }
+
+        // We reached here means, the match pattern provided is valid and been parsed to protocol, host and path.
+        // Convert the url provided into a url object, happens only if the match string is parsed properly.
+        try {
+            url = new Url(urlStr);
+        }
+        catch (e) {
+            return false;
+        }
+
+        // Check for the protocol availability in the parsed match protocol array
+        if (!_.includes(matchRegexObject.protocol, url.protocol)) {
+            return false;
+        }
+
+        /*
+        * For Host match, we are considering the port with the host, hence we are using getRemote() instead of getHost()
+        * We need to address three cases for the host urlStr
+        * 1. * It matches all the host + protocol,  hence we are not having any parsing logic for it.
+        * 2. .*foo.bar.com Here the prefix could be anything but it should end with foo.bar.com
+        * 3. foo.bar.com This is the absolute matching needs to done.
+        */
+        if (matchRegexObject.host === MATCH_ALL) {
+          // Don't check anything in host. simple go ahead for the path matching logic
+        }
+        else if (matchRegexObject.host[0] === MATCH_ALL) {
+            // It must be *.foo. We also need to allow foo by itself.
+            hostSuffix = matchRegexObject.host.substr(2);
+            if (url.getRemote() !== hostSuffix && !url.getRemote().endsWith('.' + hostSuffix)) {
+                return false;
+            }
+        }
+        else if (matchRegexObject.host !== url.getRemote()) {
+            return false;
+        }
+
+        // The path of the url has been tested
+        if (!url.getPath().match(matchRegexObject.path)) {
+            return false;
+        }
+
+        // If all the conditions are satisfied then it is matched.
+        return true;
+    },
+
+    globPatternToRegexp: function(pattern) {
+        // Escape everything except ? and *.
+        pattern = pattern.replace(regexes.escapeMatcher, regexes.escapeMatchReplacement);
+        pattern = pattern.replace(regexes.questionmarkMatcher, regexes.questionmarkReplacment);
+        pattern = pattern.replace(regexes.starMatcher, regexes.starReplacement);
+        return new RegExp(PREFIX_DELIMITER + pattern + POSTFIX_DELIMITER);
     }
 });
 

--- a/test/integration/proxy-config-list-test.js
+++ b/test/integration/proxy-config-list-test.js
@@ -3,6 +3,17 @@ var expect = require('expect.js'),
 
 /* global describe, it */
 describe('Proxy Config List', function () {
+    it('Assigns, <all_urls> as match pattern and resolves any url provided', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('http://www.google.com/').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
+    });
+
     it('Matches any URL that uses the http protocol', function () {
         var parent = {},
             list = new ProxyConfigList(parent,

--- a/test/integration/proxy-config-list-test.js
+++ b/test/integration/proxy-config-list-test.js
@@ -2,32 +2,131 @@ var expect = require('expect.js'),
     ProxyConfigList = require('../../').ProxyConfigList;
 
 /* global describe, it */
-describe('ProxyConfigList', function () {
-    var parent = {},
-        list = new ProxyConfigList(parent,
-            [
-                { match: 'https://example.com*', server: 'https://proxy.com', tunnel: true },
-                { match: 'https://example[0-9]+.com', server: 'http://proxydigit.com' },
-                { match: 'https://example2*.com', server: 'http://proxyintermediate.com' }
-            ]
-        );
-
-    it('should resolve the match from the list', function () {
-        expect(list.resolve('https://example.com').server.getHost()).to.eql('proxy.com');
+describe('Proxy Config List', function () {
+    it('Matches any URL that uses the http protocol', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: 'http://*/*', server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('http://www.google.com/').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
     });
 
-    it('should resolve the match from the list having the wildcard in between the match', function () {
-        expect(list.resolve('https://example2456s.com').server.getHost()).to.eql('proxyintermediate.com');
+    it('Matches any URL that uses the http protocol, on any host, as long as the path starts with /foo', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: 'http://*/foo*', server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('http://example.com/foo/bar.html').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://www.google.com/foo').server.getHost()).to.eql('proxy.com');
     });
 
-    it('should resolve the match from the list having the digits wildcard', function () {
-        expect(list.resolve('https://example2.com').server.getHost()).to.eql('proxydigit.com');
+    it('Matches any URL that uses the https protocol, is on a google.com host', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: 'http://*.google.com/foo*bar', server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('http://www.google.com/foo/baz/bar').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://docs.google.com/foobar').server.getHost()).to.eql('proxy.com');
     });
 
-    list.add({ server: 'http://proxymatchall.com' });
-
-    it('should resolve the default wildcard match of all other urls', function () {
-        console.log(list.toJSON());
-        expect(list.resolve('https://any.com').server.getHost()).to.eql('proxymatchall.com');
+    it('Matches the specified URL', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: 'http://example.org/foo/bar.html', server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
     });
+
+    it('Matches any URL that uses the http protocol and is on the host 127.0.0.1', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: 'http://127.0.0.1/*', server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('http://127.0.0.1/').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://127.0.0.1/foo/bar.html').server.getHost()).to.eql('proxy.com');
+    });
+
+    it('Matches any URL that uses the http protocol and is on the host ends with 0.0.1', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: 'http://*.0.0.1/', server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('http://127.0.0.1/').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://125.0.0.1/').server.getHost()).to.eql('proxy.com');
+    });
+
+    it('Matches any URL which has host mail.google.com', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: '*://mail.google.com/*', server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('http://mail.google.com/foo/baz/bar').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('https://mail.google.com/foobar').server.getHost()).to.eql('proxy.com');
+    });
+
+    it('Bad Match pattern [No Path]', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: 'http://www.google.com', server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('http://www.google.com')).to.eql(undefined);
+    });
+
+    it('Bad Match pattern ["*" in the host can be followed only by a "." or "/"]', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: 'http://*foo/bar', server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('http://www.foo/bar')).to.eql(undefined);
+    });
+
+    it('Bad Match pattern [If "*" is in the host, it must be the first character]', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: 'http://foo.*.bar/baz ', server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('http://foo.z.bar/baz')).to.eql(undefined);
+    });
+
+    it('Bad Match pattern [Missing protocol separator ("/" should be "//")]', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: 'http:/bar', server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('http:/bar')).to.eql(undefined);
+    });
+
+    it('Bad Match pattern [Invalid protocol]', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: 'foo://*', server: 'https://proxy.com/', tunnel: true }
+                ]
+            );
+        expect(list.resolve('foo://www.foo/bar')).to.eql(undefined);
+    });
+
 });

--- a/test/integration/proxy-config.test.js
+++ b/test/integration/proxy-config.test.js
@@ -6,7 +6,7 @@ describe('Proxy Config', function () {
     it('should initialize the values to their defaults', function () {
         var p = new ProxyConfig();
 
-        expect(p.match).to.be('*');
+        expect(p.match).to.be('<all_urls>');
         expect(p.tunnel).to.be(false);
     });
 
@@ -31,6 +31,6 @@ describe('Proxy Config', function () {
             server: 'http://proxy.com'
         });
 
-        expect(p.match).to.be('*');
+        expect(p.match).to.be('<all_urls>');
     });
 });


### PR DESCRIPTION
The proxy config resolver has been changes by adding the match pattern standardized according to the chrome [match pattern](https://developer.chrome.com/extensions/match_patterns) spec.