### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/collection/property.js
+++ b/lib/collection/property.js
@@ -1,5 +1,5 @@
 var _ = require('../util').lodash,
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     PropertyBase = require('./property-base').PropertyBase,
     Description = require('./description').Description,
     Substitutor = require('../superstring').Substitutor,

--- a/lib/superstring/index.js
+++ b/lib/superstring/index.js
@@ -1,5 +1,5 @@
 var _ = require('../util').lodash,
-    uuid = require('node-uuid'),
+    uuid = require('uuid'),
     E = '',
 
     SuperString, // constructor

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "mime-format": "1.0.2",
     "mime-types": "2.1.13",
     "node-oauth1": "1.2.0",
-    "node-uuid": "1.4.7",
     "sanitize-html": "1.13.0",
     "schema-compiler": "0.0.3",
-    "semver": "5.3.0"
+    "semver": "5.3.0",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "async": "2.0.1",


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.