### PR TITLE
Feature/proxy-config-list-async

### DIFF
--- a/lib/collection/proxy-config-list.js
+++ b/lib/collection/proxy-config-list.js
@@ -32,16 +32,23 @@ _.assign(ProxyConfigList.prototype, /** @lends ProxyConfigList.prototype */ {
      * @returns {ProxyConfig~definition=} The matched proxyConfig object
      * @param {String=} [url] The url for which the proxy config needs to be fetched
      */
-    resolve: function(url) {
+    resolve: function(url, cb) {
         // url must be either string or an instance of url.
         if (!_.isString(url) && !Url.isUrl(url)) {
             return;
         }
 
         // @todo - use a fixed-length cacheing of regexes in future
-        return this.find(function(proxyConfig) {
+        var config = this.find(function(proxyConfig) {
             return !proxyConfig.disabled && proxyConfig.test(url);
         });
+
+
+        if (!config) {
+            return cb('Proxy Configuration not found for URL : ' + url);
+        }
+
+        return cb(null, config);
 
     }
 });

--- a/lib/collection/proxy-config-list.js
+++ b/lib/collection/proxy-config-list.js
@@ -46,10 +46,10 @@ _.assign(ProxyConfigList.prototype, /** @lends ProxyConfigList.prototype */ {
 
 
         if (!config) {
-            return cb('Proxy Configuration not found for URL : ' + url);
+            return _.isFunction(cb) && cb('Proxy Configuration not found for URL : ' + url);
         }
 
-        return cb(null, config);
+        return _.isFunction(cb) && cb(null, config);
 
     }
 });

--- a/lib/collection/proxy-config-list.js
+++ b/lib/collection/proxy-config-list.js
@@ -31,6 +31,7 @@ _.assign(ProxyConfigList.prototype, /** @lends ProxyConfigList.prototype */ {
      * Matches and gets the proxy config for the particular url
      * @returns {ProxyConfig~definition=} The matched proxyConfig object
      * @param {String=} [url] The url for which the proxy config needs to be fetched
+     * @param {function} cb Callback that will be called with node-style argument signature with the resolved proxy configuration.
      */
     resolve: function(url, cb) {
         // url must be either string or an instance of url.

--- a/test/integration/proxy-config-list-test.js
+++ b/test/integration/proxy-config-list-test.js
@@ -10,8 +10,12 @@ describe('Proxy Config List', function () {
                     { server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('http://www.google.com/').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
+        list.resolve('http://www.google.com/', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
+        list.resolve('http://example.org/foo/bar.html', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
     });
 
     it('Assigns, <all_urls> as match pattern and respect the disabled prop in the congfig', function () {
@@ -21,7 +25,9 @@ describe('Proxy Config List', function () {
                     { server: 'https://proxy.com/', tunnel: true, disabled: true }
                 ]
             );
-        expect(list.resolve('foo://www.foo/bar')).to.eql(undefined);
+        list.resolve('foo://www.foo/bar', function (err, config) {
+            expect(config).to.eql(undefined);
+        });
     });
 
     it('Matches any URL that uses the http protocol', function () {
@@ -31,8 +37,12 @@ describe('Proxy Config List', function () {
                     { match: 'http://*/*', server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('http://www.google.com/').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
+        list.resolve('http://www.google.com/', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
+        list.resolve('http://example.org/foo/bar.html', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
     });
 
     it('Matches any URL that uses the http protocol, on any host, as long as the path starts with /foo', function () {
@@ -42,8 +52,12 @@ describe('Proxy Config List', function () {
                     { match: 'http://*/foo*', server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('http://example.com/foo/bar.html').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('http://www.google.com/foo').server.getHost()).to.eql('proxy.com');
+        list.resolve('http://example.com/foo/bar.html', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
+        list.resolve('http://www.google.com/foo', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
     });
 
     it('Matches any URL that uses the https protocol, is on a google.com host', function () {
@@ -53,8 +67,12 @@ describe('Proxy Config List', function () {
                     { match: 'http://*.google.com/foo*bar', server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('http://www.google.com/foo/baz/bar').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('http://docs.google.com/foobar').server.getHost()).to.eql('proxy.com');
+        list.resolve('http://www.google.com/foo/baz/bar', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
+        list.resolve('http://docs.google.com/foobar', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
     });
 
     it('Matches the specified URL', function () {
@@ -64,7 +82,9 @@ describe('Proxy Config List', function () {
                     { match: 'http://example.org/foo/bar.html', server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
+        list.resolve('http://example.org/foo/bar.html', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
     });
 
     it('Matches any URL that uses the http protocol and is on the host 127.0.0.1', function () {
@@ -74,8 +94,12 @@ describe('Proxy Config List', function () {
                     { match: 'http://127.0.0.1/*', server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('http://127.0.0.1/').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('http://127.0.0.1/foo/bar.html').server.getHost()).to.eql('proxy.com');
+        list.resolve('http://127.0.0.1/', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
+        list.resolve('http://127.0.0.1/foo/bar.html', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
     });
 
     it('Matches any URL that uses the http protocol and is on the host ends with 0.0.1', function () {
@@ -85,8 +109,12 @@ describe('Proxy Config List', function () {
                     { match: 'http://*.0.0.1/', server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('http://127.0.0.1/').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('http://125.0.0.1/').server.getHost()).to.eql('proxy.com');
+        list.resolve('http://127.0.0.1/', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
+        list.resolve('http://125.0.0.1/', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
     });
 
     it('Matches any URL which has host mail.google.com', function () {
@@ -96,8 +124,12 @@ describe('Proxy Config List', function () {
                     { match: '*://mail.google.com/*', server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('http://mail.google.com/foo/baz/bar').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('https://mail.google.com/foobar').server.getHost()).to.eql('proxy.com');
+        list.resolve('http://mail.google.com/foo/baz/bar', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
+        list.resolve('https://mail.google.com/foobar', function (err, config) {
+            expect(config.server.getHost()).to.eql('proxy.com');
+        });
     });
 
     it('Bad Match pattern [No Path]', function () {
@@ -107,7 +139,9 @@ describe('Proxy Config List', function () {
                     { match: 'http://www.google.com', server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('http://www.google.com')).to.eql(undefined);
+        list.resolve('http://www.google.com', function (err, config) {
+            expect(config).to.eql(undefined);
+        });
     });
 
     it('Bad Match pattern ["*" in the host can be followed only by a "." or "/"]', function () {
@@ -117,7 +151,9 @@ describe('Proxy Config List', function () {
                     { match: 'http://*foo/bar', server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('http://www.foo/bar')).to.eql(undefined);
+        list.resolve('http://www.foo/bar', function (err, config) {
+            expect(config).to.eql(undefined);
+        });
     });
 
     it('Bad Match pattern [If "*" is in the host, it must be the first character]', function () {
@@ -127,7 +163,9 @@ describe('Proxy Config List', function () {
                     { match: 'http://foo.*.bar/baz', server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('http://foo.z.bar/baz')).to.eql(undefined);
+        list.resolve('http://foo.z.bar/baz', function (err, config) {
+            expect(config).to.eql(undefined);
+        });
     });
 
     it('Bad Match pattern [Missing protocol separator ("/" should be "//")]', function () {
@@ -137,7 +175,9 @@ describe('Proxy Config List', function () {
                     { match: 'http:/bar', server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('http:/bar')).to.eql(undefined);
+        list.resolve('http:/bar', function (err, config) {
+            expect(config).to.eql(undefined);
+        });
     });
 
     it('Bad Match pattern [Invalid protocol]', function () {
@@ -147,7 +187,9 @@ describe('Proxy Config List', function () {
                     { match: 'foo://*', server: 'https://proxy.com/', tunnel: true }
                 ]
             );
-        expect(list.resolve('foo://www.foo/bar')).to.eql(undefined);
+        list.resolve('foo://www.foo/bar', function (err, config) {
+            expect(config).to.eql(undefined);
+        });
     });
 
 });

--- a/test/integration/proxy-config-list-test.js
+++ b/test/integration/proxy-config-list-test.js
@@ -11,9 +11,11 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('http://www.google.com/', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
         list.resolve('http://example.org/foo/bar.html', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
     });
@@ -26,6 +28,7 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('foo://www.foo/bar', function (err, config) {
+            expect(err).to.not.eql(null);
             expect(config).to.eql(undefined);
         });
     });
@@ -38,9 +41,11 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('http://www.google.com/', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
         list.resolve('http://example.org/foo/bar.html', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
     });
@@ -53,9 +58,11 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('http://example.com/foo/bar.html', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
         list.resolve('http://www.google.com/foo', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
     });
@@ -68,9 +75,11 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('http://www.google.com/foo/baz/bar', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
         list.resolve('http://docs.google.com/foobar', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
     });
@@ -83,6 +92,7 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('http://example.org/foo/bar.html', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
     });
@@ -95,9 +105,11 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('http://127.0.0.1/', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
         list.resolve('http://127.0.0.1/foo/bar.html', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
     });
@@ -110,9 +122,11 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('http://127.0.0.1/', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
         list.resolve('http://125.0.0.1/', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
     });
@@ -125,9 +139,11 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('http://mail.google.com/foo/baz/bar', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
         list.resolve('https://mail.google.com/foobar', function (err, config) {
+            expect(err).to.eql(null);
             expect(config.server.getHost()).to.eql('proxy.com');
         });
     });
@@ -140,6 +156,7 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('http://www.google.com', function (err, config) {
+            expect(err).to.not.eql(null);
             expect(config).to.eql(undefined);
         });
     });
@@ -152,6 +169,7 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('http://www.foo/bar', function (err, config) {
+            expect(err).to.not.eql(null);
             expect(config).to.eql(undefined);
         });
     });
@@ -164,6 +182,7 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('http://foo.z.bar/baz', function (err, config) {
+            expect(err).to.not.eql(null);
             expect(config).to.eql(undefined);
         });
     });
@@ -176,6 +195,7 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('http:/bar', function (err, config) {
+            expect(err).to.not.eql(null);
             expect(config).to.eql(undefined);
         });
     });
@@ -188,6 +208,7 @@ describe('Proxy Config List', function () {
                 ]
             );
         list.resolve('foo://www.foo/bar', function (err, config) {
+            expect(err).to.not.eql(null);
             expect(config).to.eql(undefined);
         });
     });

--- a/test/unit/proxy-config-list.test.js
+++ b/test/unit/proxy-config-list.test.js
@@ -12,8 +12,13 @@ describe('Proxy Config List', function () {
                         { server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://www.google.com/').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
+            list.resolve('http://www.google.com/', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
+
+            list.resolve('http://example.org/foo/bar.html', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
         });
 
         it('Matches any URL that uses the http protocol', function () {
@@ -23,8 +28,13 @@ describe('Proxy Config List', function () {
                         { match: 'http://*/*', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://www.google.com/').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve(new Url('http://example.org/foo/bar.html')).server.getHost()).to.eql('proxy.com');
+            list.resolve('http://www.google.com/', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
+
+            list.resolve(new Url('http://example.org/foo/bar.html'), function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
         });
 
         it('Matches any URL that uses the http protocol, on any host, as long as the path starts with /foo', function () {
@@ -34,8 +44,13 @@ describe('Proxy Config List', function () {
                         { match: 'http://*/foo*', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://example.com/foo/bar.html').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve('http://www.google.com/foo').server.getHost()).to.eql('proxy.com');
+            list.resolve('http://example.com/foo/bar.html', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
+
+            list.resolve('http://www.google.com/foo', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
         });
 
         it('Matches any URL that uses the https protocol, is on a google.com host', function () {
@@ -45,8 +60,12 @@ describe('Proxy Config List', function () {
                         { match: 'http://*.google.com/foo*bar', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://www.google.com/foo/baz/bar').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve('http://docs.google.com/foobar').server.getHost()).to.eql('proxy.com');
+            list.resolve('http://www.google.com/foo/baz/bar', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
+            list.resolve('http://docs.google.com/foobar', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
         });
 
         it('Matches the specified URL', function () {
@@ -56,7 +75,9 @@ describe('Proxy Config List', function () {
                         { match: 'http://example.org/foo/bar.html', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
+            list.resolve('http://example.org/foo/bar.html', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
         });
 
         it('Matches any URL that uses the http protocol and is on the host 127.0.0.1', function () {
@@ -66,8 +87,13 @@ describe('Proxy Config List', function () {
                         { match: 'http://127.0.0.1/*', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://127.0.0.1/').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve('http://127.0.0.1/foo/bar.html').server.getHost()).to.eql('proxy.com');
+            list.resolve('http://127.0.0.1/', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
+
+            list.resolve('http://127.0.0.1/foo/bar.html', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
         });
 
         it('Matches any URL that uses the http protocol and is on the host ends with 0.0.1', function () {
@@ -77,8 +103,13 @@ describe('Proxy Config List', function () {
                         { match: 'http://*.0.0.1/', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://127.0.0.1/').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve('http://125.0.0.1/').server.getHost()).to.eql('proxy.com');
+            list.resolve('http://127.0.0.1/', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
+
+            list.resolve('http://125.0.0.1/', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
         });
 
         it('Matches any URL which has host mail.google.com', function () {
@@ -88,8 +119,13 @@ describe('Proxy Config List', function () {
                         { match: '*://mail.google.com/*', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://mail.google.com/foo/baz/bar').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve('https://mail.google.com/foobar').server.getHost()).to.eql('proxy.com');
+            list.resolve('http://mail.google.com/foo/baz/bar', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
+
+            list.resolve('https://mail.google.com/foobar', function (err, config) {
+                expect(config.server.getHost()).to.eql('proxy.com');
+            });
         });
 
         it('Bad Match pattern [No Path]', function () {
@@ -99,7 +135,9 @@ describe('Proxy Config List', function () {
                         { match: 'http://www.google.com', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://www.google.com')).to.eql(undefined);
+            list.resolve('http://www.google.com', function (err, config) {
+                expect(config).to.eql(undefined);
+            });
         });
 
         it('Bad Match pattern ["*" in the host can be followed only by a "." or "/"]', function () {
@@ -109,7 +147,9 @@ describe('Proxy Config List', function () {
                         { match: 'http://*foo/bar', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://www.foo/bar')).to.eql(undefined);
+            list.resolve('http://www.foo/bar', function (err, config) {
+                expect(config).to.eql(undefined);
+            });
         });
 
         it('Bad Match pattern [If "*" is in the host, it must be the first character]', function () {
@@ -119,7 +159,9 @@ describe('Proxy Config List', function () {
                         { match: 'http://foo.*.bar/baz', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://foo.z.bar/baz')).to.eql(undefined);
+            list.resolve('http://foo.z.bar/baz', function (err, config) {
+                expect(config).to.eql(undefined);
+            });
         });
 
         it('Bad Match pattern [Missing protocol separator ("/" should be "//")]', function () {
@@ -129,7 +171,9 @@ describe('Proxy Config List', function () {
                         { match: 'http:/bar', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http:/bar')).to.eql(undefined);
+            list.resolve('http:/bar', function (err, config) {
+                expect(config).to.eql(undefined);
+            });
         });
 
         it('Bad Match pattern [Invalid protocol]', function () {
@@ -139,7 +183,9 @@ describe('Proxy Config List', function () {
                         { match: 'foo://*', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('foo://www.foo/bar')).to.eql(undefined);
+            list.resolve('foo://www.foo/bar', function (err, config) {
+                expect(config).to.eql(undefined);
+            });
         });
 
         it('Bad url for the match [Empty url]', function () {
@@ -149,7 +195,9 @@ describe('Proxy Config List', function () {
                         { match: 'foo://*', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve('')).to.eql(undefined);
+            list.resolve('', function (err, config) {
+                expect(config).to.eql(undefined);
+            });
         });
 
         it('Bad url for the match [Non String url]', function () {
@@ -159,7 +207,9 @@ describe('Proxy Config List', function () {
                         { match: 'foo://*', server: 'https://proxy.com/', tunnel: true }
                     ]
                 );
-            expect(list.resolve({ remote: 'random remote' })).to.eql(undefined);
+            list.resolve({ remote: 'random remote' }, function (err, config) {
+                expect(config).to.eql(undefined);
+            });
         });
     });
 

--- a/test/unit/proxy-config-list.test.js
+++ b/test/unit/proxy-config-list.test.js
@@ -13,10 +13,12 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('http://www.google.com/', function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
 
             list.resolve('http://example.org/foo/bar.html', function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
         });
@@ -29,10 +31,12 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('http://www.google.com/', function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
 
             list.resolve(new Url('http://example.org/foo/bar.html'), function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
         });
@@ -45,6 +49,7 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('http://example.com/foo/bar.html', function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
 
@@ -61,9 +66,11 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('http://www.google.com/foo/baz/bar', function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
             list.resolve('http://docs.google.com/foobar', function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
         });
@@ -76,6 +83,7 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('http://example.org/foo/bar.html', function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
         });
@@ -88,6 +96,7 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('http://127.0.0.1/', function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
 
@@ -104,10 +113,12 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('http://127.0.0.1/', function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
 
             list.resolve('http://125.0.0.1/', function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
         });
@@ -120,10 +131,12 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('http://mail.google.com/foo/baz/bar', function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
 
             list.resolve('https://mail.google.com/foobar', function (err, config) {
+                expect(err).to.eql(null);
                 expect(config.server.getHost()).to.eql('proxy.com');
             });
         });
@@ -136,6 +149,7 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('http://www.google.com', function (err, config) {
+                expect(err).to.not.eql(null);
                 expect(config).to.eql(undefined);
             });
         });
@@ -148,6 +162,7 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('http://www.foo/bar', function (err, config) {
+                expect(err).to.not.eql(null);
                 expect(config).to.eql(undefined);
             });
         });
@@ -160,6 +175,7 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('http://foo.z.bar/baz', function (err, config) {
+                expect(err).to.not.eql(null);
                 expect(config).to.eql(undefined);
             });
         });
@@ -172,6 +188,7 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('http:/bar', function (err, config) {
+                expect(err).to.not.eql(null);
                 expect(config).to.eql(undefined);
             });
         });
@@ -184,6 +201,7 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('foo://www.foo/bar', function (err, config) {
+                expect(err).to.not.eql(null);
                 expect(config).to.eql(undefined);
             });
         });
@@ -196,6 +214,7 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve('', function (err, config) {
+                expect(err).to.not.eql(null);
                 expect(config).to.eql(undefined);
             });
         });
@@ -208,6 +227,7 @@ describe('Proxy Config List', function () {
                     ]
                 );
             list.resolve({ remote: 'random remote' }, function (err, config) {
+                expect(err).to.not.eql(null);
                 expect(config).to.eql(undefined);
             });
         });


### PR DESCRIPTION
Modifies the `resolve` method of `ProxyConfigList` to be async. This solves a problem with the postman native app where resolution of proxy configuration is failing due to change in the `this` context in IPC calls.