### PR TITLE
Adds proxyConfig to Request.js schema

### DIFF
--- a/examples/collection-v2.json
+++ b/examples/collection-v2.json
@@ -98,7 +98,11 @@
                         "exec": "console.log(\"hello\");"
                     }
                 }
-            ]
+            ],
+            "proxy": {
+                "match": "https://*.getpostman.com/*",
+                "server": "https://proxy.com"
+            }
         },
         {
             "id": "request-200-post",

--- a/lib/collection/request.js
+++ b/lib/collection/request.js
@@ -2,6 +2,7 @@ var _ = require('../util').lodash,
     Property = require('./property').Property,
     PropertyList = require('./property-list').PropertyList,
     Url = require('./url').Url,
+    ProxyConfig = require('./proxy-config').ProxyConfig,
     Header = require('./header').Header,
     RequestBody = require('./request-body').RequestBody,
     RequestAuth = require('./request-auth').RequestAuth,
@@ -15,6 +16,7 @@ var _ = require('../util').lodash,
  * @property {Array<Header~definition>} header The headers that should be sent as a part of this request.
  * @property {RequestBody~definition} body The request body definition.
  * @property {RequestAuth~definition} auth The authentication/signing information for this request.
+ * @property {ProxyConfig~definition} proxy The proxy information for this request.
  */
 _.inherit((
 
@@ -61,7 +63,12 @@ _.inherit((
             /**
              * @type {RequestAuth}
              */
-            auth: _.createDefined(options, 'auth', RequestAuth)
+            auth: _.createDefined(options, 'auth', RequestAuth),
+
+            /**
+             * @type {ProxyConfig}
+             */
+            proxy: options.proxy && new ProxyConfig(options.proxy)
         });
     }), Property);
 
@@ -180,9 +187,11 @@ _.assign(Request.prototype, /** @lends Request.prototype */ {
     toJSON: function () {
         var body,
             auth,
+            proxy,
             url;
 
         auth = (this.auth && this.auth.type) ? this.auth.toJSON() : undefined;
+        proxy = this.proxy ? this.proxy.toJSON() : undefined;
         body = this.body ? this.body.toJSON() : undefined;
         url = (this.url.variables && this.url.variables.count()) ? this.url.toJSON() : this.url.toString();
         return {
@@ -192,6 +201,7 @@ _.assign(Request.prototype, /** @lends Request.prototype */ {
             header: this.headers && this.headers.count() ? this.headers.toJSON() : undefined,
             body: body,
             auth: auth,
+            proxy: proxy,
             description: this.description && this.description.toJSON ? this.description.toJSON() : undefined
         };
     },

--- a/lib/schema/request.json
+++ b/lib/schema/request.json
@@ -14,6 +14,9 @@
                 "auth": {
                     "$ref": "#/definitions/auth"
                 },
+                "proxy": {
+                    "$ref": "#/definitions/proxy-config"
+                },
                 "method": {
                     "description": "The HTTP method associated with this request.",
                     "type": "string",

--- a/test/unit/request.test.js
+++ b/test/unit/request.test.js
@@ -16,6 +16,7 @@ describe('Request', function () {
             expect(jsonified.header).to.eql(rawRequest.header);
             expect(jsonified.body).to.eql(rawRequest.body);
             expect(jsonified.description).to.eql(rawRequest.description);
+            expect(jsonified.proxy).to.eql(rawRequest.proxy);
         });
     });
 


### PR DESCRIPTION
This adds a property `proxyConfig` to `Request.js` so [runtime](https://github.com/postmanlabs/postman-runtime/blob/d9b81ca2f178571f1dc698871535c306ba46a023/lib/requester/request-wrapper.js#L88) can now expose the proxy used for a request, though a public API.