### PR TITLE
Feature/prevent meta property serialisation

### DIFF
--- a/lib/collection/property-base.js
+++ b/lib/collection/property-base.js
@@ -1,6 +1,9 @@
 var _ = require('../util').lodash,
     Description = require('./description').Description,
 
+    STRING = 'string',
+    META_PREFIX_CHAR = '_',
+
     PropertyBase; // constructor
 
 /**
@@ -154,7 +157,7 @@ _.assign(PropertyBase, /** @lends Base */ {
      * @returns {boolean}
      */
     propertyIsMeta: function (value, key) {
-        return _.startsWith(key, '_') && (key !== '_');
+        return (typeof key === STRING) && (key.charAt() === META_PREFIX_CHAR) && (key !== META_PREFIX_CHAR);
     },
 
     /**

--- a/lib/collection/property-base.js
+++ b/lib/collection/property-base.js
@@ -100,21 +100,12 @@ _.assign(PropertyBase.prototype, /** @lends PropertyBase.prototype */ {
                 key = key.slice(0, -1);
             }
 
-            // Handle 'PropertyBase's
-            if (value && _.isFunction(value.toJSON)) {
-                accumulator[key] = value.toJSON();
-                return accumulator;
-            }
-
-            // Handle Strings
-            if (_.isString(value)) {
-                accumulator[key] = value;
+            if (PropertyBase.propertyIsMeta(value, key)) {
                 return accumulator;
             }
 
             // Everything else
-            accumulator[key] = _.cloneElement(value);
-            return accumulator;
+            return ((accumulator[key] = _.cloneElement(value)), accumulator);
         }, {});
     },
 

--- a/lib/collection/property-base.js
+++ b/lib/collection/property-base.js
@@ -21,7 +21,7 @@ var _ = require('../util').lodash,
 PropertyBase = function PropertyBase (definition) {
     // In case definition object is missing, there is no point moving forward. Also if the definition is basic string
     // we do not need to do anything with it.
-    if (!definition || typeof definition === 'string') { return; }
+    if (!definition || typeof definition === STRING) { return; }
 
     // call the meta extraction functions to create the object where all keys that are prefixed with underscore can be
     // stored. more details on that can be retrieved from the propertyExtractMeta function itself.
@@ -169,7 +169,7 @@ _.assign(PropertyBase, /** @lends Base */ {
      * @returns {String}
      */
     propertyUnprefixMeta: function (value, key) {
-        return _.trimStart(key, '_');
+        return _.trimStart(key, META_PREFIX_CHAR);
     }
 });
 


### PR DESCRIPTION
Refer to commit messages. In short: toJSON of base, no longer publishes meta properties