### PR TITLE
Event#update script bugfix

### DIFF
--- a/lib/collection/event-list.js
+++ b/lib/collection/event-list.js
@@ -40,7 +40,7 @@ _.assign(EventList.prototype, /** @lends EventList.prototype */ {
             // array we are compiling for return
             (parent !== this.__parent) && EventList.isEventList(parent.events) &&
                 (parentEvents = parent.events.listenersOwn(name)) && parentEvents.length &&
-                all.push.apply(all, parentEvents);
+                all.push.apply(all, parentEvents); // eslint-disable-line prefer-spread
         }, this);
 
         return all;

--- a/lib/collection/event.js
+++ b/lib/collection/event.js
@@ -56,7 +56,10 @@ _.assign(Event.prototype, /** @lends Event.prototype */ {
              * The script that is to be executed when this event is triggered.
              * @type {Script}
              */
-            script: _.isString(definition.script) ? definition.script : new Script(definition.script)
+            script: Script.isScript(definition.script) ? definition.script :
+                ((_.isArray(definition.script) || _.isString(definition.script)) ?
+                    new Script({ exec: definition.script }) : _.isObject(definition.script) ?
+                        new Script(definition.script) : undefined)
         });
     }
 });

--- a/lib/collection/event.js
+++ b/lib/collection/event.js
@@ -45,6 +45,19 @@ _.assign(Event.prototype, /** @lends Event.prototype */ {
             return;
         }
 
+        var result,
+            script = definition.script;
+
+        if (Script.isScript(script)) {
+            result = script;
+        }
+        else if (_.isArray(script) || _.isString(script)) {
+            result = new Script({ exec: script });
+        }
+        else if (_.isObject(script)) {
+            result = new Script(script);
+        }
+
         _.mergeDefined(this, /** @lends Event.prototype */ {
             /**
              * Name of the event that this instance is intended to listen to.
@@ -56,10 +69,7 @@ _.assign(Event.prototype, /** @lends Event.prototype */ {
              * The script that is to be executed when this event is triggered.
              * @type {Script}
              */
-            script: Script.isScript(definition.script) ? definition.script :
-                ((_.isArray(definition.script) || _.isString(definition.script)) ?
-                    new Script({ exec: definition.script }) : _.isObject(definition.script) ?
-                        new Script(definition.script) : undefined)
+            script: result
         });
     }
 });

--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -214,7 +214,7 @@ _.assign(Header, /** @lends Header */ {
     create: function () {
         var args = Array.prototype.slice.call(arguments);
         args.unshift(Header);
-        return new (Header.bind.apply(Header, args))();
+        return new (Header.bind.apply(Header, args))(); // eslint-disable-line prefer-spread
     },
 
     /**

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -157,6 +157,7 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
         // create new instance of the item based on the type specified if it is not already
         this.insert((item.constructor === this.Type) ? item :
             // if the prperty has acreate static function, use it.
+            // eslint-disable-next-line prefer-spread
             (_.has(this.Type, 'create') ? this.Type.create.apply(this.Type, arguments) : new this.Type(item)));
     },
 

--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -60,7 +60,18 @@ _.assign(Script, /** @lends Script */ {
      * @readOnly
      * @type {String}
      */
-    _postman_propertyName: 'Script'
+    _postman_propertyName: 'Script',
+
+    /**
+     * Check whether an object is an instance of {@link ItemGroup}.
+     *
+     * @param {*} obj
+     * @returns {Boolean}
+     */
+    isScript: function (obj) {
+        return obj && ((obj instanceof Script) ||
+            _.inSuperChain(obj.constructor, '_postman_propertyName', Script._postman_propertyName));
+    }
 });
 
 module.exports = {

--- a/test/unit/event.test.js
+++ b/test/unit/event.test.js
@@ -26,35 +26,35 @@ describe('Event', function () {
         });
     });
 
-    describe('udpate', function () {
+    describe('update', function () {
         var script = 'console.log("This is a test log");';
 
         it('must work with script instance definitions', function () {
-            var eventObj = new Event(rawEvent);
+            var event = new Event(rawEvent);
 
-            eventObj.update({ script: new Script({ exec: script }) });
-            expect(eventObj.toJSON().script.exec).to.eql([script]);
+            event.update({ script: new Script({ exec: script }) });
+            expect(event.toJSON().script.exec).to.eql([script]);
         });
 
         it('must work with script strings', function () {
-            var eventObj = new Event(rawEvent);
+            var event = new Event(rawEvent);
 
-            eventObj.update({ script: script });
-            expect(eventObj.toJSON().script.exec).to.eql([script]);
+            event.update({ script: script });
+            expect(event.toJSON().script.exec).to.eql([script]);
         });
 
         it('must work with script arrays', function () {
-            var eventObj = new Event(rawEvent);
+            var event = new Event(rawEvent);
 
-            eventObj.update({ script: [script] });
-            expect(eventObj.toJSON().script.exec).to.eql([script]);
+            event.update({ script: [script] });
+            expect(event.toJSON().script.exec).to.eql([script]);
         });
 
         it('must correctly handle invalid/undefined script input', function () {
-            var eventObj = new Event(rawEvent);
+            var event = new Event(rawEvent);
 
-            eventObj.update();
-            expect(eventObj.toJSON().script.exec).to.eql([rawEvent.script.exec]);
+            event.update();
+            expect(event.toJSON().script.exec).to.eql([rawEvent.script.exec]);
         });
     });
 });

--- a/test/unit/event.test.js
+++ b/test/unit/event.test.js
@@ -1,18 +1,60 @@
 var expect = require('expect.js'),
-    fixtures = require('../fixtures'),
-    Event = require('../../lib/index.js').Event;
+    sdk = require('../../lib/index.js'),
+
+    Event = sdk.Event,
+    Script = sdk.Script;
 
 /* global describe, it */
 describe('Event', function () {
-    var rawEvent = fixtures.collectionV2.event[0],
-        event = new Event(rawEvent);
+    var rawEvent = {
+        listen: 'test',
+        id: 'my-global-script-1',
+        script: {
+            type: 'text/javascript',
+            exec: 'console.log("hello");'
+        }
+    };
 
     describe('json representation', function () {
         it('must match what the event was initialized with', function () {
-            var jsonified = event.toJSON();
+            var event = new Event(rawEvent),
+                jsonified = event.toJSON();
+
             expect(jsonified.listen).to.eql(event.listen);
             // Script property checking is done independently
             expect(jsonified).to.have.property('script');
+        });
+    });
+
+    describe('udpate', function () {
+        var script = 'console.log("This is a test log");';
+
+        it('must work with script instance definitions', function () {
+            var eventObj = new Event(rawEvent);
+
+            eventObj.update({ script: new Script({ exec: script }) });
+            expect(eventObj.toJSON().script.exec).to.eql([script]);
+        });
+
+        it('must work with script strings', function () {
+            var eventObj = new Event(rawEvent);
+
+            eventObj.update({ script: script });
+            expect(eventObj.toJSON().script.exec).to.eql([script]);
+        });
+
+        it('must work with script arrays', function () {
+            var eventObj = new Event(rawEvent);
+
+            eventObj.update({ script: [script] });
+            expect(eventObj.toJSON().script.exec).to.eql([script]);
+        });
+
+        it('must correctly handle invalid/undefined script input', function () {
+            var eventObj = new Event(rawEvent);
+
+            eventObj.update();
+            expect(eventObj.toJSON().script.exec).to.eql([rawEvent.script.exec]);
         });
     });
 });

--- a/test/unit/request.test.js
+++ b/test/unit/request.test.js
@@ -8,7 +8,7 @@ describe('Request', function () {
         request = new Request(rawRequest);
 
     describe('isRequest', function () {
-        it('must distinguish between collections and other objects', function () {
+        it('must distinguish between requests and other objects', function () {
             var request = new Request(),
                 nonRequest = {};
 

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -12,7 +12,7 @@ var fs = require('fs'),
 /* global describe, it */
 describe('Response', function () {
     describe('isResponse', function () {
-        it('must distinguish between collections and other objects', function () {
+        it('must distinguish between responses and other objects', function () {
             var response = new Response(),
                 nonResponse = {};
 

--- a/test/unit/script.test.js
+++ b/test/unit/script.test.js
@@ -7,6 +7,16 @@ describe('Script', function () {
     var rawScript = fixtures.collectionV2.event[1].script,
         script = new Script(rawScript);
 
+    describe('isScript', function () {
+        it('must distinguish between scripts and other objects', function () {
+            var script = new Script(),
+                nonScript = {};
+
+            expect(Script.isScript(script)).to.be(true);
+            expect(Script.isScript(nonScript)).to.be(false);
+        });
+    });
+
     describe('json representation', function () {
         it('must match what the script was initialized with', function () {
             var jsonified = script.toJSON();


### PR DESCRIPTION
`Event#update` now works correctly with the following script types:

* `Strings`
* `Arrays`
* `Script` instances
* Plain script objects (for backward compatibility)