### PR TITLE
Added VariableScope PM API helpers

### DIFF
--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -171,9 +171,6 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
 
         !context && (context = this);
 
-        // maintain consistency when being used in bulk from PropertyList#clear
-        predicate = predicate || this.members[0];
-
         // if predicate is id, then create a function to remove that from array
         if (_.isString(predicate)) {
             (match = this.one(predicate)) && (predicate = function (item) {
@@ -202,6 +199,21 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
     },
 
     /**
+     * Removes all items in the list
+     */
+    clear: function () {
+        // we unlink every member from it's parent (assuming this is their parent)
+        this.all().forEach(PropertyList._unlinkItemFromParent);
+
+        this.members.length = 0; // remove all items from list
+
+        // now we remove all items from index reference
+        Object.keys(this.reference).forEach(function (key) {
+            delete this.reference[key];
+        }.bind(this));
+    },
+
+    /**
      * Load one or more items
      *
      * @param {Object|Array} items
@@ -214,13 +226,6 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
             // if population is not an array, we send this as single item in an array or send each property separately
             // if the core Type supports Type.create
             ((_.isPlainObject(items) && _.has(this.Type, 'create')) ? items : [items]), this.add.bind(this));
-    },
-
-    /**
-     * Removes all items in the list
-     */
-    clear: function () {
-        this.each(this.remove.bind(this));
     },
 
     /**
@@ -392,6 +397,16 @@ _.assign(PropertyList, /** @lends PropertyList */ {
      * @type {String}
      */
     _postman_propertyName: 'PropertyList',
+
+    /**
+     * Removes child-parent links for the provided PropertyList member.
+     *
+     * @param {Property} item - The property for which to perform parent de-linking.
+     * @private
+     */
+    _unlinkItemFromParent: function (item) {
+        item.__parent && (delete item.__parent); // prevents V8 from making unnecessary look-ups if there is no __parent
+    },
 
     /**
      * Checks whether an object is a PropertyList

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -170,6 +170,10 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
         var match; // to be used if predicate is an ID
 
         !context && (context = this);
+
+        // maintain consistency when being used in bulk from PropertyList#clear
+        predicate = predicate || this.members[0];
+
         // if predicate is id, then create a function to remove that from array
         if (_.isString(predicate)) {
             (match = this.one(predicate)) && (predicate = function (item) {

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -44,6 +44,47 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      */
     _postman_requiresId: true,
 
+
+    /**
+     * Fetches a variable from the current scope.
+     *
+     * @param {String} key - The name of the variable to set.
+     * @returns {String|*} The value of the specified variable in the current context.
+     */
+    get: function (key) {
+        var variable = this.values.one(key);
+        return variable ? variable.valueOf() : undefined;
+    },
+
+    /**
+     * Creates a new variable, or updates an existing one.
+     *
+     * @param {String} key - The name of the variable to set.
+     * @param {String} value - The value of the variable to be set.
+     */
+    set: function (key, value) {
+        var variable = this.values.one(key);
+
+        // If a variable by the name key was not found in the previous lookup, create a new variable and insert it.
+        if (variable) { return variable.set(value); }
+
+        this.values.add({ key: key, value: value });
+    },
+
+    /**
+     * Removes the variable with the specified name.
+     */
+    unset: function (key) {
+        this.values.remove(key);
+    },
+
+    /**
+     * Removes *all* variables from the current scope. This is a destructive action.
+     */
+    clear: function () {
+        this.values.clear();
+    },
+
     /**
      * Using this function, one can sync the values of this variable list from a reference object.
      *

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -143,6 +143,31 @@ describe('PropertyList', function () {
         expect(Object.keys(list.reference)).to.eql(['yoLoLo2']);
     });
 
+    it('should remove all items correctly', function () {
+        var FakeType,
+            list;
+
+        FakeType = function (options) {
+            this.keyAttr = options.keyAttr;
+            this.value = options.value;
+        };
+
+        FakeType._postman_propertyIndexKey = 'keyAttr';
+        // FakeType._postman_propertyIndexCaseInsensitive = false; // this is default
+
+        list = new PropertyList(FakeType, {}, [{
+            keyAttr: 'yoLoLo1',
+            value: 'what'
+        }, {
+            keyAttr: 'yoLoLo2',
+            value: 'where'
+        }]);
+
+        list.clear();
+
+        expect(list.count()).to.be(0);
+    });
+
     describe('reordering method', function () {
         // We create two variables that we would usually deal within these tests to insert and remove stuff
         var enterprise,

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -265,4 +265,101 @@ describe('VariableScope', function () {
             expect(target).not.have.property('extra');
         });
     });
+
+    describe('PM API helpers', function () {
+        describe('get', function () {
+            var scope = new VariableScope({
+                values: [{
+                    key: 'var-1',
+                    value: 'var-1-value'
+                }, {
+                    key: 'var-2',
+                    value: 'var-2-value'
+                }]
+            });
+
+            it('must correctly return the specified value', function () {
+                expect(scope.get('var-1')).to.be('var-1-value');
+            });
+
+            it('must return undefined for ', function () {
+                expect(scope.get('random')).to.be(undefined);
+            });
+        });
+
+        describe('set', function () {
+            var scope = new VariableScope({
+                values: [{
+                    key: 'var-1',
+                    value: 'var-1-value'
+                }, {
+                    key: 'var-2',
+                    value: 'var-2-value'
+                }]
+            });
+
+            it('must correctly update an existing value', function () {
+                scope.set('var-1', 'new-var-1-value');
+                expect(scope.get('var-1')).to.be('new-var-1-value');
+            });
+
+            it('must create a new variable if non-existent', function () {
+                scope.set('var-3', 'var-3-value');
+
+                expect(scope.values.count()).to.be(3);
+                expect(scope.get('var-3')).to.be('var-3-value');
+            });
+        });
+
+        describe('unset', function () {
+            it('must correctly remove an existing variable', function () {
+                var scope = new VariableScope({
+                    values: [{
+                        key: 'var-1',
+                        value: 'var-1-value'
+                    }, {
+                        key: 'var-2',
+                        value: 'var-2-value'
+                    }]
+                });
+
+                scope.unset('var-1');
+
+                expect(scope.values.count()).to.be(1);
+                expect(scope.get('var-1')).to.be(undefined);
+            });
+
+            it('must leave the scope untouched for an invalid key', function () {
+                var scope = new VariableScope({
+                    values: [{
+                        key: 'var-1',
+                        value: 'var-1-value'
+                    }, {
+                        key: 'var-2',
+                        value: 'var-2-value'
+                    }]
+                });
+
+                scope.unset('random');
+                expect(scope.values.count()).to.be(2);
+            });
+        });
+
+        describe('clear', function () {
+            var scope = new VariableScope({
+                values: [{
+                    key: 'var-1',
+                    value: 'var-1-value'
+                }, {
+                    key: 'var-2',
+                    value: 'var-2-value'
+                }]
+            });
+
+            it('must correctly remove all variables', function () {
+                scope.clear();
+                expect(scope.values.count()).to.be(0);
+            });
+        });
+    });
 });


### PR DESCRIPTION
This pull request adds the following to `VariableScope.prototype`:

1. `set`: Creates new or updates existing variables in the current context.
2. `get`: Fetches variable values in the current scope by variable name.
3. `unset`: Removes variables from the current scope by variable name.
4. `clear`: Destroys all variables in the current scope. This is a **destructive** action.

> Bonus: Fixed a bug in PropertyList#clear which would cause only the first member to be removed, not all. Associated unit tests are included as well.