### PR TITLE
Response details standard name

### DIFF
--- a/lib/collection/response.js
+++ b/lib/collection/response.js
@@ -138,10 +138,10 @@ _.assign(Response.prototype, /** @lends Response.prototype */ {
         // options.stream accepts new Buffer() as well as new Buffer().toJSON()
         var stream = normaliseStream(options.stream);
 
-        this._details = _.mergeDefined(_.clone(httpReasons.lookup(options.code)), {
+        _.mergeDefined((this._details = _.clone(httpReasons.lookup(options.code))), {
             name: _.choose(options.reason, options.status),
             code: options.code,
-            fromServer: options.reason || options.status
+            standardName: this._details.name
         });
 
         _.mergeDefined(this, /** @lends Response.prototype */ {
@@ -226,7 +226,7 @@ _.assign(Response.prototype, /** @lends Response.prototype */ {
         if (!this._details || this._details.code !== this.code) {
             this._details = _.clone(httpReasons.lookup(this.code));
             this._details.code = this.code;
-            this._details.name = _.choose(this.reason, this.status, this._details.name);
+            this._details.standardName = this._details.name;
         }
         return _.clone(this._details);
     },

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -67,17 +67,18 @@ describe('Response', function () {
         it('should correctly accept provided details', function () {
             expect(new Response({ code: 200 }).details()).to.eql({
                 name: 'OK',
+                standardName: 'OK',
                 detail: reason.lookup(200).detail,
                 code: 200
             });
         });
 
         it('should correctly set a flag for server reasons', function () {
-            expect(new Response({ code: 200, reason: true }).details()).to.eql({
+            expect(new Response({ code: 200 }).details()).to.eql({
                 name: 'OK',
+                standardName: 'OK',
                 detail: reason.lookup(200).detail,
-                code: 200,
-                fromServer: true
+                code: 200
             });
         });
 
@@ -86,6 +87,7 @@ describe('Response', function () {
 
             expect(response.details()).to.eql({
                 name: 'OK',
+                standardName: 'OK',
                 detail: reason.lookup(200).detail,
                 code: 200
             });
@@ -94,9 +96,9 @@ describe('Response', function () {
 
             expect(response.details()).to.eql({
                 name: 'Created',
+                standardName: 'Created',
                 detail: reason.lookup('201').detail,
-                code: 201,
-                fromServer: true
+                code: 201
             });
         });
 
@@ -107,6 +109,7 @@ describe('Response', function () {
 
             expect(response.details()).to.eql({
                 name: 'Created',
+                standardName: 'Created',
                 detail: reason.lookup(201).detail,
                 code: 201
             });


### PR DESCRIPTION
* The `fromServer` flag in Response details has been replaced with `standardName`.