### PR TITLE
Better static helpers

### DIFF
--- a/lib/collection/certificate-list.js
+++ b/lib/collection/certificate-list.js
@@ -71,7 +71,7 @@ _.assign(CertificateList, /** @lends CertificateList */ {
      * @returns {Boolean}
      */
     isCertificateList: function (obj) {
-        return obj && ((obj instanceof CertificateList) ||
+        return Boolean(obj) && ((obj instanceof CertificateList) ||
           _.inSuperChain(obj.constructor, '_postman_propertyName', CertificateList._postman_propertyName));
     }
 });

--- a/lib/collection/collection.js
+++ b/lib/collection/collection.js
@@ -216,7 +216,7 @@ _.assign(Collection, /** @lends Collection */ {
      * @returns {Boolean}
      */
     isCollection: function (obj) {
-        return obj && ((obj instanceof Collection) ||
+        return Boolean(obj) && ((obj instanceof Collection) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', Collection._postman_propertyName));
     }
 });

--- a/lib/collection/cookie.js
+++ b/lib/collection/cookie.js
@@ -224,7 +224,7 @@ _.assign(Cookie, /** @lends Cookie */ {
      * @returns {Boolean}
      */
     isCookie: function (obj) {
-        return obj && ((obj instanceof Cookie) ||
+        return Boolean(obj) && ((obj instanceof Cookie) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', Cookie._postman_propertyName));
     },
 

--- a/lib/collection/description.js
+++ b/lib/collection/description.js
@@ -178,7 +178,7 @@ _.assign(Description, /** @lends Description */ {
      * @returns {Boolean}
      */
     isDescription: function (obj) {
-        return obj && ((obj instanceof Description) ||
+        return Boolean(obj) && ((obj instanceof Description) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', Description._postman_propertyName));
     }
 });

--- a/lib/collection/event-list.js
+++ b/lib/collection/event-list.js
@@ -76,7 +76,7 @@ _.assign(EventList, /** @lends EventList */ {
      * @returns {boolean}
      */
     isEventList: function (obj) {
-        return obj && ((obj instanceof EventList) ||
+        return Boolean(obj) && ((obj instanceof EventList) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', EventList._postman_propertyName));
     }
 });

--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -197,7 +197,7 @@ _.assign(Header, /** @lends Header */ {
      * @returns {Boolean}
      */
     isHeader: function (obj) {
-        return obj && ((obj instanceof Header) ||
+        return Boolean(obj) && ((obj instanceof Header) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', Header._postman_propertyName));
     },
 

--- a/lib/collection/item-group.js
+++ b/lib/collection/item-group.js
@@ -229,7 +229,7 @@ _.assign(ItemGroup, /** @lends ItemGroup */ {
      * @returns {Boolean}
      */
     isItemGroup: function (obj) {
-        return obj && ((obj instanceof ItemGroup) ||
+        return Boolean(obj) && ((obj instanceof ItemGroup) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', ItemGroup._postman_propertyName));
     }
 });

--- a/lib/collection/item.js
+++ b/lib/collection/item.js
@@ -191,7 +191,7 @@ _.assign(Item, /** @lends Item */ {
      * @returns {Boolean}
      */
     isItem: function (obj) {
-        return obj && ((obj instanceof Item) ||
+        return Boolean(obj) && ((obj instanceof Item) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', Item._postman_propertyName));
     }
 });

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -437,7 +437,7 @@ _.assign(PropertyList, /** @lends PropertyList */ {
      * @returns {Boolean}
      */
     isPropertyList: function (obj) {
-        return obj && ((obj instanceof PropertyList) ||
+        return Boolean(obj) && ((obj instanceof PropertyList) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', PropertyList._postman_propertyName));
     }
 });

--- a/lib/collection/proxy-config-list.js
+++ b/lib/collection/proxy-config-list.js
@@ -64,7 +64,7 @@ _.assign(ProxyConfigList, /** @lends ProxyConfigList */ {
      * @returns {Boolean}
      */
     isProxyConfigList: function (obj) {
-        return obj && ((obj instanceof ProxyConfigList) ||
+        return Boolean(obj) && ((obj instanceof ProxyConfigList) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', ProxyConfigList._postman_propertyName));
     }
 });

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -131,7 +131,7 @@ _.assign(ProxyConfig, /** @lends ProxyConfig */ {
      * @returns {Boolean}
      */
     isProxyConfig: function (obj) {
-        return obj && ((obj instanceof ProxyConfig) ||
+        return Boolean(obj) && ((obj instanceof ProxyConfig) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', ProxyConfig._postman_propertyName));
     }
 });

--- a/lib/collection/request.js
+++ b/lib/collection/request.js
@@ -254,7 +254,7 @@ _.assign(Request, /** @lends Request */ {
      * @returns {Boolean}
      */
     isRequest: function (obj) {
-        return obj && ((obj instanceof Request) ||
+        return Boolean(obj) && ((obj instanceof Request) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', Request._postman_propertyName));
     }
 });

--- a/lib/collection/response.js
+++ b/lib/collection/response.js
@@ -414,7 +414,7 @@ _.assign(Response, /** @lends Response */ {
      * @returns {Boolean}
      */
     isResponse: function (obj) {
-        return obj && ((obj instanceof Response) ||
+        return Boolean(obj) && ((obj instanceof Response) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', Response._postman_propertyName));
     },
 

--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -69,7 +69,7 @@ _.assign(Script, /** @lends Script */ {
      * @returns {Boolean}
      */
     isScript: function (obj) {
-        return obj && ((obj instanceof Script) ||
+        return Boolean(obj) && ((obj instanceof Script) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', Script._postman_propertyName));
     }
 });

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -402,7 +402,7 @@ _.assign(Url, /** @lends Url */ {
      * @returns {Boolean}
      */
     isUrl: function (obj) {
-        return obj && ((obj instanceof Url) ||
+        return Boolean(obj) && ((obj instanceof Url) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', Url._postman_propertyName));
     }
 });

--- a/lib/collection/variable-list.js
+++ b/lib/collection/variable-list.js
@@ -206,7 +206,7 @@ _.assign(VariableList, /** @lends VariableList */ {
      * @returns {Boolean}
      */
     isVariableList: function (obj) {
-        return obj && ((obj instanceof VariableList) ||
+        return Boolean(obj) && ((obj instanceof VariableList) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', VariableList._postman_propertyName));
     },
 

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -145,7 +145,7 @@ _.assign(VariableScope, /** @lends VariableScope */ {
      * @returns {Boolean}
      */
     isVariableScope: function (obj) {
-        return obj && ((obj instanceof VariableScope) ||
+        return Boolean(obj) && ((obj instanceof VariableScope) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', VariableScope._postman_propertyName));
     }
 });

--- a/lib/collection/variable.js
+++ b/lib/collection/variable.js
@@ -211,7 +211,7 @@ _.assign(Variable, /** @lends Variable */ {
      * @returns {Boolean}
      */
     isVariable: function (obj) {
-        return obj && ((obj instanceof Variable) ||
+        return Boolean(obj) && ((obj instanceof Variable) ||
             _.inSuperChain(obj.constructor, '_postman_propertyName', Variable._postman_propertyName));
     }
 });

--- a/test/unit/certificate-list.test.js
+++ b/test/unit/certificate-list.test.js
@@ -49,6 +49,7 @@ describe('CertificateList', function () {
         it('should return true for CertificateList instance', function() {
             var certificateList = new CertificateList({}, [{ matches: [] }]);
 
+            expect(CertificateList.isCertificateList()).to.eql(false);
             expect(CertificateList.isCertificateList(certificateList)).to.eql(true);
             expect(CertificateList.isCertificateList({})).to.eql(false);
             expect(CertificateList.isCertificateList({ _postman_propertyName: 'CertificateList' })).to.eql(false);

--- a/test/unit/collection.test.js
+++ b/test/unit/collection.test.js
@@ -9,6 +9,7 @@ describe('Collection', function () {
                 nonCollection = {};
 
             expect(Collection.isCollection(collection)).to.be(true);
+            expect(Collection.isCollection()).to.be(false);
             expect(Collection.isCollection(nonCollection)).to.be(false);
         });
     });

--- a/test/unit/cookie.test.js
+++ b/test/unit/cookie.test.js
@@ -39,4 +39,31 @@ describe('Cookie', function () {
             expect(ext.value).to.be('HIGH');
         });
     });
+
+    describe('isCookie', function () {
+        var rawCookie = {
+            domain: '.httpbin.org',
+            expires: 1502442248,
+            hostOnly: false,
+            httpOnly: false,
+            key: '_ga',
+            path: '/',
+            secure: false,
+            session: false,
+            _postman_storeId: '0',
+            value: 'GA1.2.113558537.1435817423'
+        };
+
+        it('should return true for a cookie instance', function () {
+            expect(Cookie.isCookie(new Cookie(rawCookie))).to.be(true);
+        });
+
+        it('should return false for a raw cookie object', function () {
+            expect(Cookie.isCookie(rawCookie)).to.be(false);
+        });
+
+        it('should return false when called without arguments', function () {
+            expect(Cookie.isCookie()).to.be(false);
+        });
+    });
 });

--- a/test/unit/description.test.js
+++ b/test/unit/description.test.js
@@ -15,4 +15,23 @@ describe('Description', function () {
             expect(jsonified.type).to.eql(rawDescription.type || 'text/plain');
         });
     });
+
+    describe('isDescription', function () {
+        var rawDescription = {
+            content: '<h1>This is H1</h1> <i>italic</i> <script>this will be dropped in toString()</script>',
+            version: '2.0.1-abc+efg'
+        };
+
+        it('should return true for a description instance', function () {
+            expect(Description.isDescription(new Description(rawDescription))).to.be(true);
+        });
+
+        it('should return false for a raw description object', function () {
+            expect(Description.isDescription(rawDescription)).to.be(false);
+        });
+
+        it('should return false when called without arguments', function () {
+            expect(Description.isDescription()).to.be(false);
+        });
+    });
 });

--- a/test/unit/event-list.test.js
+++ b/test/unit/event-list.test.js
@@ -1,0 +1,29 @@
+var expect = require('expect.js'),
+    sdk = require('../../lib/index.js'),
+
+    EventList = sdk.EventList;
+
+describe('EventList', function () {
+    describe('isEventList', function () {
+        var rawEventList = [{
+            listen: 'test',
+            id: 'my-global-script-1',
+            script: {
+                type: 'text/javascript',
+                exec: 'console.log("hello");'
+            }
+        }];
+
+        it('should return true for a valid EventList instance', function () {
+            expect(EventList.isEventList(new EventList(rawEventList))).to.be(true);
+        });
+
+        it('should return false for a raw EventList', function () {
+            expect(EventList.isEventList(rawEventList)).to.be(false);
+        });
+
+        it('should return false when called without arguments', function () {
+            expect(EventList.isEventList()).to.be(false);
+        });
+    });
+});

--- a/test/unit/header.test.js
+++ b/test/unit/header.test.js
@@ -160,4 +160,20 @@ describe('Header', function () {
             }]);
         });
     });
+
+    describe('isHeader', function () {
+        var rawHeader = 'Content-Type: application/json\nAuthorization: Hawk id="dh37fgj492je", ts="1448549987", nonce="eOJZCd", mac="O2TFlvAlMvKVSKOzc6XkfU6+5285k5p3m5dAjxumo2k="\n';
+
+        it('should return true for a Header instance', function () {
+            expect(Header.isHeader(new Header(rawHeader))).to.be(true);
+        });
+
+        it('should return false for a raw Header object', function () {
+            expect(Header.isHeader(rawHeader)).to.be(false);
+        });
+
+        it('should return false when called without arguments', function () {
+            expect(Header.isHeader()).to.be(false);
+        });
+    });
 });

--- a/test/unit/item-group.test.js
+++ b/test/unit/item-group.test.js
@@ -108,4 +108,18 @@ describe('ItemGroup', function () {
             expect(parent.name).to.be(collection.name);
         });
     });
+
+    describe('isItemGroup', function () {
+        it('should return true for a ItemGroup instance', function () {
+            expect(sdk.ItemGroup.isItemGroup(new sdk.ItemGroup(fixtures.collectionV2.item))).to.be(true);
+        });
+
+        it('should return false for a raw ItemGroup object', function () {
+            expect(sdk.ItemGroup.isItemGroup(fixtures.collectionV2.item)).to.be(false);
+        });
+
+        it('should return false when called without arguments', function () {
+            expect(sdk.ItemGroup.isItemGroup()).to.be(false);
+        });
+    });
 });

--- a/test/unit/item.test.js
+++ b/test/unit/item.test.js
@@ -50,4 +50,20 @@ describe('Item', function () {
             expect(parent.name).to.be(collection.name);
         });
     });
+
+    describe('isItem', function () {
+        var rawItem = fixtures.collectionV2.item[0];
+
+        it('should return true for a Item instance', function () {
+            expect(sdk.Item.isItem(new sdk.Item(rawItem))).to.be(true);
+        });
+
+        it('should return false for a raw Item object', function () {
+            expect(sdk.Item.isItem(rawItem)).to.be(false);
+        });
+
+        it('should return false when called without arguments', function () {
+            expect(sdk.Item.isItem()).to.be(false);
+        });
+    });
 });

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -431,4 +431,39 @@ describe('PropertyList', function () {
             });
         });
     });
+
+    describe('isPropertyList', function () {
+        var list,
+            rawList = [{
+                keyAttr: 'key1',
+                value: 'val1'
+            }, {
+                keyAttr: 'key1',
+                value: 'val2'
+            }, {
+                keyAttr: 'key2',
+                value: 'val3'
+            }],
+            FakeType = function (options) {
+                this.keyAttr = options.keyAttr;
+                this.value = options.value;
+            };
+
+        FakeType._postman_propertyIndexKey = 'keyAttr';
+        FakeType._postman_propertyAllowsMultipleValues = true;
+
+        list = new PropertyList(FakeType, {}, rawList);
+
+        it('should return true for a PropertyList instance', function () {
+            expect(PropertyList.isPropertyList(list)).to.be(true);
+        });
+
+        it('should return false for a raw PropertyList object', function () {
+            expect(PropertyList.isPropertyList(rawList)).to.be(false);
+        });
+
+        it('should return false when called without arguments', function () {
+            expect(PropertyList.isPropertyList()).to.be(false);
+        });
+    });
 });

--- a/test/unit/proxy-config-list.test.js
+++ b/test/unit/proxy-config-list.test.js
@@ -173,5 +173,9 @@ describe('Proxy Config List', function () {
             var list = { _postman_propertyName: 'ProxyConfigList' };
             expect(ProxyConfigList.isProxyConfigList(list)).to.eql(false);
         });
+
+        it('should return false when called witohut arguments', function () {
+            expect(ProxyConfigList.isProxyConfigList()).to.eql(false);
+        });
     });
 });

--- a/test/unit/proxy-config.test.js
+++ b/test/unit/proxy-config.test.js
@@ -115,5 +115,9 @@ describe('Proxy Config', function () {
         it('correctly identify non ProxyConfig objects', function() {
             expect(ProxyConfig.isProxyConfig({})).to.eql(false);
         });
+
+        it('should return false when called without arguments', function() {
+            expect(ProxyConfig.isProxyConfig()).to.eql(false);
+        });
     });
 });

--- a/test/unit/request.test.js
+++ b/test/unit/request.test.js
@@ -14,6 +14,7 @@ describe('Request', function () {
 
             expect(Request.isRequest(request)).to.be(true);
             expect(Request.isRequest(nonRequest)).to.be(false);
+            expect(Request.isRequest()).to.be(false);
         });
     });
 

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -18,6 +18,7 @@ describe('Response', function () {
                 nonResponse = {};
 
             expect(Response.isResponse(response)).to.be(true);
+            expect(Response.isResponse({})).to.be(false);
             expect(Response.isResponse(nonResponse)).to.be(false);
         });
     });

--- a/test/unit/script.test.js
+++ b/test/unit/script.test.js
@@ -13,6 +13,7 @@ describe('Script', function () {
                 nonScript = {};
 
             expect(Script.isScript(script)).to.be(true);
+            expect(Script.isScript({})).to.be(false);
             expect(Script.isScript(nonScript)).to.be(false);
         });
     });

--- a/test/unit/variable-list.test.js
+++ b/test/unit/variable-list.test.js
@@ -169,9 +169,9 @@ describe('VariableList', function () {
         ]);
 
         it('should work correctly for isVariableList', function () {
-            expect(VariableList.isVariableList(variableList)).to.be.ok();
-            expect(VariableList.isVariableList({})).to.not.be.ok();
-            expect(VariableList.isVariableList()).to.not.be.ok();
+            expect(VariableList.isVariableList(variableList)).to.be(true);
+            expect(VariableList.isVariableList({})).to.be(false);
+            expect(VariableList.isVariableList()).to.be(false);
         });
 
         it('should work correctly for listify', function () {

--- a/test/unit/variable-list.test.js
+++ b/test/unit/variable-list.test.js
@@ -171,6 +171,7 @@ describe('VariableList', function () {
         it('should work correctly for isVariableList', function () {
             expect(VariableList.isVariableList(variableList)).to.be.ok();
             expect(VariableList.isVariableList({})).to.not.be.ok();
+            expect(VariableList.isVariableList()).to.not.be.ok();
         });
 
         it('should work correctly for listify', function () {

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -362,4 +362,28 @@ describe('VariableScope', function () {
             });
         });
     });
+
+    describe('isVariableScope', function () {
+        var rawVariableScope = {
+            values: [{
+                key: 'var-1',
+                value: 'var-1-value'
+            }, {
+                key: 'var-2',
+                value: 'var-2-value'
+            }]
+        };
+
+        it('should return true for a VariableScope instance', function () {
+            expect(VariableScope.isVariableScope(new VariableScope(rawVariableScope))).to.be(true);
+        });
+
+        it('should return false for a raw VariableScope object', function () {
+            expect(VariableScope.isVariableScope(rawVariableScope)).to.be(false);
+        });
+
+        it('should return false when called without arguments', function () {
+            expect(VariableScope.isVariableScope()).to.be(false);
+        });
+    });
 });

--- a/test/unit/variable.test.js
+++ b/test/unit/variable.test.js
@@ -62,4 +62,18 @@ describe('Variable', function () {
         v.valueType('number');
         expect(v.get()).to.be(3.142);
     });
+
+    describe('isVariable', function () {
+        it('should return true for a valid Variable instance', function () {
+            expect(Variable.isVariable(new Variable({ type: 'string', key: 'foo', value: 'bar' }))).to.be(true);
+        });
+
+        it('should return false for a raw variable object', function () {
+            expect(Variable.isVariable({ type: 'string', key: 'foo', value: 'bar' })).to.be(false);
+        });
+
+        it('should return false when called without arguments', function () {
+            expect(Variable.isVariable()).to.be(false);
+        });
+    });
 });


### PR DESCRIPTION
All static helpers of the form `XYZ.isXYZ` will now return strict `Boolean` values, even for falsey input.