### PR TITLE
variable scope improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Postman Collection SDK Changelog
 
 #### Unreleased
+* Added support for variable types via VariableScope `.set` function
+* Added `VariableScope~variables` to access all variables as a plain object
 * Ensure that `Xyz.isXyz()` functions always return a boolean
 * Fixed a bug which caused `Request` to not initialize headers
 

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -44,6 +44,45 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      */
     _postman_requiresId: true,
 
+    /**
+     * Get a copy of all variables in form of a plain object. This is useful for iteration and other use.
+     * @returns {Object}
+     *
+     * @example <caption>Iterate on all variables</caption>
+     * var env = new VariableScope([{
+     *         key: 'var1',
+     *         value: 'one'
+     *     }, {
+     *         key: 'var2',
+     *         value: 2,
+     *         type: 'number'
+     *     }, {
+     *         key: 'var3',
+     *         value: true,
+     *         type: 'boolean'
+     *     }]),
+     *     obj;
+     *
+     * // get all variables consolidated as an object
+     * obj = env.variables();
+     *
+     * Object.keys(obj).forEach(function(varname) {
+     *     console.log(obj[varname]); // log all variables
+     * });
+     */
+    variables: function () {
+        return this.values.syncToObject({});
+    },
+
+    /**
+     * Determines whether one particular variable is defined in this scope of variables.
+     *
+     * @param {String} variableName
+     * @returns {Boolean}
+     */
+    has: function (variableName) {
+        return this.values.has(variableName);
+    },
 
     /**
      * Fetches a variable from the current scope.
@@ -87,6 +126,7 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
 
     /**
      * Using this function, one can sync the values of this variable list from a reference object.
+     * @private
      *
      * @param {Object} obj
      * @param {Boolean=} [track]
@@ -99,6 +139,7 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
 
     /**
      * Transfer the variables in this scope to an object
+     * @private
      *
      * @param {Object=} [obj]
      *

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -88,7 +88,7 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      * Fetches a variable from the current scope.
      *
      * @param {String} key - The name of the variable to set.
-     * @returns {String|*} The value of the specified variable in the current context.
+     * @returns {*} The value of the specified variable in the current context.
      */
     get: function (key) {
         var variable = this.values.one(key);
@@ -99,15 +99,23 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      * Creates a new variable, or updates an existing one.
      *
      * @param {String} key - The name of the variable to set.
-     * @param {String} value - The value of the variable to be set.
+     * @param {*} value - The value of the variable to be set.
+     * @param {Variable.types} [type] - Optionally, the value of the variable can be set to a type
      */
-    set: function (key, value) {
-        var variable = this.values.one(key);
+    set: function (key, value, type) {
+        var variable = this.values.one(key),
+
+            update = { // create an object that will be used as setter
+                key: key,
+                value: value
+            };
+
+        _.isString(type) && (update.type = type);
 
         // If a variable by the name key exists, update it's value and return.
-        if (variable) { return variable.set(value); }
+        if (variable) { return variable.update(update); }
 
-        this.values.add({ key: key, value: value });
+        this.values.add(update);
     },
 
     /**

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -309,6 +309,16 @@ describe('VariableScope', function () {
                 expect(scope.values.count()).to.be(3);
                 expect(scope.get('var-3')).to.be('var-3-value');
             });
+
+            it('must correctly update type of existing value', function () {
+                scope.set('var-1', 3.142, 'number');
+                expect(scope.get('var-1')).to.be(3.142);
+            });
+
+            it('must correctly create a new typed value', function () {
+                scope.set('var-4', 3.142, 'boolean');
+                expect(scope.get('var-4')).to.be(true);
+            });
         });
 
         describe('unset', function () {

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -386,4 +386,30 @@ describe('VariableScope', function () {
             expect(VariableScope.isVariableScope()).to.be(false);
         });
     });
+
+    describe('.variables()', function () {
+        var scope = new VariableScope({
+            values: [{
+                key: 'var1',
+                value: 'one'
+            }, {
+                key: 'var2',
+                value: 2,
+                type: 'number'
+            }, {
+                key: 'var3',
+                value: true,
+                type: 'boolean'
+            }]
+        });
+
+        it('must return a copy of all variables in an object form', function () {
+            expect(scope.variables()).be.an('object');
+            expect(scope.variables()).be.eql({
+                var1: 'one',
+                var2: 2,
+                var3: true
+            });
+        });
+    });
 });


### PR DESCRIPTION
- .set now supports type
- added .variables() as an alias of .syncVariablesTo
- improved documentation