### PR TITLE
addition of header list property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Added `VariableScope~variables` to access all variables as a plain object
 * Ensure that `Xyz.isXyz()` functions always return a boolean
 * Fixed a bug which caused `Request` to not initialize headers
+* Added generic `.toObject` and `.toString` method to PropertyList to work for Types that has a .valueOf and `.unparse` defined.
+* Added HeaderList and **discontinued** `Header.headerValue` in favour of `HeaderList.get`
 
 #### 1.1.0 (April 03, 2017)
 * Enhanced the `PropertyList` to allow keys with multiple values

--- a/lib/collection/header-list.js
+++ b/lib/collection/header-list.js
@@ -1,0 +1,55 @@
+var _ = require('../util').lodash,
+    PropertyList = require('./property-list').PropertyList,
+    Header = require('./header').Header,
+
+    HeaderList;
+
+_.inherit((
+
+  /**
+   * @constructor
+   * @extends {PropertyList}
+   */
+  HeaderList = function (parent, headers) {
+      // this constructor is intended to inherit and as such the super constructor is required to be executed
+      HeaderList.super_.call(this, Header, parent, headers);
+  }), PropertyList);
+
+_.assign(HeaderList.prototype, /** @lends HeaderList.prototype */ {
+    /**
+     * Gets size of a list of headers excluding standard header prefix.
+     *
+     * @returns {Number}
+     */
+    contentSize: function () {
+        var raw = '';
+        raw += Header.unparse(this, '\r\n');
+        raw += '\r\n\r\n';
+        return raw.length;
+    }
+});
+
+_.assign(HeaderList, /** @lends HeaderList */ {
+    /**
+     * Defines the name of this property for internal use.
+     * @private
+     * @readOnly
+     * @type {String}
+     */
+    _postman_propertyName: 'HeaderList',
+
+    /**
+     * Checks if the given object is a HeaderList
+     *
+     * @param {*} obj
+     * @returns {Boolean}
+     */
+    isHeaderList: function (obj) {
+        return Boolean(obj) && ((obj instanceof HeaderList) ||
+          _.inSuperChain(obj.constructor, '_postman_propertyName', HeaderList._postman_propertyName));
+    }
+});
+
+module.exports = {
+    HeaderList: HeaderList
+};

--- a/lib/collection/header-list.js
+++ b/lib/collection/header-list.js
@@ -7,6 +7,8 @@ var _ = require('../util').lodash,
 _.inherit((
 
   /**
+   * Contains a list of header elements
+   *
    * @constructor
    * @extends {PropertyList}
    */

--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -236,23 +236,6 @@ _.assign(Header, /** @lends Header */ {
         var args = Array.prototype.slice.call(arguments);
         args.unshift(Header);
         return new (Header.bind.apply(Header, args))(); // eslint-disable-line prefer-spread
-    },
-
-    /**
-     * Gets value from an Array or {@link PropertyList} of Headers by filtering through key.
-     *
-     * @param {Array|PropertyList<Header>} headers
-     * @param {string} key
-     * @returns {string}
-     */
-    headerValue: function (headers, key) {
-        if (!_.isArray(headers) && !PropertyList.isPropertyList(headers)) {
-            return undefined;
-        }
-        var header = headers.find(function (header) {
-            return header.key === key;
-        });
-        return header ? header.value : undefined;
     }
 });
 

--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -124,6 +124,14 @@ _.assign(Header, /** @lends Header */ {
     _postman_propertyIndexCaseInsensitive: true,
 
     /**
+     * Return the value of this header
+     * @return {String}
+     */
+    valueOf: function () {
+        return this.value;
+    },
+
+    /**
      * Parses a multi line header string into an array of {@link Header~definition}.
      *
      * @param headerString

--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -70,6 +70,14 @@ _.assign(Header.prototype, /** @lends Header.prototype */ {
     },
 
     /**
+     * Return the value of this header
+     * @return {String}
+     */
+    valueOf: function () {
+        return this.value;
+    },
+
+    /**
      * Assigns the given properties to the Header
      *
      * @param options
@@ -127,14 +135,6 @@ _.assign(Header, /** @lends Header */ {
      * @type {boolean}
      */
     _postman_propertyIndexCaseInsensitive: true,
-
-    /**
-     * Return the value of this header
-     * @return {String}
-     */
-    valueOf: function () {
-        return this.value;
-    },
 
     /**
      * Parses a multi line header string into an array of {@link Header~definition}.
@@ -253,24 +253,6 @@ _.assign(Header, /** @lends Header */ {
             return header.key === key;
         });
         return header ? header.value : undefined;
-    },
-
-    /**
-     * Gets size of an Array or {@link PropertyList} of Headers.
-     *
-     * @param {Array|PropertyList<Header>} headers
-     * @returns {Number}
-     */
-    size: function (headers, statusCode, reason) {
-        if (!_.isArray(headers) && !PropertyList.isPropertyList(headers)) {
-            return 0;
-        }
-        // https://tools.ietf.org/html/rfc7230#section-3.1.2
-        // status-line = HTTP-version SP status-code SP reason-phrase CRLF
-        var raw = 'HTTP/X.X ' + statusCode + ' ' + reason + '\r\n';
-        raw += this.unparse(headers, '\r\n');
-        raw += '\r\n\r\n';
-        return raw.length;
     }
 });
 

--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -1,5 +1,10 @@
 var util = require('../util'),
     _ = util.lodash,
+
+    E = '',
+    SPC = ' ',
+    HEADER_KV_SEPARATOR = ':',
+
     PropertyBase = require('./property-base').PropertyBase,
     PropertyList = require('./property-list').PropertyList,
     Header;
@@ -74,13 +79,13 @@ _.assign(Header.prototype, /** @lends Header.prototype */ {
          * The header Key
          * @type {String}
          */
-        this.key = _.get(options, 'key') || '';
+        this.key = _.get(options, 'key') || E;
 
         /**
          * The header value
          * @type {String}
          */
-        this.value = _.get(options, 'value') || '';
+        this.value = _.get(options, 'value') || E;
 
         /**
          * Indicates whether the header was added by internal SDK operations, such as authorizing a request.
@@ -163,9 +168,9 @@ _.assign(Header, /** @lends Header */ {
      * @returns {{key: string, value: string}}
      */
     parseSingle: function (header) {
-        if (!_.isString(header)) { return { key: '', value: '' }; }
+        if (!_.isString(header)) { return { key: E, value: E }; }
 
-        var index = header.indexOf(':'),
+        var index = header.indexOf(HEADER_KV_SEPARATOR),
             key,
             value;
 
@@ -190,12 +195,20 @@ _.assign(Header, /** @lends Header */ {
      */
     unparse: function (headers, separator) {
         if (!_.isArray(headers) && !PropertyList.isPropertyList(headers)) {
-            return '';
+            return E;
         }
 
-        return headers.map(function (header) {
-            return header.key + ': ' + header.value;
-        }).join(separator ? separator : '\n');
+        return headers.map(Header.unparseSingle).join(separator ? separator : '\n');
+    },
+
+    /**
+     * Unparses a single Header.
+     * @param {String} header
+     * @returns {String}
+     */
+    unparseSingle: function (header) {
+        if (!_.isObject(header)) { return E; }
+        return header.key + HEADER_KV_SEPARATOR + SPC + header.value;
     },
 
     /**

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -5,6 +5,11 @@ var _ = require('../util').lodash,
     DEFAULT_INDEX_ATTR = 'id',
     DEFAULT_INDEXCASE_ATTR = false,
 
+    // utility function to be used in iterators to get value of the argument
+    returnValueOf = function (value) {
+        return _.isArray(value) ? _.last(value).valueOf() : value.valueOf();
+    },
+
     PropertyList;
 
 _.inherit((
@@ -377,6 +382,27 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
             prev = parent;
             parent = parent.__parent;
         }
+    },
+
+    /**
+     * Converts a list of Properties into an object where key is `_postman_propertyIndexKey` and value is determined
+     * by the `valueOf` function
+     *
+     * @return {Object}
+     */
+    toObject: function (caseSensitive) {
+        if (!caseSensitive) {
+            return _.mapValues(this.reference, returnValueOf);
+        }
+
+        var obj = {},
+            key = this._postman_listIndexKey;
+
+        this.each(function (member) {
+            member.hasOwnProperty(key) && (obj[member[key]] = member.valueOf());
+        });
+
+        return obj;
     },
 
     toJSON: function () {

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -279,6 +279,20 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
     },
 
     /**
+     * Get the value of an item in this list. This is similar to {@link PropertyList.one} barring the fact that it
+     * returns the value of the underlying type of the list content instead of the item itself.
+     *
+     * @param {String|Function} key
+     * @returns {PropertyList.Type}
+     */
+    get: function (key) {
+        var member = this.one(key);
+        if (!member) { return; }
+
+        return member.valueOf();
+    },
+
+    /**
      * Iterate on each item of this list
      */
     each: function (iterator, context) {

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -5,11 +5,6 @@ var _ = require('../util').lodash,
     DEFAULT_INDEX_ATTR = 'id',
     DEFAULT_INDEXCASE_ATTR = false,
 
-    // utility function to be used in iterators to get value of the argument
-    returnValueOf = function (value) {
-        return _.isArray(value) ? _.last(value).valueOf() : value.valueOf();
-    },
-
     PropertyList;
 
 _.inherit((
@@ -390,17 +385,28 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
      *
      * @return {Object}
      */
-    toObject: function (caseSensitive) {
-        if (!caseSensitive) {
-            return _.mapValues(this.reference, returnValueOf);
-        }
-
+    toObject: function (excludeDisabled, caseSensitive) {
         var obj = {},
             key = this._postman_listIndexKey;
 
-        this.each(function (member) {
-            member.hasOwnProperty(key) && (obj[member[key]] = member.valueOf());
-        });
+        if (caseSensitive) {
+            this.each(function (member) {
+                if (!member.hasOwnProperty(key)) { return; }
+                if (excludeDisabled && member.disabled) { return; }
+
+                obj[member[key]] = member.valueOf();
+            });
+        }
+        else {
+            _.forOwn(this.reference, function (member, prop) {
+                _.isArray(member) && (member = _.last(member));
+                if (excludeDisabled && member.disabled) { // do no process disabled objects
+                    return;
+                }
+
+                obj[prop] = member.valueOf();
+            });
+        }
 
         return obj;
     },

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -405,6 +405,18 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
         return obj;
     },
 
+    /**
+     * Adds ability to convert a list to a string provided it's underlying format has unparse function defined
+     * @return {String}
+     */
+    toString: function () {
+        if (this.Type.unparse) {
+            return this.Type.unparse(this.members);
+        }
+
+        return this.constructor ? this.constructor.prototype.toString.call(this) : '';
+    },
+
     toJSON: function () {
         if (!this.count()) {
             return [];

--- a/lib/collection/request.js
+++ b/lib/collection/request.js
@@ -1,10 +1,9 @@
 var _ = require('../util').lodash,
     Property = require('./property').Property,
-    PropertyList = require('./property-list').PropertyList,
     Url = require('./url').Url,
     ProxyConfig = require('./proxy-config').ProxyConfig,
     Certificate = require('./certificate').Certificate,
-    Header = require('./header').Header,
+    HeaderList = require('./header-list').HeaderList,
     RequestBody = require('./request-body').RequestBody,
     RequestAuth = require('./request-auth').RequestAuth,
 
@@ -46,9 +45,9 @@ _.inherit((
             url: new Url(),
 
             /**
-             * @type {PropertyList<Header>}
+             * @type {HeaderList}
              */
-            headers: new PropertyList(Header, this, options && options.header),
+            headers: new HeaderList(this, options && options.header),
 
             /**
              * @type {String}
@@ -116,15 +115,8 @@ _.assign(Request.prototype, /** @lends Request.prototype */ {
      * the value of the header which occurs the last.
      */
     getHeaders: function getHeaders (options) {
-        var headers = {},
-            self = this;
-
-        options = options || {};
-        _.forEach(self.headers.all(), function (header) {
-            if (options.enabled && header.disabled) { return; }
-            headers[options.ignoreCase ? header.key.toLowerCase() : header.key] = header.value;
-        });
-        return headers;
+        !options && (options = {});
+        return this.headers.toObject(options.enabled, !options.ignoreCase);
     },
 
     /**

--- a/lib/collection/response.js
+++ b/lib/collection/response.js
@@ -349,8 +349,8 @@ _.assign(Response.prototype, /** @lends Response.prototype */ {
      */
     size: function () {
         var sizeInfo = {},
-            contentEncoding = Header.headerValue(this.headers, CONTENT_ENCODING),
-            contentLength = Header.headerValue(this.headers, CONTENT_LENGTH);
+            contentEncoding = this.headers.get(CONTENT_ENCODING),
+            contentLength = this.headers.get(CONTENT_LENGTH);
 
         // if 'Content-Length' header is present and encoding is of type gzip/deflate
         if (contentLength && (/^(gzip|deflate)$/).test(contentEncoding) && util.isNumeric(contentLength)) {
@@ -374,7 +374,7 @@ _.assign(Response.prototype, /** @lends Response.prototype */ {
      * @returns {Object} - {format: string, source: string}
      */
     encoding: function () {
-        var contentEncoding = Header.headerValue(this.headers, CONTENT_ENCODING),
+        var contentEncoding = this.headers.get(CONTENT_ENCODING),
             body = this.stream || this.body,
             source;
 

--- a/lib/collection/response.js
+++ b/lib/collection/response.js
@@ -10,6 +10,7 @@ var util = require('../util'),
     Header = require('./header').Header,
     Cookie = require('./cookie').Cookie,
     PropertyList = require('./property-list').PropertyList,
+    HeaderList = require('./header-list').HeaderList,
 
     /**
      * @private
@@ -162,9 +163,9 @@ _.assign(Response.prototype, /** @lends Response.prototype */ {
             code: options.code,
 
             /**
-             * @type {PropertyList<Header>}
+             * @type {HeaderList}
              */
-            headers: new PropertyList(Header, this, options.header),
+            headers: new HeaderList(this, options.header),
 
             /**
              * @type {String}
@@ -361,7 +362,9 @@ _.assign(Response.prototype, /** @lends Response.prototype */ {
         }
 
         // size of header is added
-        sizeInfo.header = Header.size(this.headers, this.code, this.reason());
+        // https://tools.ietf.org/html/rfc7230#section-3.1.2
+        // status-line = HTTP-version SP status-code SP reason-phrase CRLF
+        sizeInfo.header = ('HTTP/X.X ' + this.code + ' ' + this.reason() + '\r\n').length + this.headers.contentSize();
         return sizeInfo;
     },
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,6 +9,7 @@ module.exports = {
     EventList: require('./collection/event-list').EventList,
     FormParam: require('./collection/form-param').FormParam,
     Header: require('./collection/header').Header,
+    HeaderList: require('./collection/header-list').HeaderList,
     Item: require('./collection/item').Item,
     ItemGroup: require('./collection/item-group').ItemGroup,
     PropertyList: require('./collection/property-list').PropertyList,

--- a/lib/schema/header-list.json
+++ b/lib/schema/header-list.json
@@ -1,0 +1,9 @@
+{
+    "id": "#/definitions/header-list",
+    "title": "Header List",
+    "description": "A representation for a list of headers",
+    "type": "array",
+    "items": {
+        "$ref": "#/definitions/header"
+    }
+}

--- a/test/unit/header-list.test.js
+++ b/test/unit/header-list.test.js
@@ -1,0 +1,26 @@
+var expect = require('expect.js'),
+    sdk = require('../../lib/index.js'),
+
+    HeaderList = sdk.HeaderList;
+
+describe('HeaderList', function () {
+
+    it('should be a working constructor', function () {
+        expect(new HeaderList()).be.a(HeaderList);
+    });
+
+    it('should be able to initialise with header as string', function () {
+        var hl = new HeaderList(null, 'Accept: *\nContent-Type: text/html');
+        expect(hl.count()).eql(2);
+    });
+
+    it('should be able to export headers to string', function () {
+        var hl = new HeaderList(null, 'Accept: *\nContent-Type: text/html');
+        expect(hl.toString()).eql('Accept: *\nContent-Type: text/html');
+    });
+
+    it('should be able to return header size', function () {
+        var hl = new HeaderList(null, 'Accept: *\nContent-Type: text/html');
+        expect(hl.contentSize(200, 'OK')).eql(38);
+    });
+});

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -571,4 +571,34 @@ describe('PropertyList', function () {
             });
         });
     });
+
+    describe('.get', function () {
+        var FakeType = function (options) {
+            this.keyAttr = options.keyAttr;
+            this.value = options.value;
+            this.disabled = options.disabled;
+        };
+
+        FakeType._postman_propertyIndexKey = 'keyAttr';
+        FakeType._postman_propertyIndexCaseInsensitive = true;
+        FakeType._postman_propertyAllowsMultipleValues = false;
+        FakeType.prototype.valueOf = function () {
+            return this.value;
+        };
+
+        it('should return a pojo', function () {
+            var list = new PropertyList(FakeType, {}, [{
+                keyAttr: 'key1',
+                value: 'val1'
+            }, {
+                keyAttr: 'key1',
+                value: 'val2'
+            }, {
+                keyAttr: 'key2',
+                value: 'val3'
+            }]);
+
+            expect(list.get('key1')).to.eql('val2');
+        });
+    });
 });

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -499,4 +499,55 @@ describe('PropertyList', function () {
             expect(PropertyList.isPropertyList()).to.be(false);
         });
     });
+
+    describe('toObject', function () {
+        var FakeType = function (options) {
+                this.keyAttr = options.keyAttr;
+                this.value = options.value;
+            };
+
+        FakeType._postman_propertyIndexKey = 'keyAttr';
+        FakeType._postman_propertyIndexCaseInsensitive = true;
+        FakeType._postman_propertyAllowsMultipleValues = true;
+        FakeType.prototype.valueOf = function () {
+            return this.value;
+        };
+
+        it('should return a pojo', function () {
+            var list = new PropertyList(FakeType, {}, [{
+                keyAttr: 'key1',
+                value: 'val1'
+            }, {
+                keyAttr: 'key1',
+                value: 'val2'
+            }, {
+                keyAttr: 'key2',
+                value: 'val3'
+            }]);
+
+            expect(list.toObject()).to.eql({
+                key1: 'val2',
+                key2: 'val3'
+            });
+        });
+
+        it('should be able to override case sensitivity return a pojo', function () {
+            var list = new PropertyList(FakeType, {}, [{
+                keyAttr: 'key1',
+                value: 'val1'
+            }, {
+                keyAttr: 'KEY1',
+                value: 'val2'
+            }, {
+                keyAttr: 'key2',
+                value: 'val3'
+            }]);
+
+            expect(list.toObject(true)).to.eql({
+                key1: 'val1',
+                KEY1: 'val2',
+                key2: 'val3'
+            });
+        });
+    });
 });

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -502,9 +502,10 @@ describe('PropertyList', function () {
 
     describe('toObject', function () {
         var FakeType = function (options) {
-                this.keyAttr = options.keyAttr;
-                this.value = options.value;
-            };
+            this.keyAttr = options.keyAttr;
+            this.value = options.value;
+            this.disabled = options.disabled;
+        };
 
         FakeType._postman_propertyIndexKey = 'keyAttr';
         FakeType._postman_propertyIndexCaseInsensitive = true;
@@ -537,16 +538,36 @@ describe('PropertyList', function () {
                 value: 'val1'
             }, {
                 keyAttr: 'KEY1',
-                value: 'val2'
+                value: 'val2',
+                disabled: true
             }, {
                 keyAttr: 'key2',
                 value: 'val3'
             }]);
 
-            expect(list.toObject(true)).to.eql({
+            expect(list.toObject(null, true)).to.eql({
                 key1: 'val1',
                 KEY1: 'val2',
                 key2: 'val3'
+            });
+        });
+
+        it('should be able to exclude disabled items return a pojo', function () {
+            var list = new PropertyList(FakeType, {}, [{
+                keyAttr: 'key1',
+                value: 'val1'
+            }, {
+                keyAttr: 'key2',
+                value: 'val2',
+                disabled: true
+            }, {
+                keyAttr: 'key3',
+                value: 'val3'
+            }]);
+
+            expect(list.toObject(true)).to.eql({
+                key1: 'val1',
+                key3: 'val3'
             });
         });
     });

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -8,7 +8,8 @@ var fs = require('fs'),
     fixtures = require('../fixtures'),
     Cookie = require('../../lib/index.js').Cookie,
     Response = require('../../lib/index.js').Response,
-    Header = require('../../lib/index.js').Header;
+    Header = require('../../lib/index.js').Header,
+    HeaderList = require('../../lib/index.js').HeaderList;
 
 /* global describe, it */
 describe('Response', function () {
@@ -344,10 +345,11 @@ describe('Response', function () {
                 }
 
                 var response = Response.createFromNode(res),
-                    body = response.toJSON();
+                    body = response.toJSON(),
+                    headers = new HeaderList(null, body.header);
 
-                expect(Header.headerValue(body.header, 'bar')).to.be('foo');
-                expect(Header.headerValue(body.header, 'foo')).to.be('bar, bar2');
+                expect(headers.get('bar')).to.be('foo');
+                expect(headers.get('foo')).to.be('bar, bar2');
 
                 validateResponse(response);
                 done();
@@ -452,13 +454,14 @@ describe('Response', function () {
                     var response = Response.createFromNode(res),
                         json = response.toJSON(),
                         body = JSON.parse(json.body),
-                        mime = response.mime();
+                        mime = response.mime(),
+                        headers = new HeaderList(null, json.header);
 
                     expect(mime._originalContentType).to.be('application/json');
                     expect(mime._sanitisedContentType).to.be('application/json');
 
                     expect(body.gzipped).to.be(true);
-                    expect(Header.headerValue(json.header, 'content-encoding')).to.be('gzip');
+                    expect(headers.get('content-encoding')).to.be('gzip');
 
                     checkMime(mime);
                     validateResponse(response);
@@ -502,7 +505,7 @@ describe('Response', function () {
                     expect(mime._originalContentType).to.be('text/html; charset=utf-8');
                     expect(mime._sanitisedContentType).to.be('text/html');
 
-                    expect(Header.headerValue(json.header, 'content-type')).to.match(/^text\/html/);
+                    expect((new HeaderList(null, json.header)).get('content-type')).to.match(/^text\/html/);
                     expect(json.body).to.match(/<html>.*/);
 
                     checkMime(mime);


### PR DESCRIPTION
The goal was to have dedicated header list object so that we can **begin** to remove header specific helpers from response/request and make them common across both.

- Changes are done to PropertyList that was found to be generic and easy to work with on all lists while making HeaderList.
- Added concepts of valueOf in Properties and made lists aware of it so that getters can be easily written.
- Changes were made in places where they depended on Header.XYZ static functions
- Fixed the behaviour of computing header size by adhering to proper segregation of concerns.
- Header.headerValue is doscontinued in favour of HeaderList.get and Header (instance) .valueOf