### PR TITLE
Add convenience method to variable scope to convert variable list to obj

### DIFF
--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -562,5 +562,18 @@ describe('VariableScope', function () {
                 'key3': 'val3'
             });
         });
+
+        it('uses the last found key-val pair should a duplicate key exists', function () {
+            var scope = new VariableScope(keyVals.concat({
+                key: 'key3',
+                value: 'duplicate-val3'
+            }));
+
+            expect(scope.toObject()).to.eql({
+                'key1': 'val1',
+                'key2': 'val2',
+                'key3': 'duplicate-val3'
+            });
+        });
     });
 });

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -540,4 +540,27 @@ describe('VariableScope', function () {
             expect(scope.toJSON()._layers).to.be(undefined);
         });
     });
+
+    describe('.toObject()', function () {
+        var keyVals = [{
+            key: 'key1',
+            value: 'val1'
+        }, {
+            key: 'key2',
+            value: 'val2'
+        }, {
+            key: 'key3',
+            value: 'val3'
+        }];
+
+        it('should return a pojo', function () {
+            var scope = new VariableScope(keyVals);
+
+            expect(scope.toObject()).to.eql({
+                'key1': 'val1',
+                'key2': 'val2',
+                'key3': 'val3'
+            });
+        });
+    });
 });


### PR DESCRIPTION
Add `variableScope.toObject` as a proxy to `propertyList.toObject`.  This is done to accommodate the new `pmapi`.

Why ?
The new pmapi exposes pm.variables as an instance of VariableScope. Having `pm.variables.variables` is redundant and does not make a good API. `VariableScope.variables` is deprecated as of version `1.2.5.*`