### PR TITLE
Bumped recursive-readdir to v2.2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "parse-gitignore": "0.4.0",
     "postman-jsdoc-theme": "0.0.2",
     "postman-request": "2.80.1-postman.1",
-    "recursive-readdir": "2.2.0",
+    "recursive-readdir": "2.2.1",
     "require-all": "2.2.0",
     "schema-compiler": "0.0.3",
     "shelljs": "0.7.7",


### PR DESCRIPTION
`v2.2.0` was pulled from npmjs.org