### PR TITLE
Path variable identifier expansion

### DIFF
--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -95,7 +95,7 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
         // backward compatibility with path variables being storing thins with `id`
         if (_.isArray(variable)) {
             variable = _.map(variable, function (v) {
-                _.isObject(v) && (v.key = v.id); // @note this will be removed once path variables are deprecated
+                _.isObject(v) && (v.key = v.key || v.id); // @todo this will be removed once path variables are deprecated
                 return v;
             });
         }

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -411,6 +411,25 @@ describe('Url', function () {
 
             expect(url.getPath()).to.eql('/get/:beta/:gamma/:delta/:epsilon/:phi');
         });
+
+        it('should work correctly without the id field as well', function () {
+            var url = new Url({
+                protocol: 'https',
+                host: 'postman-echo.com',
+                port: '443',
+                path: '/:alpha/:beta/:gamma/:delta/:epsilon/:phi',
+                variable: [
+                    { key: 'alpha', value: 'get' },
+                    { key: 'beta', value: null },
+                    { key: 'gamma', value: NaN },
+                    { key: 'gamma', value: undefined },
+                    { key: 'epsilon', value: [] },
+                    { key: 'phi', value: {} }
+                ]
+            });
+
+            expect(url.getPath()).to.eql('/get/:beta/:gamma/:delta/:epsilon/:phi');
+        });
     });
 
     describe('URL Encoding', function () {


### PR DESCRIPTION
With this change, path variables can be referenced correctly even if the `id` key is missing from the object definition.