### PR TITLE
update proxyConfig structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Postman Collection SDK Changelog
 
+## Unreleased
+* Updated the ProxyConfig & UrlMatchPattern to support multiple protocols
+
 #### v1.2.8 (May 31, 2017)
 * Fixed a bug where converting `QueryParam` and `FormParam` lists to objects was not working
 

--- a/lib/collection/proxy-config-list.js
+++ b/lib/collection/proxy-config-list.js
@@ -16,7 +16,7 @@ _.inherit((
      * @example <caption>Create a new ProxyConfigList</caption>
      * var ProxyConfigList = require('postman-collection').ProxyConfigList,
      *     myProxyConfig = new ProxyConfigList({}, [
-     *              {match: 'example.com/*',host: 'proxy.com', port: 8080, protocols: ['https], tunnel: true},
+     *              {match: 'example.com/*',host: 'proxy.com', port: 8080, protocols: ['https'], tunnel: true},
      *              {match: 'example2.com/*',host: 'proxy2.com'},
      *          ]);
      */

--- a/lib/collection/proxy-config-list.js
+++ b/lib/collection/proxy-config-list.js
@@ -16,8 +16,8 @@ _.inherit((
      * @example <caption>Create a new ProxyConfigList</caption>
      * var ProxyConfigList = require('postman-collection').ProxyConfigList,
      *     myProxyConfig = new ProxyConfigList({}, [
-     *              {match: 'example.com/*',host: 'proxy.com', port: 8080, protocols: ['https'], tunnel: true},
-     *              {match: 'example2.com/*',host: 'proxy2.com'},
+     *              {match: 'example.com/*', host: 'proxy.com', port: 8080, protocols: ['https'], tunnel: true},
+     *              {match: 'example2.com/*', host: 'proxy2.com'},
      *          ]);
      */
     ProxyConfigList = function PostmanProxyConfigList (parent, populate) {

--- a/lib/collection/proxy-config-list.js
+++ b/lib/collection/proxy-config-list.js
@@ -16,8 +16,8 @@ _.inherit((
      * @example <caption>Create a new ProxyConfigList</caption>
      * var ProxyConfigList = require('postman-collection').ProxyConfigList,
      *     myProxyConfig = new ProxyConfigList({}, [
-     *              {match: 'https://example.com/*',server: 'https://proxy.com',tunnel: true},
-     *              {match: 'https://example2.com/*',server: 'http://proxy2.com'},
+     *              {match: 'example.com/*',host: 'proxy.com', port: 8080, protocols: ['https], tunnel: true},
+     *              {match: 'example2.com/*',host: 'proxy2.com'},
      *          ]);
      */
     ProxyConfigList = function PostmanProxyConfigList (parent, populate) {
@@ -30,7 +30,7 @@ _.assign(ProxyConfigList.prototype, /** @lends ProxyConfigList.prototype */ {
     /**
      * Matches and gets the proxy config for the particular url
      * @returns {ProxyConfig~definition=} The matched proxyConfig object
-     * @param {String=} [url] The url for which the proxy config needs to be fetched
+     * @param {URL=} [url] The url for which the proxy config needs to be fetched
      */
     resolve: function(url) {
         // url must be either string or an instance of url.

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -63,7 +63,7 @@ _.inherit((
         ProxyConfig.super_.call(this, options);
 
         // Assign defaults before proceeding
-        _.assign(this, /** @lends ProxyConfig.prototype */ {
+        _.assign(this, /** @lends ProxyConfig */ {
             /**
              * The url mach for which the proxy has been associated with.
              * @type {String}

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -1,7 +1,7 @@
 var _ = require('../util').lodash,
     Property = require('./property').Property,
     UrlMatchPattern = require('../url-pattern/url-match-pattern').UrlMatchPattern,
-    MATCH_ALL_URLS = '<all_urls>',
+    MATCH_ALL_URLS = UrlMatchPattern.MATCH_ALL_URLS,
     DEFAULT_PROTOCOLS = ['http'],
     regexes = {
         protocolMatcher: /.*:\/\//

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -161,14 +161,6 @@ _.assign(ProxyConfig, /** @lends ProxyConfig */ {
     _postman_propertyName: 'ProxyConfig',
 
     /**
-     * Specify the key to be used while indexing this object
-     * @private
-     * @readOnly
-     * @type {String}
-     */
-    _postman_propertyIndexKey: 'match',
-
-    /**
      * Check whether an object is an instance of PostmanItem.
      *
      * @param {*} obj

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -1,8 +1,11 @@
 var _ = require('../util').lodash,
     Property = require('./property').Property,
-    Url = require('./url').Url,
     UrlMatchPattern = require('../url-pattern/url-match-pattern').UrlMatchPattern,
-
+    MATCH_ALL_URLS = '<all_urls>',
+    DEFAULT_PROTOCOLS = ['http'],
+    regexes = {
+        protocolMatcher: /.*:\/\//
+    },
     ProxyConfig;
 
 
@@ -12,15 +15,19 @@ var _ = require('../util').lodash,
 * Proxy instance.
 * @typedef ProxyConfig~definition
 *
-* @property {String=} [url = *] The match for which the proxy needs to be configured. `*` represents select all.
-* @property {Url=} [server = new Url()] The proxy server url.
+* @property {String=} [match = '<all_url>'] The match for which the proxy needs to be configured.
+* @property {String=} [host = ''] The proxy server url.
+* @property {Integer=} [port = 8080] The proxy server port number.
+* @property {Array=} [protocols = ['http']] The protocols that the proxy server supports
 * @property {Boolean=} [tunnel = false] The tunneling option for the proxy request.
 * @property {Boolean=} [disabled = false] To override the proxy for the particiular url, you need to provide true.
 *
 * @example <caption>JSON definition of an example proxy object</caption>
 * {
-*     match: 'https://example.com/*',
-*     server: 'https://proxy.com',
+*     match: 'example.com/*',
+*     host: 'proxy.com',
+*     port: 8080
+*     protocols: ['https']
 *     tunnel: true,
 *     disabled: false
 * }
@@ -40,8 +47,10 @@ _.inherit((
      * @example <caption>Create a new ProxyConfig</caption>
      * var ProxyConfig = require('postman-collection').ProxyConfig,
      *     myProxyConfig = new ProxyConfig({
-     *          match: 'https://example*',
-     *          server: 'https://proxy.com',
+     *          match: 'example.com/*',
+     *          host: 'proxy.com',
+     *          port: 8080
+     *          protocols: ['https']
      *          tunnel: true,
      *          disabled: false
      *     });
@@ -60,10 +69,22 @@ _.inherit((
             match: new UrlMatchPattern(),
 
             /**
-             * The server url or the proxy url.
-             * @type {Url}
+             * The proxy server host or ip
+             * @type {String}
              */
-            server: new Url(),
+            host: '',
+
+            /**
+             * The proxy server port number
+             * @type {Integer}
+             */
+            port: 8080,
+
+            /**
+             * The protocol(s) that the proxy server supports
+             * @type {Array}
+             */
+            protocols: DEFAULT_PROTOCOLS,
 
             /**
              * This represents whether the tunneling needs to done while proxying this request.
@@ -85,9 +106,22 @@ _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
         if (!_.isObject(options)) {
             return;
         }
-        _.has(options, 'server') && this.server.update(options.server);
-        _.isString(options.match) && (this.match = new UrlMatchPattern(options.match));
-        _.has(options, 'server') && (this.tunnel = _.isBoolean(options.tunnel) ? options.tunnel : false);
+        _.isString(options.host) && (this.host = options.host.replace(regexes.protocolMatcher, ''));
+        _.isInteger(options.port) && (options.port >= 0 && options.port <= 65535) && (this.port = options.port);
+        _.isBoolean(options.tunnel) && (this.tunnel = options.tunnel);
+
+        // match pattern
+        if (_.isString(options.match)) {
+            if (_.isEmpty(options.match) || options.match === MATCH_ALL_URLS) {
+                this.match = new UrlMatchPattern();
+            }
+            else {
+                this.match = new UrlMatchPattern('://' + options.match.replace(regexes.protocolMatcher, ''));
+            }
+        }
+        // protocols
+        _.isArray(options.protocols) && (this.protocols = options.protocols) ||
+            _.isString(options.protocols) && (this.protocols = [options.protocols]);
     },
 
     /**

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -137,7 +137,7 @@ _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
             return false;
         }
 
-        return this.match.test(urlStr);
+        return this.match.test(urlStr, this.protocols);
     }
 });
 

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -63,15 +63,6 @@ _.inherit((
         ProxyConfig.super_.call(this, options);
 
         // Assign defaults before proceeding
-        _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
-            /**
-             * Defines whether this property instances requires an id
-             * @private
-             * @readOnly
-             * @type {String}
-             */
-            _postman_requiresId: true
-        });
         _.assign(this, /** @lends ProxyConfig.prototype */ {
             /**
              * The url mach for which the proxy has been associated with.
@@ -108,6 +99,14 @@ _.inherit((
     }), Property);
 
 _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
+    /**
+     * Defines whether this property instances requires an id
+     * @private
+     * @readOnly
+     * @type {String}
+     */
+    _postman_requiresId: true,
+
     /**
      * Updates the properties of the proxy object based on the options provided.
      *

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -63,6 +63,15 @@ _.inherit((
         ProxyConfig.super_.call(this, options);
 
         // Assign defaults before proceeding
+        _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
+            /**
+             * Defines whether this property instances requires an id
+             * @private
+             * @readOnly
+             * @type {String}
+             */
+            _postman_requiresId: true
+        });
         _.assign(this, /** @lends ProxyConfig.prototype */ {
             /**
              * The url mach for which the proxy has been associated with.

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -2,6 +2,9 @@ var _ = require('../util').lodash,
     Property = require('./property').Property,
     UrlMatchPattern = require('../url-pattern/url-match-pattern').UrlMatchPattern,
     DEFAULT_PROTOCOLS = ['http'],
+    DEFAULT_PORT = 8080,
+    MAX_PORT = 65535,
+    MIN_PORT = 0,
     regexes = {
         protocolMatcher: /.*:\/\//
     },
@@ -77,7 +80,7 @@ _.inherit((
              * The proxy server port number
              * @type {Integer}
              */
-            port: 8080,
+            port: DEFAULT_PORT,
 
             /**
              * The protocol(s) that the proxy server supports
@@ -106,7 +109,7 @@ _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
             return;
         }
         _.isString(options.host) && (this.host = options.host.replace(regexes.protocolMatcher, ''));
-        _.isInteger(options.port) && (options.port >= 0 && options.port <= 65535) && (this.port = options.port);
+        _.isInteger(options.port) && (options.port >= MIN_PORT && options.port <= MAX_PORT) && (this.port = options.port);
         _.isBoolean(options.tunnel) && (this.tunnel = options.tunnel);
 
         // match pattern

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -1,7 +1,6 @@
 var _ = require('../util').lodash,
     Property = require('./property').Property,
     UrlMatchPattern = require('../url-pattern/url-match-pattern').UrlMatchPattern,
-    MATCH_ALL_URLS = UrlMatchPattern.MATCH_ALL_URLS,
     DEFAULT_PROTOCOLS = ['http'],
     regexes = {
         protocolMatcher: /.*:\/\//
@@ -112,12 +111,11 @@ _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
 
         // match pattern
         if (_.isString(options.match)) {
-            if (_.isEmpty(options.match) || options.match === MATCH_ALL_URLS) {
-                this.match = new UrlMatchPattern();
-            }
-            else {
-                this.match = new UrlMatchPattern('://' + options.match.replace(regexes.protocolMatcher, ''));
-            }
+            var matchPatternOptions = {
+                ignoreProtocol: true,
+                pattern: options.match
+            };
+            this.match = new UrlMatchPattern(matchPatternOptions);
         }
         // protocols
         _.isArray(options.protocols) && (this.protocols = options.protocols) ||

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -121,17 +121,19 @@ _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
         _.isInteger(options.port) && (options.port >= MIN_PORT && options.port <= MAX_PORT) && (this.port = options.port);
         _.isBoolean(options.tunnel) && (this.tunnel = options.tunnel);
 
+        // protocols
+        _.isArray(options.protocols) && (this.protocols = options.protocols) ||
+        _.isString(options.protocols) && (this.protocols = [options.protocols]);
+
         // match pattern
         if (_.isString(options.match)) {
             var matchPatternOptions = {
-                ignoreProtocol: true,
-                pattern: options.match
+                allowProtocols: true,
+                pattern: options.match,
+                protocols: this.protocols
             };
             this.match = new UrlMatchPattern(matchPatternOptions);
         }
-        // protocols
-        _.isArray(options.protocols) && (this.protocols = options.protocols) ||
-            _.isString(options.protocols) && (this.protocols = [options.protocols]);
     },
 
     /**
@@ -147,7 +149,7 @@ _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
             return false;
         }
 
-        return this.match.test(urlStr, this.protocols);
+        return this.match.test(urlStr);
     }
 });
 

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -86,7 +86,7 @@ _.inherit((
              * The protocol(s) that the proxy server supports
              * @type {Array}
              */
-            protocols: DEFAULT_PROTOCOLS,
+            protocols: _.clone(DEFAULT_PROTOCOLS),
 
             /**
              * This represents whether the tunneling needs to done while proxying this request.

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -127,7 +127,6 @@ _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
         // match pattern
         if (_.isString(options.match)) {
             var matchPatternOptions = {
-                allowProtocols: true,
                 pattern: options.match,
                 protocols: this.protocols
             };

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -74,7 +74,7 @@ _.inherit((
              * The proxy server host or ip
              * @type {String}
              */
-            host: '',
+            host: undefined,
 
             /**
              * The proxy server port number

--- a/lib/url-pattern/url-match-pattern.js
+++ b/lib/url-pattern/url-match-pattern.js
@@ -7,7 +7,6 @@ var _ = require('../util').lodash,
     POSTFIX_DELIMITER = '$',
     MATCH_ALL_URLS = '<all_urls>',
     ALLOWED_PROTOCOLS = ['http', 'https', 'file', 'ftp'],
-    DEFAULT_PROTOCOLS = ['http'],
     ALLOWED_PROTOCOLS_REGEX = ALLOWED_PROTOCOLS.join('|'),
 
     regexes = {
@@ -60,11 +59,9 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
          * The protocols which will be used to match the URLs
          * @type {Array}
          */
-        this.protocols = _.get(options, 'protocols', this.protocols) || DEFAULT_PROTOCOLS;
-        !_.isArray(this.protocols) && (this.protocols = DEFAULT_PROTOCOLS);
+        this.protocols = _.get(options, 'protocols');
 
-        this._allowProtocols = _.get(options, 'allowProtocols', this._allowProtocols) || false;
-        this._allowProtocols && (this.pattern = this.pattern.replace(regexes.protocolMatcher, ''));
+        _.isArray(this.protocols) && (this.pattern = this.pattern.replace(regexes.protocolMatcher, ''));
 
         // create a match pattern and store it on cache
         this._matchPatternObject = this.createMatchPattern();
@@ -81,7 +78,7 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
 
         // Check the match pattern of sanity and split it into protocol, host and path
 
-        if (this._allowProtocols) {
+        if (_.isArray(this.protocols)) {
             match = matchPattern.match(regexes.noProtocolPatternSplit);
         }
         else {
@@ -94,9 +91,9 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
         }
 
         return {
-            protocol: this._allowProtocols ? null : match[1],
-            host: this._allowProtocols ? match[1] : match[2],
-            path: this._allowProtocols ? this.globPatternToRegexp(match[2]) : this.globPatternToRegexp(match[3])
+            protocol: _.isArray(this.protocols) ? null : match[1],
+            host: _.isArray(this.protocols) ? match[1] : match[2],
+            path: _.isArray(this.protocols) ? this.globPatternToRegexp(match[2]) : this.globPatternToRegexp(match[3])
         };
     },
 
@@ -123,7 +120,7 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
     testProtocol: function (protocol) {
         var matchRegexObject = this._matchPatternObject;
 
-        if (this._allowProtocols) {
+        if (_.isArray(this.protocols)) {
             return _.indexOf(this.protocols, protocol) !== -1;
         }
 

--- a/lib/url-pattern/url-match-pattern.js
+++ b/lib/url-pattern/url-match-pattern.js
@@ -100,14 +100,16 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
      * @param {String=} protocol The protocol to be checked if the pattern allows.
      * @return {Boolean=}
      */
-    testProtocol: function (protocol) {
+    testProtocol: function (protocol, allowedProtocols) {
         var matchRegexObject = this._matchPatternObject;
 
-        // Do not match if protocol is invalid
+        if (_.isArray(allowedProtocols)) {
+            return _.indexOf(allowedProtocols, protocol) !== -1;
+        }
+
         if (!_.includes(ALLOWED_PROTOCOLS, protocol)) {
             return false;
         }
-
         // Return true if test pattern is *, else return match
         return matchRegexObject.protocol === MATCH_ALL ? true : matchRegexObject.protocol === protocol;
     },
@@ -186,7 +188,7 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
       * @param {String=} urlStr The url string for which the proxy match needs to be done.
       * @returns {Boolean=}
       */
-    test: function (urlStr) {
+    test: function (urlStr, allowedProtocols) {
         /*
         * This function executes the code in the following sequence for early return avoiding the costly regex matches.
         * To avoid most of the memory consuming code.
@@ -198,7 +200,6 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
         * 4. Checks the host, as it doesn't involve regex match and has only string comparisons.
         * 5. Finally, checks for the path, which actually involves the Regex matching, the slow process.
         */
-
         // If the matchPattern is <all_urls> then there is no need for any validations.
         if (this.pattern === MATCH_ALL_URLS) {
             return true;
@@ -219,7 +220,7 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
             return false;
         }
 
-        return (this.testProtocol(url.protocol) &&
+        return (this.testProtocol(url.protocol, allowedProtocols) &&
             this.testHost(url.getRemote()) &&
             this.testPath(url.getPath()));
     },

--- a/lib/url-pattern/url-match-pattern.js
+++ b/lib/url-pattern/url-match-pattern.js
@@ -16,6 +16,8 @@ var _ = require('../util').lodash,
         questionmarkReplacment: '.',
         starMatcher: '*',
         starReplacement: '.*',
+        protocolMatcher: /.*:\/\//g,
+        noProtocolPatternSplit: '^(\\*|\\*\\.[^*/]+|[^*/]+|)(/.*)$',
         patternSplit: '^(' + ALLOWED_PROTOCOLS_REGEX + '|\\*)*://(\\*|\\*\\.[^*/]+|[^*/]+|)(/.*)$'
     },
 
@@ -53,6 +55,9 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
          */
         this.pattern = _.get(options, 'pattern') || MATCH_ALL_URLS;
 
+        this._ignoreProtocol = _.get(options, 'ignoreProtocol') || false;
+        this._ignoreProtocol && (this.pattern = this.pattern.replace(regexes.protocolMatcher, ''));
+
         // create a match pattern and store it on cache
         this._matchPatternObject = this.createMatchPattern();
     },
@@ -64,9 +69,16 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
      */
     createMatchPattern: function () {
         var matchPattern = this.pattern,
+            match;
 
-            // Check the match pattern of sanity and split it into protocol, host and path
+        // Check the match pattern of sanity and split it into protocol, host and path
+
+        if (this._ignoreProtocol) {
+            match = matchPattern.match(regexes.noProtocolPatternSplit);
+        }
+        else {
             match = matchPattern.match(regexes.patternSplit);
+        }
 
         if (!match) {
             // This ensures it is a invalid match pattern
@@ -74,9 +86,9 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
         }
 
         return {
-            protocol: match[1],
-            host: match[2],
-            path: this.globPatternToRegexp(match[3])
+            protocol: this._ignoreProtocol ? null : match[1],
+            host: this._ignoreProtocol ? match[1] : match[2],
+            path: this._ignoreProtocol ? this.globPatternToRegexp(match[2]) : this.globPatternToRegexp(match[3])
         };
     },
 

--- a/lib/url-pattern/url-match-pattern.js
+++ b/lib/url-pattern/url-match-pattern.js
@@ -122,7 +122,7 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
         var matchRegexObject = this._matchPatternObject;
 
         if (_.isArray(this.protocols)) {
-            return _.indexOf(this.protocols, protocol) !== -1;
+            return _.includes(this.protocols, protocol);
         }
 
         if (!_.includes(ALLOWED_PROTOCOLS, protocol)) {

--- a/lib/url-pattern/url-match-pattern.js
+++ b/lib/url-pattern/url-match-pattern.js
@@ -40,6 +40,22 @@ _.inherit((
       // this constructor is intended to inherit and as such the super constructor is required to be executed
       UrlMatchPattern.super_.apply(this, arguments);
 
+      // Assign defaults before proceeding
+      _.assign(this, /** @lends UrlMatchPattern */ {
+          /**
+           * The url match pattern string
+           * @type {String}
+           */
+          pattern: MATCH_ALL_URLS,
+
+          /**
+           * The protocols which will be used to match the URLs.
+           * This field is optional. If not passed then the pattern is supposed to have the protocol information
+           * @type {Array}
+           */
+          protocols: undefined
+      });
+
       this.update(options);
   }), Property);
 
@@ -49,18 +65,8 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
      * @param {{ pattern: (string) }} options
      */
     update: function (options) {
-        /**
-         * The url match pattern string
-         * @type {String}
-         */
-        this.pattern = _.get(options, 'pattern') || this.pattern || MATCH_ALL_URLS;
-
-        /**
-         * The protocols which will be used to match the URLs
-         * @type {Array}
-         */
-        this.protocols = _.get(options, 'protocols');
-
+        _.has(options, 'pattern') && (_.isString(options.pattern)) && (this.pattern = options.pattern);
+        _.has(options, 'protocols') && (this.protocols = options.protocols);
         _.isArray(this.protocols) && (this.pattern = this.pattern.replace(regexes.protocolMatcher, ''));
 
         // create a match pattern and store it on cache

--- a/lib/url-pattern/url-match-pattern.js
+++ b/lib/url-pattern/url-match-pattern.js
@@ -74,11 +74,12 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
      */
     createMatchPattern: function () {
         var matchPattern = this.pattern,
+            allowProtocols = _.isArray(this.protocols),
             match;
 
         // Check the match pattern of sanity and split it into protocol, host and path
 
-        if (_.isArray(this.protocols)) {
+        if (allowProtocols) {
             match = matchPattern.match(regexes.noProtocolPatternSplit);
         }
         else {
@@ -91,9 +92,9 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
         }
 
         return {
-            protocol: _.isArray(this.protocols) ? null : match[1],
-            host: _.isArray(this.protocols) ? match[1] : match[2],
-            path: _.isArray(this.protocols) ? this.globPatternToRegexp(match[2]) : this.globPatternToRegexp(match[3])
+            protocol: allowProtocols ? null : match[1],
+            host: allowProtocols ? match[1] : match[2],
+            path: allowProtocols ? this.globPatternToRegexp(match[2]) : this.globPatternToRegexp(match[3])
         };
     },
 

--- a/lib/url-pattern/url-match-pattern.js
+++ b/lib/url-pattern/url-match-pattern.js
@@ -7,6 +7,7 @@ var _ = require('../util').lodash,
     POSTFIX_DELIMITER = '$',
     MATCH_ALL_URLS = '<all_urls>',
     ALLOWED_PROTOCOLS = ['http', 'https', 'file', 'ftp'],
+    DEFAULT_PROTOCOLS = ['http'],
     ALLOWED_PROTOCOLS_REGEX = ALLOWED_PROTOCOLS.join('|'),
 
     regexes = {
@@ -53,10 +54,17 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
          * The url match pattern string
          * @type {String}
          */
-        this.pattern = _.get(options, 'pattern') || MATCH_ALL_URLS;
+        this.pattern = _.get(options, 'pattern') || this.pattern || MATCH_ALL_URLS;
 
-        this._ignoreProtocol = _.get(options, 'ignoreProtocol') || false;
-        this._ignoreProtocol && (this.pattern = this.pattern.replace(regexes.protocolMatcher, ''));
+        /**
+         * The protocols which will be used to match the URLs
+         * @type {Array}
+         */
+        this.protocols = _.get(options, 'protocols', this.protocols) || DEFAULT_PROTOCOLS;
+        !_.isArray(this.protocols) && (this.protocols = DEFAULT_PROTOCOLS);
+
+        this._allowProtocols = _.get(options, 'allowProtocols', this._allowProtocols) || false;
+        this._allowProtocols && (this.pattern = this.pattern.replace(regexes.protocolMatcher, ''));
 
         // create a match pattern and store it on cache
         this._matchPatternObject = this.createMatchPattern();
@@ -73,7 +81,7 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
 
         // Check the match pattern of sanity and split it into protocol, host and path
 
-        if (this._ignoreProtocol) {
+        if (this._allowProtocols) {
             match = matchPattern.match(regexes.noProtocolPatternSplit);
         }
         else {
@@ -86,9 +94,9 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
         }
 
         return {
-            protocol: this._ignoreProtocol ? null : match[1],
-            host: this._ignoreProtocol ? match[1] : match[2],
-            path: this._ignoreProtocol ? this.globPatternToRegexp(match[2]) : this.globPatternToRegexp(match[3])
+            protocol: this._allowProtocols ? null : match[1],
+            host: this._allowProtocols ? match[1] : match[2],
+            path: this._allowProtocols ? this.globPatternToRegexp(match[2]) : this.globPatternToRegexp(match[3])
         };
     },
 
@@ -112,11 +120,11 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
      * @param {String=} protocol The protocol to be checked if the pattern allows.
      * @return {Boolean=}
      */
-    testProtocol: function (protocol, allowedProtocols) {
+    testProtocol: function (protocol) {
         var matchRegexObject = this._matchPatternObject;
 
-        if (_.isArray(allowedProtocols)) {
-            return _.indexOf(allowedProtocols, protocol) !== -1;
+        if (this._allowProtocols) {
+            return _.indexOf(this.protocols, protocol) !== -1;
         }
 
         if (!_.includes(ALLOWED_PROTOCOLS, protocol)) {
@@ -200,7 +208,7 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
       * @param {String=} urlStr The url string for which the proxy match needs to be done.
       * @returns {Boolean=}
       */
-    test: function (urlStr, allowedProtocols) {
+    test: function (urlStr) {
         /*
         * This function executes the code in the following sequence for early return avoiding the costly regex matches.
         * To avoid most of the memory consuming code.
@@ -232,7 +240,7 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
             return false;
         }
 
-        return (this.testProtocol(url.protocol, allowedProtocols) &&
+        return (this.testProtocol(url.protocol) &&
             this.testHost(url.getRemote()) &&
             this.testPath(url.getPath()));
     },

--- a/test/integration/proxy-config-list.test.js
+++ b/test/integration/proxy-config-list.test.js
@@ -7,104 +7,132 @@ describe('Proxy Config List', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { server: 'https://proxy.com/', tunnel: true }
+                    { host: 'proxy.com', tunnel: true }
                 ]
             );
-        expect(list.resolve('http://www.google.com/').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://www.google.com/').host).to.eql('proxy.com');
+        expect(list.resolve('http://example.org/foo/bar.html').host).to.eql('proxy.com');
     });
 
     it('Assigns, <all_urls> as match pattern and respect the disabled prop in the congfig', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { server: 'https://proxy.com/', tunnel: true, disabled: true }
+                    { host: 'proxy.com', tunnel: true, disabled: true }
                 ]
             );
         expect(list.resolve('foo://www.foo/bar')).to.eql(undefined);
     });
 
-    it('Matches any URL that uses the http protocol', function () {
+    it('Matches only the URLs that uses the default (http) protocol', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { match: 'http://*/*', server: 'https://proxy.com/', tunnel: true }
+                    { match: '*/*', host: 'proxy.com' }
                 ]
             );
-        expect(list.resolve('http://www.google.com/').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://www.google.com/').host).to.eql('proxy.com');
+        expect(list.resolve('http://example.org/foo/bar.html').host).to.eql('proxy.com');
+        expect(list.resolve('https://example.org/foo/bar.html')).to.eql(undefined);
+    });
+
+    it('Matches only the URLs that uses the https protocol', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: '*/*', host: 'proxy.com', protocols: 'https' }
+                ]
+            );
+        expect(list.resolve('https://www.google.com/').host).to.eql('proxy.com');
+        expect(list.resolve('https://example.org/foo/bar.html').host).to.eql('proxy.com');
+        expect(list.resolve('http://example.org/foo/bar.html')).to.eql(undefined);
+    });
+
+    it('Matches any URL that uses the http or https protocol', function () {
+        var parent = {},
+            list = new ProxyConfigList(parent,
+                [
+                    { match: '*/*', host: 'proxy.com', protocols: ['http', 'https'] }
+                ]
+            );
+        expect(list.resolve('http://www.google.com/').host).to.eql('proxy.com');
+        expect(list.resolve('https://example.org/foo/bar.html').host).to.eql('proxy.com');
     });
 
     it('Matches any URL that uses the http protocol, on any host, as long as the path starts with /foo', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { match: 'http://*/foo*', server: 'https://proxy.com/', tunnel: true }
+                    { match: '*/foo*', host: 'proxy.com' }
                 ]
             );
-        expect(list.resolve('http://example.com/foo/bar.html').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('http://www.google.com/foo').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://example.com/foo/bar.html').host).to.eql('proxy.com');
+        expect(list.resolve('http://www.google.com/foo').host).to.eql('proxy.com');
     });
 
     it('Matches any URL that uses the https protocol, is on a google.com host', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { match: 'http://*.google.com/foo*bar', server: 'https://proxy.com/', tunnel: true }
+                    { match: '*.google.com/foo*bar', host: 'proxy.com', protocols: 'https' }
                 ]
             );
-        expect(list.resolve('http://www.google.com/foo/baz/bar').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('http://docs.google.com/foobar').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('https://www.google.com/foo/baz/bar').host).to.eql('proxy.com');
+        expect(list.resolve('https://docs.google.com/foobar').host).to.eql('proxy.com');
+        expect(list.resolve('http://docs.google.com/foobar')).to.eql(undefined);
     });
 
     it('Matches the specified URL', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { match: 'http://example.org/foo/bar.html', server: 'https://proxy.com/', tunnel: true }
+                    { match: 'example.org/foo/bar.html', host: 'proxy.com' }
                 ]
             );
-        expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://example.org/foo/bar.html').host).to.eql('proxy.com');
     });
 
     it('Matches any URL that uses the http protocol and is on the host 127.0.0.1', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { match: 'http://127.0.0.1/*', server: 'https://proxy.com/', tunnel: true }
+                    { match: '127.0.0.1/*', host: 'proxy.com' }
                 ]
             );
-        expect(list.resolve('http://127.0.0.1/').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('http://127.0.0.1/foo/bar.html').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://127.0.0.1/').host).to.eql('proxy.com');
+        expect(list.resolve('http://127.0.0.1/foo/bar.html').host).to.eql('proxy.com');
+        expect(list.resolve('https://127.0.0.1/')).to.eql(undefined);
     });
 
     it('Matches any URL that uses the http protocol and is on the host ends with 0.0.1', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { match: 'http://*.0.0.1/', server: 'https://proxy.com/', tunnel: true }
+                    { match: '*.0.0.1/', host: 'proxy.com' }
                 ]
             );
-        expect(list.resolve('http://127.0.0.1/').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('http://125.0.0.1/').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://127.0.0.1/').host).to.eql('proxy.com');
+        expect(list.resolve('http://125.0.0.1/').host).to.eql('proxy.com');
+        expect(list.resolve('https://125.0.0.1/')).to.eql(undefined);
     });
 
     it('Matches any URL which has host mail.google.com', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { match: '*://mail.google.com/*', server: 'https://proxy.com/', tunnel: true }
+                    { match: 'mail.google.com/*', host: 'proxy.com', protocols: ['http', 'https'] }
                 ]
             );
-        expect(list.resolve('http://mail.google.com/foo/baz/bar').server.getHost()).to.eql('proxy.com');
-        expect(list.resolve('https://mail.google.com/foobar').server.getHost()).to.eql('proxy.com');
+        expect(list.resolve('http://mail.google.com/foo/baz/bar').host).to.eql('proxy.com');
+        expect(list.resolve('https://mail.google.com/foobar').host).to.eql('proxy.com');
+        expect(list.resolve('https://google.com/foobar')).to.eql(undefined);
     });
 
     it('Bad Match pattern [No Path]', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { match: 'http://www.google.com', server: 'https://proxy.com/', tunnel: true }
+                    { match: 'www.google.com', host: 'proxy.com' }
                 ]
             );
         expect(list.resolve('http://www.google.com')).to.eql(undefined);
@@ -114,7 +142,7 @@ describe('Proxy Config List', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { match: 'http://*foo/bar', server: 'https://proxy.com/', tunnel: true }
+                    { match: '*foo/bar', host: 'proxy.com' }
                 ]
             );
         expect(list.resolve('http://www.foo/bar')).to.eql(undefined);
@@ -124,7 +152,7 @@ describe('Proxy Config List', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { match: 'http://foo.*.bar/baz', server: 'https://proxy.com/', tunnel: true }
+                    { match: 'foo.*.bar/baz', host: 'proxy.com' }
                 ]
             );
         expect(list.resolve('http://foo.z.bar/baz')).to.eql(undefined);
@@ -134,7 +162,7 @@ describe('Proxy Config List', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { match: 'http:/bar', server: 'https://proxy.com/', tunnel: true }
+                    { match: 'http:/bar', host: 'proxy.com' }
                 ]
             );
         expect(list.resolve('http:/bar')).to.eql(undefined);
@@ -144,7 +172,7 @@ describe('Proxy Config List', function () {
         var parent = {},
             list = new ProxyConfigList(parent,
                 [
-                    { match: 'foo://*', server: 'https://proxy.com/', tunnel: true }
+                    { match: 'www.foo/bar', host: 'proxy.com', protocol: 'foo' }
                 ]
             );
         expect(list.resolve('foo://www.foo/bar')).to.eql(undefined);

--- a/test/integration/proxy-config.test.js
+++ b/test/integration/proxy-config.test.js
@@ -12,7 +12,7 @@ describe('Proxy Config', function () {
 
     it('should prepopulate the values when pass through the constructor', function () {
         var p = new ProxyConfig({
-            match: 'http://example.com',
+            match: 'http://*.google.com/foo*bar',
             host: 'proxy.com',
             port: 8080,
             protocols: ['http'],
@@ -20,7 +20,9 @@ describe('Proxy Config', function () {
             disabled: true
         });
 
-        expect(p.match.pattern).to.be('://example.com');
+        expect(p.match.pattern).to.be('*.google.com/foo*bar');
+        expect(p.test('http://mail.google.com/foo/baz/bar')).to.be(true);
+        expect(p.test('http://docs.google.com/foobar')).to.be(true);
         expect(p.protocols).to.be.eql(['http']);
         expect(p.host).to.be('proxy.com');
         expect(p.tunnel).to.be(true);

--- a/test/integration/proxy-config.test.js
+++ b/test/integration/proxy-config.test.js
@@ -13,14 +13,16 @@ describe('Proxy Config', function () {
     it('should prepopulate the values when pass through the constructor', function () {
         var p = new ProxyConfig({
             match: 'http://example.com',
-            server: 'http://proxy.com',
+            host: 'proxy.com',
+            port: 8080,
+            protocols: ['http'],
             tunnel: true,
             disabled: true
         });
 
-        expect(p.match.pattern).to.be('http://example.com');
-        expect(p.server.protocol).to.be('http');
-        expect(p.server.getHost()).to.be('proxy.com');
+        expect(p.match.pattern).to.be('://example.com');
+        expect(p.protocols).to.be.eql(['http']);
+        expect(p.host).to.be('proxy.com');
         expect(p.tunnel).to.be(true);
         expect(p.disabled).to.be(true);
     });
@@ -28,9 +30,13 @@ describe('Proxy Config', function () {
 
     it('should prepopulate the values of match to * if it is not provided', function () {
         var p = new ProxyConfig({
-            server: 'http://proxy.com'
+            host: 'http://proxy.com'
         });
 
         expect(p.match.pattern).to.be('<all_urls>');
+        expect(p.protocols).to.be.eql(['http']);
+        expect(p.host).to.be('proxy.com');
+        expect(p.tunnel).to.be(false);
+        expect(p.disabled).to.not.be.ok();
     });
 });

--- a/test/unit/proxy-config-list.test.js
+++ b/test/unit/proxy-config-list.test.js
@@ -9,94 +9,94 @@ describe('Proxy Config List', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { server: 'https://proxy.com/', tunnel: true }
+                        { host: 'proxy.com', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://www.google.com/').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
+            expect(list.resolve('http://www.google.com/').host).to.eql('proxy.com');
+            expect(list.resolve('http://example.org/foo/bar.html').host).to.eql('proxy.com');
         });
 
         it('Matches any URL that uses the http protocol', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'http://*/*', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'http://*/*', host: 'proxy.com', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://www.google.com/').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve(new Url('http://example.org/foo/bar.html')).server.getHost()).to.eql('proxy.com');
+            expect(list.resolve('http://www.google.com/').host).to.eql('proxy.com');
+            expect(list.resolve(new Url('http://example.org/foo/bar.html')).host).to.eql('proxy.com');
         });
 
         it('Matches any URL that uses the http protocol, on any host, as long as the path starts with /foo', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'http://*/foo*', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'http://*/foo*', host: 'proxy.com', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://example.com/foo/bar.html').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve('http://www.google.com/foo').server.getHost()).to.eql('proxy.com');
+            expect(list.resolve('http://example.com/foo/bar.html').host).to.eql('proxy.com');
+            expect(list.resolve('http://www.google.com/foo').host).to.eql('proxy.com');
         });
 
         it('Matches any URL that uses the https protocol, is on a google.com host', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'http://*.google.com/foo*bar', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'http://*.google.com/foo*bar', host: 'proxy.com', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://www.google.com/foo/baz/bar').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve('http://docs.google.com/foobar').server.getHost()).to.eql('proxy.com');
+            expect(list.resolve('http://www.google.com/foo/baz/bar').host).to.eql('proxy.com');
+            expect(list.resolve('http://docs.google.com/foobar').host).to.eql('proxy.com');
         });
 
         it('Matches the specified URL', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'http://example.org/foo/bar.html', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'http://example.org/foo/bar.html', host: 'proxy.com', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://example.org/foo/bar.html').server.getHost()).to.eql('proxy.com');
+            expect(list.resolve('http://example.org/foo/bar.html').host).to.eql('proxy.com');
         });
 
         it('Matches any URL that uses the http protocol and is on the host 127.0.0.1', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'http://127.0.0.1/*', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'http://127.0.0.1/*', host: 'proxy.com', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://127.0.0.1/').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve('http://127.0.0.1/foo/bar.html').server.getHost()).to.eql('proxy.com');
+            expect(list.resolve('http://127.0.0.1/').host).to.eql('proxy.com');
+            expect(list.resolve('http://127.0.0.1/foo/bar.html').host).to.eql('proxy.com');
         });
 
         it('Matches any URL that uses the http protocol and is on the host ends with 0.0.1', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'http://*.0.0.1/', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'http://*.0.0.1/', host: 'proxy.com', tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://127.0.0.1/').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve('http://125.0.0.1/').server.getHost()).to.eql('proxy.com');
+            expect(list.resolve('http://127.0.0.1/').host).to.eql('proxy.com');
+            expect(list.resolve('http://125.0.0.1/').host).to.eql('proxy.com');
         });
 
         it('Matches any URL which has host mail.google.com', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: '*://mail.google.com/*', server: 'https://proxy.com/', tunnel: true }
+                        { match: '*://mail.google.com/*', host: 'proxy.com', protocols: ['http', 'https'], tunnel: true }
                     ]
                 );
-            expect(list.resolve('http://mail.google.com/foo/baz/bar').server.getHost()).to.eql('proxy.com');
-            expect(list.resolve('https://mail.google.com/foobar').server.getHost()).to.eql('proxy.com');
+            expect(list.resolve('http://mail.google.com/foo/baz/bar').host).to.eql('proxy.com');
+            expect(list.resolve('https://mail.google.com/foobar').host).to.eql('proxy.com');
         });
 
         it('Bad Match pattern [No Path]', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'http://www.google.com', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'http://www.google.com', host: 'proxy.com', tunnel: true }
                     ]
                 );
             expect(list.resolve('http://www.google.com')).to.eql(undefined);
@@ -106,7 +106,7 @@ describe('Proxy Config List', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'http://*foo/bar', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'http://*foo/bar', host: 'proxy.com', tunnel: true }
                     ]
                 );
             expect(list.resolve('http://www.foo/bar')).to.eql(undefined);
@@ -116,7 +116,7 @@ describe('Proxy Config List', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'http://foo.*.bar/baz', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'http://foo.*.bar/baz', host: 'proxy.com', tunnel: true }
                     ]
                 );
             expect(list.resolve('http://foo.z.bar/baz')).to.eql(undefined);
@@ -126,7 +126,7 @@ describe('Proxy Config List', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'http:/bar', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'http:/bar', host: 'proxy.com', tunnel: true }
                     ]
                 );
             expect(list.resolve('http:/bar')).to.eql(undefined);
@@ -136,7 +136,7 @@ describe('Proxy Config List', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'foo://*', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'foo://*', host: 'proxy.com', tunnel: true }
                     ]
                 );
             expect(list.resolve('foo://www.foo/bar')).to.eql(undefined);
@@ -146,7 +146,7 @@ describe('Proxy Config List', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'foo://*', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'foo://*', host: 'proxy.com', tunnel: true }
                     ]
                 );
             expect(list.resolve('')).to.eql(undefined);
@@ -156,7 +156,7 @@ describe('Proxy Config List', function () {
             var parent = {},
                 list = new ProxyConfigList(parent,
                     [
-                        { match: 'foo://*', server: 'https://proxy.com/', tunnel: true }
+                        { match: 'foo://*', host: 'proxy.com', tunnel: true }
                     ]
                 );
             expect(list.resolve({ remote: 'random remote' })).to.eql(undefined);

--- a/test/unit/proxy-config.test.js
+++ b/test/unit/proxy-config.test.js
@@ -47,7 +47,7 @@ describe('Proxy Config', function () {
         });
 
         it('should parse any URL which has host mail.google.com', function () {
-            var pc = new ProxyConfig({ match: '*://mail.google.com/*', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: '*://mail.google.com/*', server: 'https://proxy.com/', protocols: ['http', 'https'] });
             expect(pc.test('http://mail.google.com/foo/baz/bar')).to.eql(true);
             expect(pc.test('https://mail.google.com/foobar')).to.eql(true);
         });
@@ -94,11 +94,11 @@ describe('Proxy Config', function () {
 
     describe('toJSON', function() {
         it('should retain properties from original json', function() {
-            var rawConfig = { match: 'http://*/*', server: 'https://proxy.com/', tunnel: true, disabled: false },
+            var rawConfig = { match: 'http://*/*', parsedMatch: '://*/*', server: 'https://proxy.com/', tunnel: true, disabled: false },
                 proxyConfig = new ProxyConfig(rawConfig),
                 serialisedConfig = proxyConfig.toJSON();
 
-            expect(serialisedConfig.match).to.eql({ pattern: rawConfig.match });
+            expect(serialisedConfig.match).to.eql({ pattern: rawConfig.parsedMatch });
             expect(serialisedConfig.tunnel).to.eql(rawConfig.tunnel);
             expect(serialisedConfig.disabled).to.eql(rawConfig.disabled);
         });

--- a/test/unit/proxy-config.test.js
+++ b/test/unit/proxy-config.test.js
@@ -5,86 +5,86 @@ var expect = require('expect.js'),
 describe('Proxy Config', function () {
     describe('test', function () {
         it('should match all urls provided', function () {
-            var pc = new ProxyConfig({ server: 'https://proxy.com/', tunnel: true });
+            var pc = new ProxyConfig({ host: 'proxy.com', tunnel: true });
             expect(pc.test('http://www.google.com/')).to.eql(true);
             expect(pc.test('http://foo.bar.com/')).to.eql(true);
         });
 
         it('should match all sdk Url provided', function () {
-            var pc = new ProxyConfig({ server: 'https://proxy.com/', tunnel: true });
+            var pc = new ProxyConfig({ host: 'proxy.com', tunnel: true });
             expect(pc.test(new Url('http://www.google.com/'))).to.eql(true);
             expect(pc.test(new Url('http://foo.bar.com/'))).to.eql(true);
         });
 
         it('should parse any URL that uses the http protocol', function () {
-            var pc = new ProxyConfig({ match: 'http://*/*', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: 'http://*/*', host: 'proxy.com' });
             expect(pc.test('http://www.google.com/')).to.eql(true);
             expect(pc.test('http://foo.bar.com/')).to.eql(true);
         });
 
         it('should parse any URL that uses the http protocol, on any host, with path starts with /foo', function () {
-            var pc = new ProxyConfig({ match: 'http://*/foo*', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: 'http://*/foo*', host: 'proxy.com' });
             expect(pc.test('http://example.com/foo/bar.html')).to.eql(true);
             expect(pc.test('http://www.google.com/foo')).to.eql(true);
         });
 
         it('should parse any URL that uses the https protocol, is on a google.com host', function () {
-            var pc = new ProxyConfig({ match: 'http://*.google.com/foo*bar', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: 'http://*.google.com/foo*bar', host: 'proxy.com' });
             expect(pc.test('http://www.google.com/foo/baz/bar')).to.eql(true);
             expect(pc.test('http://docs.google.com/foobar')).to.eql(true);
         });
 
         it('should parse any URL that uses the http protocol and is on the host 127.0.0.1', function () {
-            var pc = new ProxyConfig({ match: 'http://127.0.0.1/*', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: 'http://127.0.0.1/*', host: 'proxy.com' });
             expect(pc.test('http://127.0.0.1/')).to.eql(true);
             expect(pc.test('http://127.0.0.1/foo/bar.html')).to.eql(true);
         });
 
         it('should parse any URL that uses the http protocol and is on the host ends with 0.0.1', function () {
-            var pc = new ProxyConfig({ match: 'http://*.0.0.1/', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: 'http://*.0.0.1/', host: 'proxy.com' });
             expect(pc.test('http://127.0.0.1/')).to.eql(true);
             expect(pc.test('http://125.0.0.1/')).to.eql(true);
         });
 
         it('should parse any URL which has host mail.google.com', function () {
-            var pc = new ProxyConfig({ match: '*://mail.google.com/*', server: 'https://proxy.com/', protocols: ['http', 'https'] });
+            var pc = new ProxyConfig({ match: '*://mail.google.com/*', host: 'proxy.com', protocols: ['http', 'https'] });
             expect(pc.test('http://mail.google.com/foo/baz/bar')).to.eql(true);
             expect(pc.test('https://mail.google.com/foobar')).to.eql(true);
         });
 
         it('Bad Match pattern [No Path]', function () {
-            var pc = new ProxyConfig({ match: 'http://www.google.com', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: 'http://www.google.com', host: 'proxy.com' });
             expect(pc.test('http://www.google.com')).to.eql(false);
         });
 
         it('Bad Match pattern ["*" in the host can be followed only by a "." or "/"]', function () {
-            var pc = new ProxyConfig({ match: 'http://*foo/bar', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: 'http://*foo/bar', host: 'proxy.com' });
             expect(pc.test('http://*foo.com')).to.eql(false);
         });
 
         it('Bad Match pattern [If "*" is in the host, it must be the first character]', function () {
-            var pc = new ProxyConfig({ match: 'http://foo.*.bar/baz', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: 'http://foo.*.bar/baz', host: 'proxy.com' });
             expect(pc.test('http://foo.z.bar/baz')).to.eql(false);
         });
 
         it('Bad Match pattern [Missing protocol separator ("/" should be "//")]', function () {
-            var pc = new ProxyConfig({ match: 'http:/bar', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: 'http:/bar', host: 'proxy.com' });
             expect(pc.test('http:/bar.com')).to.eql(false);
         });
 
         it('Bad Match pattern [Invalid protocol', function () {
-            var pc = new ProxyConfig({ match: 'foo://*', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: 'foo://*', host: 'proxy.com' });
             expect(pc.test('foo://www.google.com')).to.eql(false);
         });
 
         it('Disallows test string with protocol not http or https', function () {
-            var pc = new ProxyConfig({ match: 'http://*', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: 'http://*', host: 'proxy.com' });
             expect(pc.test('foo://www.google.com')).to.eql(false);
             expect(pc.test('file://www.google.com')).to.eql(false);
         });
 
         it('Disallows any test string when match protocol is not http or https', function () {
-            var pc = new ProxyConfig({ match: 'ftp://*', server: 'https://proxy.com/' });
+            var pc = new ProxyConfig({ match: 'ftp://*', host: 'proxy.com' });
             expect(pc.test('foo://www.google.com')).to.eql(false);
             expect(pc.test('file://www.google.com')).to.eql(false);
             expect(pc.test('http://www.google.com')).to.eql(false);
@@ -94,7 +94,7 @@ describe('Proxy Config', function () {
 
     describe('toJSON', function() {
         it('should retain properties from original json', function() {
-            var rawConfig = { match: 'http://*/*', parsedMatch: '://*/*', server: 'https://proxy.com/', tunnel: true, disabled: false },
+            var rawConfig = { match: 'http://*/*', parsedMatch: '*/*', host: 'proxy.com', tunnel: true, disabled: false },
                 proxyConfig = new ProxyConfig(rawConfig),
                 serialisedConfig = proxyConfig.toJSON();
 
@@ -106,7 +106,7 @@ describe('Proxy Config', function () {
 
     describe('isProxyConfig', function() {
         it('should correctly identify ProxyConfig objects', function() {
-            var rawConfig = { match: 'http://*/*', server: 'https://proxy.com/', tunnel: true, disabled: false },
+            var rawConfig = { match: 'http://*/*', host: 'proxy.com', tunnel: true, disabled: false },
                 proxyConfig = new ProxyConfig(rawConfig);
 
             expect(ProxyConfig.isProxyConfig(proxyConfig)).to.eql(true);


### PR DESCRIPTION
Changes made:
- removed `server` and added `host`, `port` & `protocols` properties
- any protocol will be stripped away from both the match pattern as well the host value passed to the constructor 
  #### example
  ```js
    {
        // match pattern auto conversion
         'http://example.com/*'. : 'example.com/*',
         'example.com/*'.        : 'example.com/*',
        
        // host auto conversion
        'http://proxy.com'.      : 'proxy.com',
        'foo://proxy.com'.       : 'proxy.com'
    }
  ```
   **PS:** While stripping away protocol from `host` or `match` pattern, proxyConfig does not update it's `protocols` property.

Default values
-  protocol: `http`
-  port:  8080
- match: {pattern: '<all_urls>'}  // which is equivalent to *