### PR TITLE
Feature/list multivalue to object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Postman Collection SDK Changelog
 
+## Unreleased
+* Added support to allow duplicate indexed items to be exported as array via PropertyList.prototype.toObject
+
 #### v1.2.8 (May 31, 2017)
 * Fixed a bug where converting `QueryParam` and `FormParam` lists to objects was not working
 

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -443,28 +443,34 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
      *
      * @return {Object}
      */
-    toObject: function (excludeDisabled, caseSensitive) {
-        var obj = {},
-            key = this._postman_listIndexKey;
+    toObject: function (excludeDisabled, caseSensitive, multiValue) {
+        var obj = {}, // create transformation data accumulator
 
-        if (caseSensitive) {
-            this.each(function (member) {
-                if (!member.hasOwnProperty(key)) { return; }
-                if (excludeDisabled && member.disabled) { return; }
+            // gather all the switches of the list
+            key = this._postman_listIndexKey,
+            sensitive = !this._postman_listIndexCaseInsensitive || caseSensitive,
+            multivalue = this._postman_listAllowsMultipleValues || multiValue;
 
-                obj[member[key]] = member.valueOf();
-            });
-        }
-        else {
-            _.forOwn(this.reference, function (member, prop) {
-                _.isArray(member) && (member = _.last(member));
-                if (excludeDisabled && member.disabled) { // do no process disabled objects
-                    return;
-                }
+        // iterate on each member to create the transformation object
+        this.each(function (member) {
+            // in case the member does not have the list index key or it is marked to configre disabled ones, we bail out
+            if (!member || !member.hasOwnProperty(key) || (excludeDisabled && member.disabled)) {
+                return;
+            }
 
+            // based on case sensitivity settings, we get the property name of the item
+            var prop = sensitive ? member[key] : String(member[key]).toLowerCase();
+
+            // now, if transformation object already has a member with same property name, we either overwrite it or
+            // append to an array of values based on multi-value support
+            if (multivalue && obj.hasOwnProperty(prop)) {
+                (!Array.isArray(obj[prop])) && (obj[prop] = [obj[prop]]);
+                obj[prop].push(member.valueOf());
+            }
+            else {
                 obj[prop] = member.valueOf();
-            });
-        }
+            }
+        });
 
         return obj;
     },

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -4,6 +4,7 @@ var _ = require('../util').lodash,
     __PARENT = '__parent',
     DEFAULT_INDEX_ATTR = 'id',
     DEFAULT_INDEXCASE_ATTR = false,
+    DEFAULT_INDEXMULTI_ATTR = false,
 
     PropertyList;
 
@@ -52,7 +53,7 @@ _.inherit((
             type._postman_propertyIndexCaseInsensitive);
 
         // if the type allows multiple values, set the flag
-        _.getOwn(type, '_postman_propertyAllowsMultipleValues') && (this._postman_propertyAllowsMultipleValues =
+        _.getOwn(type, '_postman_propertyAllowsMultipleValues') && (this._postman_listAllowsMultipleValues =
             type._postman_propertyAllowsMultipleValues);
 
         // prepopulate
@@ -82,6 +83,14 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
      * @type {String}
      */
     _postman_listIndexCaseInsensitive: DEFAULT_INDEXCASE_ATTR,
+
+    /**
+     * Holds the attribute whether exporting the index retains duplicate index items
+     *
+     * @private
+     * @type {String}
+     */
+    _postman_listAllowsMultipleValues: DEFAULT_INDEXMULTI_ATTR,
 
     /**
      * Insert an element at the end of this list. When a reference member specified via second parameter is found, the
@@ -116,7 +125,7 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
             this._postman_listIndexCaseInsensitive && (index = index.toLowerCase());
 
             // if multiple values are allowed, the reference may contain an array of items, mapped to an index.
-            if (this._postman_propertyAllowsMultipleValues && this.reference.hasOwnProperty(index)) {
+            if (this._postman_listAllowsMultipleValues && this.reference.hasOwnProperty(index)) {
 
                 // if the value is not an array, convert it to an array.
                 !_.isArray(this.reference[index]) && (this.reference[index] = [this.reference[index]]);
@@ -271,7 +280,7 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
     one: function (id) {
         var val = this.reference[this._postman_listIndexCaseInsensitive ? String(id).toLowerCase() : id];
 
-        if (this._postman_propertyAllowsMultipleValues && Array.isArray(val)) {
+        if (this._postman_listAllowsMultipleValues && Array.isArray(val)) {
             return val.length ? val[val.length - 1] : undefined;
         }
 
@@ -384,7 +393,7 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
 
         // If this property allows multiple values and we get an array, we need to iterate through it and see
         // if any element matches.
-        if (this._postman_propertyAllowsMultipleValues && _.isArray(match)) {
+        if (this._postman_listAllowsMultipleValues && _.isArray(match)) {
             for (i = 0; i < match.length; i++) {
 
                 // use the value of the current element

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -499,7 +499,8 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
 
                 // Handle plurality of PropertyLists in the SDK vs the exported JSON.
                 // Basically, removes the trailing "s" from key if the value is a property list.
-                if (value && value._postman_propertyIsList && !value._postman_proprtyIsSerialisedAsPlural && _.endsWith(key, 's')) {
+                if (value && value._postman_propertyIsList && !value._postman_proprtyIsSerialisedAsPlural &&
+                    _.endsWith(key, 's')) {
                     key = key.slice(0, -1);
                 }
 

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -578,6 +578,26 @@ describe('PropertyList', function () {
                 key3: 'val3'
             });
         });
+
+        it('should return multiple values as array', function () {
+            FakeType._postman_propertyAllowsMultipleValues = true;
+
+            var list = new PropertyList(FakeType, {}, [{
+                keyAttr: 'key1',
+                value: 'val1'
+            }, {
+                keyAttr: 'key1',
+                value: 'val2'
+            }, {
+                keyAttr: 'key2',
+                value: 'val3'
+            }]);
+
+            expect(list.toObject()).to.eql({
+                key1: ['val1', 'val2'],
+                key2: 'val3'
+            });
+        });
     });
 
     describe('.get()', function () {

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -501,18 +501,26 @@ describe('PropertyList', function () {
     });
 
     describe('.toObject()', function () {
-        var FakeType = function (options) {
-            this.keyAttr = options.keyAttr;
-            this.value = options.value;
-            this.disabled = options.disabled;
-        };
+        var FakeType;
 
-        FakeType._postman_propertyIndexKey = 'keyAttr';
-        FakeType._postman_propertyIndexCaseInsensitive = true;
-        FakeType._postman_propertyAllowsMultipleValues = true;
-        FakeType.prototype.valueOf = function () {
-            return this.value;
-        };
+        beforeEach(function () {
+            FakeType = function (options) {
+                this.keyAttr = options.keyAttr;
+                this.value = options.value;
+                this.disabled = options.disabled;
+            };
+
+            FakeType._postman_propertyIndexKey = 'keyAttr';
+            FakeType._postman_propertyIndexCaseInsensitive = true;
+            FakeType._postman_propertyAllowsMultipleValues = false;
+            FakeType.prototype.valueOf = function () {
+                return this.value;
+            };
+        });
+
+        afterEach(function () {
+            FakeType = null;
+        });
 
         it('should return a pojo', function () {
             var list = new PropertyList(FakeType, {}, [{


### PR DESCRIPTION
For all Properties where `_postman_propertyAllowsMultipleValues` is set to true, when placed in a PropertyList and `.toObject` is invoked, duplicate items will appear as array of values