### PR TITLE
Improved Script constructor

### DIFF
--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -18,6 +18,8 @@ _.inherit((
         Script.super_.apply(this, arguments);
         if (!options) { return; } // in case definition object is missing, there is no point moving forward
 
+        var script;
+
         // create the request property
         /**
          * @augments {Script.prototype}
@@ -33,13 +35,14 @@ _.inherit((
             this.src = new Url(options.src)
         );
 
-        if (!this.src && options.hasOwnProperty('exec')) {
+        if (!this.src) {
+            script = options.hasOwnProperty('exec') ? options.exec : options;
+
             /**
              * @augments {Script.prototype}
              * @type {Array<string>}
              */
-            this.exec = _.isString(options.exec) && options.exec.split(/\r?\n/g) || _.isArray(options.exec) &&
-                options.exec || undefined;
+            this.exec = _.isString(script) && script.split(/\r?\n/g) || _.isArray(script) && script || undefined;
         }
     }), Property);
 

--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -2,7 +2,9 @@ var _ = require('../util').lodash,
     Property = require('./property').Property,
     Url = require('./url').Url,
 
-    Script;
+    Script,
+
+    SCRIPT_NEWLINE_PATTERN = /\r?\n/g;
 
 _.inherit((
 
@@ -14,11 +16,12 @@ _.inherit((
      * @param {Object} options
      */
     Script = function PostmanScript (options) {
-        // this constructor is intended to inherit and as such the super constructor is required to be excuted
+        // no splitting is being done here, as string scripts are split right before assignment below anyway
+        (_.isString(options) || _.isArray(options)) && (options = { exec: options });
+
+        // this constructor is intended to inherit and as such the super constructor is required to be executed
         Script.super_.apply(this, arguments);
         if (!options) { return; } // in case definition object is missing, there is no point moving forward
-
-        var script;
 
         // create the request property
         /**
@@ -35,14 +38,13 @@ _.inherit((
             this.src = new Url(options.src)
         );
 
-        if (!this.src) {
-            script = options.hasOwnProperty('exec') ? options.exec : options;
-
+        if (!this.src && options.hasOwnProperty('exec')) {
             /**
              * @augments {Script.prototype}
              * @type {Array<string>}
              */
-            this.exec = _.isString(script) && script.split(/\r?\n/g) || _.isArray(script) && script || undefined;
+            this.exec = _.isString(options.exec) ? options.exec.split(SCRIPT_NEWLINE_PATTERN) :
+                _.isArray(options.exec) ? options.exec : undefined;
         }
     }), Property);
 

--- a/test/unit/collection.test.js
+++ b/test/unit/collection.test.js
@@ -45,4 +45,36 @@ describe('Collection', function () {
             expect(target).not.have.property('extra');
         });
     });
+
+    describe('events', function () {
+        it('should allow adding events with a multitude of script definition format', function () {
+            var collection = new Collection();
+
+            collection.events.add({
+                listen: 'test',
+                script: {
+                    type: 'text/javascript',
+                    exec: ['console.log("Random");']
+                }
+            });
+            collection.events.add({
+                listen: 'prerequest',
+                script: ['console.log("A little less random");']
+            });
+
+            expect(collection.events.toJSON()).to.eql([{
+                listen: 'test',
+                script: {
+                    type: 'text/javascript',
+                    exec: ['console.log("Random");']
+                }
+            }, {
+                listen: 'prerequest',
+                script: {
+                    type: 'text/javascript',
+                    exec: ['console.log("A little less random");']
+                }
+            }]);
+        });
+    });
 });

--- a/test/unit/event-list.test.js
+++ b/test/unit/event-list.test.js
@@ -26,4 +26,46 @@ describe('EventList', function () {
             expect(EventList.isEventList()).to.be(false);
         });
     });
+
+    describe('#add', function () {
+        it('should correctly handle variadic script formats', function () {
+            var eventList = new EventList({}, [{
+                listen: 'test',
+                id: 'my-test-script-1',
+                script: {
+                    type: 'text/javascript',
+                    exec: 'console.log("hello");'
+                }
+            }]);
+
+            expect(eventList.toJSON()).to.eql([{
+                listen: 'test',
+                id: 'my-test-script-1',
+                script: {
+                    type: 'text/javascript',
+                    exec: ['console.log("hello");']
+                }
+            }]);
+
+            eventList.add({
+                listen: 'prerequest',
+                script: 'console.log("Nothing to see here, move along...");'
+            });
+
+            expect(eventList.toJSON()).to.eql([{
+                listen: 'test',
+                id: 'my-test-script-1',
+                script: {
+                    type: 'text/javascript',
+                    exec: ['console.log("hello");']
+                }
+            }, {
+                listen: 'prerequest',
+                script: {
+                    type: 'text/javascript',
+                    exec: ['console.log("Nothing to see here, move along...");']
+                }
+            }]);
+        });
+    });
 });

--- a/test/unit/script.test.js
+++ b/test/unit/script.test.js
@@ -18,6 +18,43 @@ describe('Script', function () {
         });
     });
 
+    describe('Variadic formats', function () {
+        it('should support non-wrapped strings', function () {
+            var script = new Script('console.log("This is a line of test script code");');
+
+            expect(script.toJSON()).to.eql({
+                type: 'text/javascript',
+                exec: ['console.log("This is a line of test script code");']
+            });
+        });
+
+        it('should support non-wrapped arrays', function () {
+            var script = new Script(['console.log("This is a line of test script code");']);
+
+            expect(script.toJSON()).to.eql({
+                type: 'text/javascript',
+                exec: ['console.log("This is a line of test script code");']
+            });
+        });
+    });
+
+    describe('.toSource', function () {
+        it('should correctly unparse an array of exec strings', function () {
+            var script = new Script({
+                type: 'text/javascript',
+                exec: ['console.log("Foo isn\'t bar!");']
+            });
+
+            expect(script.toSource()).to.be('console.log("Foo isn\'t bar!");');
+        });
+
+        it('should return undefined for a malformed script', function () {
+            var script = new Script({ type: 'text/javascript' });
+
+            expect(script.toSource()).to.be(undefined);
+        });
+    });
+
     describe('json representation', function () {
         it('must match what the script was initialized with', function () {
             var jsonified = script.toJSON();


### PR DESCRIPTION
This pull request allows scripts to be added in a more streamlined fashion:

Before:
```js
myCollection.events.add({
    listen: 'test',
    script: {
         exec: [
              "console.log('blah');",
              "test['hello world'] = true;"
         ]
    }
});
```

After:
```js
myCollection.events.add({
    listen: 'test',
    script: [
        "console.log('blah');",
        "test['hello world'] = true;"
    ]
});
```

**Note:** both formats are supported