### PR TITLE
Corrected disabled Query Param handling

### DIFF
--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -150,18 +150,20 @@ _.assign(QueryParam, /** @lends QueryParam */ {
             }, []);
         }
 
-        var encode = options && options.encode,
-            ignoreDisabled = options && options.ignoreDisabled,
+        var str,
+            encode = options && options.encode,
+            ignoreDisabled = options && options.ignoreDisabled;
 
-            // construct a query parameter string from the list, with considerations for disabled values
-            str = params.reduce(function (result, param) {
-                // If disabled parameters are to be ignored, bail out here
-                if (ignoreDisabled && param.disabled) { return result; }
+        // construct a query parameter string from the list, with considerations for disabled values
+        str = params.reduce(function (result, param) {
+            // If disabled parameters are to be ignored, bail out here
+            if (ignoreDisabled && (param.disabled === true)) { return result; }
 
-                result && (result += AMPERSAND);
+            // If the current unparsed result is non empty, append an ampersand
+            result && (result += AMPERSAND);
 
-                return result + QueryParam.unparseSingle(param, encode);
-            }, EMPTY);
+            return result + QueryParam.unparseSingle(param, encode);
+        }, EMPTY);
 
         encode && (str = str.replace(/%7B%7B/g, '{{').replace(/%7D%7D/g, '}}'));
 

--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -136,26 +136,34 @@ _.assign(QueryParam, /** @lends QueryParam */ {
      *
      * @param {Array|Object} params
      * @param {Object=} options
-     * @param {Boolean} options.encode - Enables URL encoding of the parameters
+     * @param {?Boolean} [options.encode=false] - Enables URL encoding of the parameters
+     * @param {?Boolean} [options.ignoreDisabled=false] - Removes disabled query parameters when set to true.
      * @returns {string}
      */
     unparse: function (params, options) {
-        var encode = options && options.encode,
-            str;
-
         if (!params) { return EMPTY; }
 
+        // Convert hash maps to an array of params
         if (!_.isArray(params) && !PropertyList.isPropertyList(params)) {
             params = _.transform(params, function (accumulator, value, key) {
                 accumulator.push({ key: key, value: value });
             }, []);
         }
 
-        str = params.map(function (param) {
-            return QueryParam.unparseSingle(param, encode);
-        }).join(AMPERSAND);
+        var encode = options && options.encode,
+            ignoreDisabled = options && options.ignoreDisabled,
 
-        (encode) && (str = str.replace(/%7B%7B/g, '{{')) && (str = str.replace(/%7D%7D/g, '}}'));
+            // construct a query parameter string from the list, with considerations for disabled values
+            str = params.reduce(function (result, param) {
+                // If disabled parameters are to be ignored, bail out here
+                if (ignoreDisabled && param.disabled) { return result; }
+
+                result && (result += AMPERSAND);
+
+                return result + QueryParam.unparseSingle(param, encode);
+            }, EMPTY);
+
+        encode && (str = str.replace(/%7B%7B/g, '{{').replace(/%7D%7D/g, '}}'));
 
         return str;
     },

--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -8,6 +8,10 @@ var _ = require('../util').lodash,
     STRING = 'string',
     EQUALS = '=',
     EMPTY = '',
+    BRACE_START = '{{',
+    BRACE_END = '}}',
+    REGEX_BRACE_START = /%7B%7B/g,
+    REGEX_BRACE_END = /%7D%7D/g,
 
     QueryParam;
 
@@ -144,6 +148,7 @@ _.assign(QueryParam, /** @lends QueryParam */ {
         if (!params) { return EMPTY; }
 
         // Convert hash maps to an array of params
+        // @todo: Consider stringifying here directly and bailing out for better performance
         if (!_.isArray(params) && !PropertyList.isPropertyList(params)) {
             params = _.transform(params, function (accumulator, value, key) {
                 accumulator.push({ key: key, value: value });
@@ -165,7 +170,7 @@ _.assign(QueryParam, /** @lends QueryParam */ {
             return result + QueryParam.unparseSingle(param, encode);
         }, EMPTY);
 
-        encode && (str = str.replace(/%7B%7B/g, '{{').replace(/%7D%7D/g, '}}'));
+        encode && (str = str.replace(REGEX_BRACE_START, BRACE_START).replace(REGEX_BRACE_END, BRACE_END));
 
         return str;
     },

--- a/test/unit/query-param.test.js
+++ b/test/unit/query-param.test.js
@@ -119,6 +119,88 @@ describe('QueryParam', function () {
         });
     });
 
+    describe('disabled-enabled states', function () {
+        // key is what the string representation should be, value is the parsed representation.
+        var testCases = [
+            {
+                ignore: {
+                    true: 'a=b',
+                    false: 'a=b&c=d'
+                },
+                list: [
+                    { key: 'a', value: 'b' },
+                    { key: 'c', value: 'd', disabled: true }
+                ]
+            },
+            {
+                ignore: {
+                    true: 'e=f',
+                    false: 'a=b&e=f'
+                },
+                list: [
+                    { key: 'a', value: 'b', disabled: true },
+                    { key: 'e', value: 'f' }
+                ]
+            },
+            {
+                ignore: {
+                    true: 'a=b&e=f',
+                    false: 'a=b&c=d&e=f'
+                },
+                list: [
+                    { key: 'a', value: 'b' },
+                    { key: 'c', value: 'd', disabled: true },
+                    { key: 'e', value: 'f' }
+                ]
+            },
+            {
+                ignore: {
+                    true: 'c=d',
+                    false: 'a=b&c=d&e=f'
+                },
+                list: [
+                    { key: 'a', value: 'b', disabled: true },
+                    { key: 'c', value: 'd' },
+                    { key: 'e', value: 'f', disabled: true }
+                ]
+            },
+            {
+                ignore: {
+                    true: 'u=v',
+                    false: 'u=v&w=x&y=z'
+                },
+                list: [
+                    { key: 'u', value: 'v' },
+                    { key: 'w', value: 'x', disabled: true },
+                    { key: 'y', value: 'z', disabled: true }
+                ]
+            },
+            {
+                ignore: {
+                    true: '',
+                    false: 'a=b&c=d&e=f'
+                },
+                list: [
+                    { key: 'a', value: 'b', disabled: true },
+                    { key: 'c', value: 'd', disabled: true },
+                    { key: 'e', value: 'f', disabled: true }
+                ]
+            }
+        ];
+
+        _.forEach(testCases, function (fixture) {
+            it(`should handle ${fixture.ignore.true || 'empty string'}, ignoreDisabled: true`, function () {
+                expect(QueryParam.unparse(fixture.list, {
+                    ignoreDisabled: true
+                })).to.eql(fixture.ignore.true);
+            });
+
+            it(`should handle ${fixture.ignore.false || 'empty string'}, ignoreDisabled: false`, function () {
+                expect(QueryParam.unparse(fixture.list)).to.eql(fixture.ignore.false);
+            });
+        });
+    });
+
     describe('encoding', function () {
         it('a=b{{c}}', function () {
             var parsed = [

--- a/test/unit/query-param.test.js
+++ b/test/unit/query-param.test.js
@@ -185,66 +185,72 @@ describe('QueryParam', function () {
         var testCases = [
             {
                 ignore: {
-                    true: 'a=b',
-                    false: 'a=b&c=d'
-                },
-                list: [
-                    { key: 'a', value: 'b' },
-                    { key: 'c', value: 'd', disabled: true }
-                ]
-            },
-            {
-                ignore: {
-                    true: 'e=f',
-                    false: 'a=b&e=f'
-                },
-                list: [
-                    { key: 'a', value: 'b', disabled: true },
-                    { key: 'e', value: 'f' }
-                ]
-            },
-            {
-                ignore: {
                     true: 'a=b&e=f',
                     false: 'a=b&c=d&e=f'
                 },
                 list: [
                     { key: 'a', value: 'b' },
                     { key: 'c', value: 'd', disabled: true },
+                    { key: 'e', value: 'f', disabled: 1 } // this is done to test the explicit true check
+                ]
+            },
+            {
+                ignore: {
+                    true: 'c=d&e=f',
+                    false: 'a=b&c=d&e=f'
+                },
+                list: [
+                    { key: 'a', value: 'b', disabled: true },
+                    { key: 'c', value: 'd', disabled: 1 },
                     { key: 'e', value: 'f' }
                 ]
             },
             {
                 ignore: {
-                    true: 'c=d',
-                    false: 'a=b&c=d&e=f'
+                    true: 'a=b&d=e&e=f',
+                    false: 'a=b&c=d&d=e&e=f'
+                },
+                list: [
+                    { key: 'a', value: 'b' },
+                    { key: 'c', value: 'd', disabled: true },
+                    { key: 'd', value: 'e', disabled: 1 },
+                    { key: 'e', value: 'f' }
+                ]
+            },
+            {
+                ignore: {
+                    true: 'c=d&g=h',
+                    false: 'a=b&c=d&e=f&g=h'
                 },
                 list: [
                     { key: 'a', value: 'b', disabled: true },
                     { key: 'c', value: 'd' },
-                    { key: 'e', value: 'f', disabled: true }
+                    { key: 'e', value: 'f', disabled: true },
+                    { key: 'g', value: 'h', disabled: 1 }
                 ]
             },
             {
                 ignore: {
-                    true: 'u=v',
-                    false: 'u=v&w=x&y=z'
+                    true: 'u=v&a=b',
+                    false: 'u=v&w=x&y=z&a=b'
                 },
                 list: [
                     { key: 'u', value: 'v' },
                     { key: 'w', value: 'x', disabled: true },
-                    { key: 'y', value: 'z', disabled: true }
+                    { key: 'y', value: 'z', disabled: true },
+                    { key: 'a', value: 'b', disabled: 1 }
                 ]
             },
             {
                 ignore: {
-                    true: '',
-                    false: 'a=b&c=d&e=f'
+                    true: 'g=h',
+                    false: 'a=b&c=d&e=f&g=h'
                 },
                 list: [
                     { key: 'a', value: 'b', disabled: true },
                     { key: 'c', value: 'd', disabled: true },
-                    { key: 'e', value: 'f', disabled: true }
+                    { key: 'e', value: 'f', disabled: true },
+                    { key: 'g', value: 'h', disabled: 1 }
                 ]
             }
         ];


### PR DESCRIPTION
With this pull request, a query param list with one or more disabled query params will be correctly converted to it's string equivalent.

This takes care of https://github.com/postmanlabs/newman/issues/1114, https://github.com/postmanlabs/postman-app-support/issues/3361 and #415