### PR TITLE
Better VariableScope layers

### DIFF
--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -82,9 +82,9 @@ _.inherit((
         // in above line, we clone the values if it is already a list. there is no point directly using the instance of
         // a variable list since one cannot be created with a parent reference to begin with.
 
-        this._layers = [];
-
         if (layers) {
+            this._layers = [];
+
             for (i = 0, ii = layers.length; i < ii; i++) {
                 VariableList.isVariableList(layers[i]) && this._layers.push(layers[i]);
             }
@@ -141,7 +141,7 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      */
     toObject: function (excludeDisabled, caseSensitive) {
         // if the scope has no layers, we simply export the contents of primary store
-        if (_.isEmpty(this._layers)) {
+        if (!this._layers) {
             return this.values.toObject(excludeDisabled, caseSensitive);
         }
 
@@ -178,7 +178,7 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
             ii;
 
         // if a variable does not exist in local scope, we search all the layers and return the first occurrence.
-        if (!(variable || _.isEmpty(this._layers))) {
+        if (!(variable || !this._layers)) {
             for (i = 0, ii = this._layers.length; i < ii; i++) {
                 variable = this._layers[i].one(key);
                 if (variable) { break; }
@@ -286,6 +286,7 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
             return;
         }
 
+        !this._layers && (this._layers = []); // lazily initialize layers
         this._layers.push(list);
     }
 });

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -17,6 +17,7 @@ describe('VariableScope', function () {
         expect(scope.id).be.ok();
 
         expect(scope).have.property('values');
+        expect(scope).to.not.have.property('_layers');
         expect(VariableList.isVariableList(scope.values)).be.ok();
         expect(scope.values.__parent).be(scope);
     });
@@ -33,6 +34,7 @@ describe('VariableScope', function () {
         expect(scope).have.property('id');
         expect(scope.id).be.ok();
         expect(scope).have.property('values');
+        expect(scope).to.not.have.property('_layers');
         expect(scope.values.count()).be(2);
 
         // check whether the
@@ -60,6 +62,7 @@ describe('VariableScope', function () {
         expect(scope).have.property('id');
         expect(scope.id).be('test-scope-id');
         expect(scope).have.property('values');
+        expect(scope).to.not.have.property('_layers');
         expect(scope.values.count()).be(2);
 
         expect(scope.values.idx(0) instanceof Variable).be.ok();
@@ -84,6 +87,7 @@ describe('VariableScope', function () {
         expect(scope.name).be('my-environment');
 
         expect(scope).have.property('values');
+        expect(scope).to.not.have.property('_layers');
         expect(VariableList.isVariableList(scope.values)).be.ok();
         expect(scope.values.count()).be(0);
     });
@@ -467,7 +471,7 @@ describe('VariableScope', function () {
             var scope = new VariableScope(layerOne);
             scope.addLayer([]);
 
-            expect(scope._layers).to.be.empty(1);
+            expect(scope).to.not.have.property('_layers');
         });
     });
 
@@ -504,13 +508,12 @@ describe('VariableScope', function () {
             var scope = new VariableScope({}, [layerOne, layerTwo]),
                 scopeOne = new VariableScope({}, undefined);
 
-
             expect(scope._layers.length).to.be(2);
             scope._layers.forEach(function (list) {
                 expect(VariableList.isVariableList(list)).to.be(true);
             });
 
-            expect(scopeOne._layers.length).to.be(0);
+            expect(scopeOne).to.not.have.property('_layers');
         });
 
         it('the additional variable list is cast to an array if it is not already', function () {


### PR DESCRIPTION
With this pull request, the `_layers` property is only initialized to a blank array on demand. It was an empty array by default earlier.

Code coverage remains at 98%, same as before.