### PR TITLE
Renamed the property _postman_requiresId to _postman_propertyRequiresId

### DIFF
--- a/lib/collection/certificate.js
+++ b/lib/collection/certificate.js
@@ -65,7 +65,7 @@ _.assign(Certificate.prototype, /** @lends Certificate.prototype */ {
      * Ensure all object have id
      * @private
      */
-    _postman_requiresId: true,
+    _postman_propertyRequiresId: true,
 
     /**
      * Updates the certificate with the given properties.

--- a/lib/collection/item-group.js
+++ b/lib/collection/item-group.js
@@ -164,7 +164,7 @@ _.assign(ItemGroup.prototype, /** @lends ItemGroup.prototype */ {
      * @private
      * @readonly
      */
-    _postman_requiresId: true,
+    _postman_propertyRequiresId: true,
 
     /**
      * Calls the callback for each item belonging to itself. If any ItemGroups are encountered,

--- a/lib/collection/item.js
+++ b/lib/collection/item.js
@@ -131,7 +131,7 @@ _.assign(Item.prototype, /** @lends Item.prototype */ {
      * @readOnly
      * @type {Boolean}
      */
-    _postman_requiresId: true,
+    _postman_propertyRequiresId: true,
 
     /**
      * Fetches applicable AuthType from the current item.

--- a/lib/collection/property.js
+++ b/lib/collection/property.js
@@ -48,7 +48,8 @@ _.inherit((
 
         // first we extract id from all possible sources
         // we also check if this property is marked to require an ID, we generate one if not found.
-        id = (src && src.id) || this.id || (this._ && this._.postman_id) || (this._postman_requiresId && uuid.v4());
+        id = (src && src.id) || this.id || (this._ && this._.postman_id) || (this._postman_propertyRequiresId &&
+            uuid.v4());
 
         /**
          * The `id` of the property is a unique string that identifies this property and can be used to refer to

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -98,7 +98,7 @@ _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
      * @readOnly
      * @type {Boolean}
      */
-    _postman_requiresId: true,
+    _postman_propertyRequiresId: true,
 
     /**
      * Updates the properties of the proxy object based on the options provided.

--- a/lib/collection/response.js
+++ b/lib/collection/response.js
@@ -221,7 +221,7 @@ _.assign(Response.prototype, /** @lends Response.prototype */ {
      * @private
      * @readOnly
      */
-    _postman_requiresId: true,
+    _postman_propertyRequiresId: true,
 
     /**
      * Convert this response into a JSON serialisable object. The _details meta property is omitted.

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -98,7 +98,7 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      * @readOnly
      * @type {String}
      */
-    _postman_requiresId: true,
+    _postman_propertyRequiresId: true,
 
     /**
      * @deprecated since v1.2.5.*


### PR DESCRIPTION
This is to be standard / convention compliant with rest of the meta property names.

- did a find and replace across entire folder
- installed this module in postman-runtime with this change and test passed
- installed this module in postman-sandbox with this change and test passed