### PR TITLE
Updated RequestAuth schema for v2.1.0 compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Postman Collection SDK Changelog
 
+#### v2.1.3 (August 28, 2017)
+* :bug: Added an option to ignore disabled parameters in `QueryParam.unparse` #429
+* :bug: Ensured that all `_.get` calls use valid and sane fallback values. #444
+* :bug: Ensured that empty hosts don't cause an exception in `Url~getHost`. #443
+
 #### v2.1.2 (August 21, 2017)
 * Renamed the property `_postman_requiresId` to `_postman_propertyRequiresId` in order to be standard compliant #441
 

--- a/lib/schema/auth.json
+++ b/lib/schema/auth.json
@@ -17,155 +17,551 @@
             ]
         },
         "awsv4": {
-            "type": "object",
-            "properties": {
-                "accessKey": {
-                    "type": "string"
-                },
-                "secretKey": {
-                    "type": "string"
-                },
-                "region": {
-                    "type": "string"
-                },
-                "service": {
-                    "type": "string"
-                }
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["accessKey"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["secretKey"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["region"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["service"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
             }
         },
         "basic": {
-            "type": "object",
-            "properties": {
-                "username": {
-                    "type": "string"
-                },
-                "password": {
-                    "type": "string"
-                }
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["username"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["password"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
             }
         },
         "digest": {
-            "type": "object",
-            "properties": {
-                "username": {
-                    "type": "string"
-                },
-                "realm": {
-                    "type": "string"
-                },
-                "password": {
-                    "type": "string"
-                },
-                "nonce": {
-                    "type": "string"
-                },
-                "nonceCount": {
-                    "type": "string"
-                },
-                "algorithm": {
-                    "type": "string"
-                },
-                "qop": {
-                    "type": "string"
-                },
-                "clientNonce": {
-                    "type": "string"
-                }
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["username"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["realm"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["password"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["nonce"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["nonceCount"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["algorithm"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["qop"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["opaque"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["clientNonce"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
             }
         },
         "hawk": {
-            "type": "object",
-            "properties": {
-                "authId": {
-                    "type": "string"
-                },
-                "authKey": {
-                    "type": "string"
-                },
-                "algorithm": {
-                    "type": "string"
-                },
-                "user": {
-                    "type": "string"
-                },
-                "nonce": {
-                    "type": "string"
-                },
-                "extraData": {
-                    "type": "string"
-                },
-                "appId": {
-                    "type": "string"
-                },
-                "delegation": {
-                    "type": "string"
-                }
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["authId"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["authKey"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["algorithm"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["user"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["nonce"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["extraData"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["appId"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["delegation"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["timestamp"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
             }
         },
         // Allow anything in No auth
         "noauth": {},
         "oauth1": {
-            "type": "object",
-            "properties": {
-                "consumerKey": {
-                    "type": "string"
-                },
-                "consumerSecret": {
-                    "type": "string"
-                },
-                "token": {
-                    "type": "string"
-                },
-                "tokenSecret": {
-                    "type": "string"
-                },
-                "signatureMethod": {
-                    "type": "string"
-                },
-                "timestamp": {
-                    "type": "string"
-                },
-                "nonce": {
-                    "type": "string"
-                },
-                "version": {
-                    "type": "string"
-                },
-                "realm": {
-                    "type": "string"
-                },
-                "encodeOAuthSign": {
-                    "type": "string"
-                }
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["consumerKey"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["consumerSecret"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["token"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["tokenSecret"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["signatureMethod"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["timestamp"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["nonce"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["version"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["realm"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["encodeOAuthSign"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
             }
         },
         "oauth2": {
-            "type": "object",
-            "properties": {
-                "addTokenTo": {
-                    "type": "string"
-                },
-                "callBackUrl": {
-                    "type": "string"
-                },
-                "authUrl": {
-                    "type": "string"
-                },
-                "accessTokenUrl": {
-                    "type": "string"
-                },
-                "clientId": {
-                    "type": "string"
-                },
-                "clientSecret": {
-                    "type": "string"
-                },
-                "scope": {
-                    "type": "string"
-                },
-                "requestAccessTokenLocally": {
-                    "type": "string"
-                }
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["addTokenTo"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["callBackUrl"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["authUrl"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["accessTokenUrl"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["clientId"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["clientSecret"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["scope"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "key": {
+                                "type": "string",
+                                "enum": ["requestAccessTokenLocally"]
+                            },
+                            "value": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
             }
         }
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "postman-collection",
   "description": "Enables developers to use a unified Postman Collection format Object across projects",
   "author": "Postman Labs <help@getpostman.com>",
-  "version": "2.1.3-beta.1",
+  "version": "2.1.3",
   "keywords": [
     "postman"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "postman-collection",
   "description": "Enables developers to use a unified Postman Collection format Object across projects",
   "author": "Postman Labs <help@getpostman.com>",
-  "version": "2.1.2",
+  "version": "2.1.3-beta.1",
   "keywords": [
     "postman"
   ],


### PR DESCRIPTION
With this pull request, request auth schema has changed from:
```json
{
  "type": "basic",
  "basic": {
    "username": "foo",
    "password": "bar"
  }
}
```

to:
```json
{
  "type": "basic",
  "basic": [
    { "key": "username", "value": "foo" },
    { "key": "password", "value": "bar" }
  ]
}
```

Related to #446 