### PR TITLE
Adds support for system property

### DIFF
--- a/lib/collection/variable.js
+++ b/lib/collection/variable.js
@@ -150,6 +150,7 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
         // @note that we cannot update the key, once created during construction
         options.hasOwnProperty('type') && this.valueType(options.type, options.hasOwnProperty('value'));
         options.hasOwnProperty('value') && this.set(options.value);
+        options.hasOwnProperty('system') && (this.system = options.system);
     }
 });
 

--- a/test/unit/variable.test.js
+++ b/test/unit/variable.test.js
@@ -8,19 +8,43 @@ describe('Variable', function () {
 
         expect(v.value).to.be(undefined);
         expect(v.type).to.be('any');
+    });
+
+    it('should initialize variable with correct system value', function () {
+        var v = new Variable();
         expect(v.system).to.be(undefined);
+
+        v = new Variable({
+            system: true
+        });
+        expect(v.system).to.be(true);
+
+        v = new Variable({
+            system: false
+        });
+        expect(v.system).to.be(false);
+    });
+
+    it('should update the sytem property of a variable', function () {
+        var v = new Variable();
+        v.update({ system: true });
+        expect(v.system).to.be(true);
+
+        v = new Variable({
+            system: true
+        });
+        v.update({ system: false });
+        expect(v.system).to.be(false);
     });
 
     it('should prepopulate value and type when passed to the constructor', function () {
         var v = new Variable({
             value: 'Picard',
-            type: 'string',
-            system: true
+            type: 'string'
         });
 
         expect(v.value).to.be('Picard');
         expect(v.type).to.be('string');
-        expect(v.system).to.be(true);
     });
 
     it('should typecast value during construction when type is provided', function () {

--- a/test/unit/variable.test.js
+++ b/test/unit/variable.test.js
@@ -8,16 +8,19 @@ describe('Variable', function () {
 
         expect(v.value).to.be(undefined);
         expect(v.type).to.be('any');
+        expect(v.system).to.be(undefined);
     });
 
     it('should prepopulate value and type when passed to the constructor', function () {
         var v = new Variable({
             value: 'Picard',
-            type: 'string'
+            type: 'string',
+            system: true
         });
 
         expect(v.value).to.be('Picard');
         expect(v.type).to.be('string');
+        expect(v.system).to.be(true);
     });
 
     it('should typecast value during construction when type is provided', function () {


### PR DESCRIPTION
- Removed the special handling of this system property from header.js
- Added at the base level in Property.js, so that it's available to other derived classes