### PR TITLE
Feature/fix object var resolution

### DIFF
--- a/lib/collection/property.js
+++ b/lib/collection/property.js
@@ -143,28 +143,36 @@ _.assign(Property.prototype, /** @lends Property.prototype */ {
      *
      * @private
      * @draft
-     * @param {?VariableList=} [variables] - One can specifically provide a VariableList for doing the substitution. In
+     * @param {?Item|ItemGroup=} [scope] - One can specifically provide an item or group with `.variables`. In
      * the event one is not provided, the variables are taken from this object or one from the parent tree.
      * @param {Array<Object>} overrides - additional objects to lookup for variable values
      * @returns {Object|undefined}
      * @throws {Error} If `variables` cannot be resolved up the parent chain.
      */
-    toObjectResolved: function (variables, overrides) {
-        var variableSourceObj = this;
+    toObjectResolved: function (scope, overrides) {
+        // 1. if variables is passed as params, use it or fall back to oneself
+        // 2. for a source from point (1), and look for `.variables`
+        // 3. if `.variables` is not found, then rise up the parent to find first .variables
 
-        // We see if variables can be found in this object itself.
-        !variables && (variables = variableSourceObj.variables);
+        var variableSourceObj = scope || this,
+            variables,
+            reference;
 
-        // We then check if variables can be procured from the parent tree
-        while ((variableSourceObj = variableSourceObj.__parent)) {
+        do {
             variables = variableSourceObj.variables;
-        }
+            variableSourceObj = variableSourceObj.__parent;
+        } while (!variables && variableSourceObj);
+
 
         if (!variables) { // worst case = no variable param and none detected in tree or object
             throw Error('Unable to resolve variables. Require a List type property for variable auto resolution.');
         }
 
-        return variables.substitute(this.toJSON(), overrides);
+        // ensure you do not substitute variables itself!
+        reference = this.toJSON();
+        _.isArray(reference.variable) && (delete reference.variable);
+
+        return variables.substitute(reference, overrides);
     }
 });
 

--- a/lib/collection/variable-list.js
+++ b/lib/collection/variable-list.js
@@ -41,7 +41,22 @@ _.assign(VariableList.prototype, /** @lends VariableList.prototype */ {
      * @returns {Array|Object}
      */
     substitute: function (obj, overrides, mutate) {
-        return Property.replaceSubstitutionsIn(obj, _.union([this], overrides), mutate);
+        var resolutionQueue = [], // we use this to store the queue of variable hierarchy
+
+            // this is an intermediate object to stimulate a property (makes the do-while loop easier)
+            variableSource = {
+                variables: this,
+                __parent: this.__parent
+            };
+
+        do { // iterate and accumulate as long as you find `.variables` in parent tree
+            variableSource.variables && resolutionQueue.push(variableSource.variables);
+            variableSource = variableSource.__parent;
+        } while (variableSource);
+
+        variableSource = null; // cautious cleanup
+
+        return Property.replaceSubstitutionsIn(obj, _.union(resolutionQueue, overrides), mutate);
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "marked": "0.3.6",
     "mime-format": "2.0.0",
     "mime-types": "2.1.17",
-    "node-oauth1": "1.2.1",
     "sanitize-html": "1.14.1",
     "semver": "5.4.1",
     "uuid": "3.1.0",

--- a/test/unit/property.test.js
+++ b/test/unit/property.test.js
@@ -35,19 +35,138 @@ describe('Property', function () {
             expect(property.toObjectResolved.bind(property)).to.throwError();
         });
 
-        it('should resolve properties correctly', function () {
+        it('should resolve and exclude its own .variables', function () {
             var property = new Property(),
                 parent = new Property();
 
-            parent.variables = new VariableList();
-            property.variables = new VariableList({}, [{ key: 'alpha', value: 'foo' }, { key: 'beta', value: 'bar' }]);
+            parent.variables = new VariableList(parent);
+            property.variables = new VariableList(property, [
+                { key: 'alpha', value: 'foo' },
+                { key: 'beta', value: 'bar' }
+            ]);
 
             property.setParent(parent);
+            expect(property.toObjectResolved()).to.eql({});
+        });
+
+        it('should resolve variables defined in its own tree, up one parent', function () {
+            var property = new Property(),
+                parent = new Property();
+
+            parent.variables = new VariableList(parent, [{
+                key: 'var1',
+                value: 'parent-value-1'
+            }, {
+                key: 'var2',
+                value: 'parent-value-2'
+            }]);
+
+            property.setParent(parent);
+            property.testProp1 = 'substituted-{{var1}}';
+            property.testProp2 = 'substituted-{{var2}}';
+
             expect(property.toObjectResolved()).to.eql({
-                variable: [
-                    { type: 'any', value: 'foo', key: 'alpha' },
-                    { type: 'any', value: 'bar', key: 'beta' }
-                ]
+                testProp1: 'substituted-parent-value-1',
+                testProp2: 'substituted-parent-value-2'
+            });
+        });
+
+        it('should resolve variables defined in its own tree, stored within itself', function () {
+            var property = new Property(),
+                parent = new Property();
+
+            property.variables = new VariableList(property, [{
+                key: 'var1',
+                value: 'child-value-1'
+            }]);
+
+            parent.variables = new VariableList(parent, [{
+                key: 'var1',
+                value: 'parent-value-1'
+            }, {
+                key: 'var2',
+                value: 'parent-value-2'
+            }]);
+
+            property.setParent(parent);
+            property.testProp1 = 'substituted-{{var1}}';
+            property.testProp2 = 'substituted-{{var2}}';
+
+            expect(property.toObjectResolved()).to.eql({
+                testProp1: 'substituted-child-value-1',
+                testProp2: 'substituted-parent-value-2'
+            });
+        });
+
+        it('should resolve variables defined in a reference property', function () {
+            var property = new Property(),
+                parent = new Property(),
+                childServices = new Property();
+
+            property.variables = new VariableList(property, [{
+                key: 'var1',
+                value: 'child-value-1'
+            }]);
+
+            parent.variables = new VariableList(parent, [{
+                key: 'var1',
+                value: 'parent-value-1'
+            }, {
+                key: 'var2',
+                value: 'parent-value-2'
+            }]);
+
+            property.setParent(parent);
+            property.testProp1 = 'substituted-{{var1}}';
+            property.testProp2 = 'substituted-{{var2}}';
+
+            childServices.variables = new VariableList(childServices, [{
+                key: 'var1',
+                value: 'external-value-1'
+            }, {
+                key: 'var2',
+                value: 'external-value-2'
+            }]);
+
+            expect(property.toObjectResolved(childServices)).to.eql({
+                testProp1: 'substituted-external-value-1',
+                testProp2: 'substituted-external-value-2'
+            });
+        });
+
+        it('should resolve variables defined in a reference property and ride up its tree', function () {
+            var property = new Property(),
+                parent = new Property(),
+                orphan = new Property();
+
+            property.variables = new VariableList(property, [{
+                key: 'var1',
+                value: 'child-value-1'
+            }]);
+
+            parent.variables = new VariableList(parent, [{
+                key: 'var1',
+                value: 'parent-value-1'
+            }, {
+                key: 'var2',
+                value: 'parent-value-2'
+            }]);
+
+            property.setParent(parent);
+
+            orphan.testProp1 = 'substituted-{{var1}}';
+            orphan.testProp2 = 'substituted-{{var2}}';
+            orphan.variables = new VariableList(orphan, [{
+                key: 'var1',
+                value: 'orphan-value-1'
+            }, {
+                key: 'var2',
+                value: 'orphan-value-2'
+            }]);
+
+            expect(orphan.toObjectResolved(property)).to.eql({
+                testProp1: 'substituted-child-value-1',
+                testProp2: 'substituted-parent-value-2'
             });
         });
     });


### PR DESCRIPTION
1. Modified `.toObjectResolved` to actually work with a tree (and a reference tree)
2. Updated variable substitution function to gather all variable lists up a tree