### PR TITLE
Made .nsprc have package version information in order to avoid packag…

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,4 +1,6 @@
 {
   "exceptions": [],
-  "exclusions": ["marked"]
+  "exclusions": {
+    "marked": "0.3.6"
+  }
 }

--- a/npm/test-system.js
+++ b/npm/test-system.js
@@ -70,7 +70,7 @@ module.exports = function (exit) {
                 offline: false,
                 package: {
                     name: pkg.name,
-                    dependencies: _.omit(pkg.dependencies, nsprc.exclusions || [])
+                    dependencies: _.omit(pkg.dependencies, _.keys(nsprc.exclusions))
                 }
             }, function (err, result) {
                 // if processing nsp had an error, simply print that and exit

--- a/test/system/nsprc.test.js
+++ b/test/system/nsprc.test.js
@@ -3,7 +3,8 @@
  */
 
 var expect = require('expect.js'),
-    fs = require('fs');
+    fs = require('fs'),
+    _ = require('lodash');
 
 /* global describe, it, before */
 describe('nsprc', function () {
@@ -21,7 +22,14 @@ describe('nsprc', function () {
         expect(nsprc.exceptions).to.eql([]);
     });
 
-    it('must exclude only a known set of packages', function () {
-        expect(nsprc.exclusions).to.eql(['marked']);
+    it('must exclude only a known set of packages (prevent erroneous exclusions)', function () {
+        expect(nsprc.exclusions).to.eql({
+            marked: '0.3.6'
+        });
+    });
+
+    it('dependency version in package.json should match .nsprc (time to remove exclusion?)', function () {
+        var pkg = _.pick(require('../../package').dependencies, _.keys(nsprc.exclusions));
+        expect(pkg).to.eql(nsprc.exclusions);
     });
 });


### PR DESCRIPTION
…es from being permanently muted.

This ensures when the package is updated in package.json, these tests are revisited and nsp exclusion is revisited.