### PR TITLE
Reverses the order of layer resolution 

### DIFF
--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -146,10 +146,9 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
         }
 
         var mergedLayers = {},
-            i,
-            ii;
+            i;
 
-        for (i = 0, ii = this._layers.length; i < ii; i++) {
+        for (i = this._layers.length - 1; i >= 0; i--) {
             _.assign(mergedLayers, this._layers[i].toObject(excludeDisabled, caseSensitive));
         }
 

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -145,12 +145,11 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
             return this.values.toObject(excludeDisabled, caseSensitive);
         }
 
-        var mergedLayers = {},
-            i;
+        var mergedLayers = {};
 
-        for (i = this._layers.length - 1; i >= 0; i--) {
-            _.assign(mergedLayers, this._layers[i].toObject(excludeDisabled, caseSensitive));
-        }
+        _.forEachRight(this._layers, function (layer) {
+            _.assign(mergedLayers, layer.toObject(excludeDisabled, caseSensitive));
+        });
 
         return _.assign(mergedLayers, this.values.toObject(excludeDisabled, caseSensitive));
     },

--- a/test/unit/url-match-pattern.test.js
+++ b/test/unit/url-match-pattern.test.js
@@ -11,7 +11,7 @@ var expect = require('expect.js'),
     runningOnTravis = process.env.TRAVIS, // eslint-disable-line no-process-env
 
     // to skip particular tests when running on travis with node version 4.x
-    travisNodeV4Skip = (runningOnTravis && nodeVersion.match(/^v4./)) ? describe.skip : describe,
+    travisNodeV4Skip = (runningOnTravis && nodeVersion === '4') ? describe.skip : describe,
 
     // Run tests for Url matching on test method of a given target
     // Reason for doing this here is, so the same tests can be run on

--- a/test/unit/url-match-pattern.test.js
+++ b/test/unit/url-match-pattern.test.js
@@ -7,12 +7,6 @@ var expect = require('expect.js'),
         return new UrlMatchPattern(matchPatternString);
     },
 
-    nodeVersion = process.env.TRAVIS_NODE_VERSION, // eslint-disable-line no-process-env
-    runningOnTravis = process.env.TRAVIS, // eslint-disable-line no-process-env
-
-    // to skip particular tests when running on travis with node version 4.x
-    travisNodeV4Skip = (runningOnTravis && nodeVersion === '4') ? describe.skip : describe,
-
     // Run tests for Url matching on test method of a given target
     // Reason for doing this here is, so the same tests can be run on
     // UrlMatchPattern and UrlMatchPatternList
@@ -143,7 +137,7 @@ describe('UrlMatchPattern', function () {
             expect(convertedPattern).to.eql(/^.*foo$/);
         });
 
-        travisNodeV4Skip('security', function () {
+        describe('security', function () {
             describe('ReDoS', function () {
                 this.timeout(1500);
 

--- a/test/unit/url-match-pattern.test.js
+++ b/test/unit/url-match-pattern.test.js
@@ -7,6 +7,12 @@ var expect = require('expect.js'),
         return new UrlMatchPattern(matchPatternString);
     },
 
+    nodeVersion = process.env.TRAVIS_NODE_VERSION, // eslint-disable-line no-process-env
+    runningOnTravis = process.env.TRAVIS, // eslint-disable-line no-process-env
+
+    // to skip particular tests when running on travis with node version 4.x
+    travisNodeV4Skip = (runningOnTravis && nodeVersion.match(/^v4./)) ? describe.skip : describe,
+
     // Run tests for Url matching on test method of a given target
     // Reason for doing this here is, so the same tests can be run on
     // UrlMatchPattern and UrlMatchPatternList
@@ -137,7 +143,7 @@ describe('UrlMatchPattern', function () {
             expect(convertedPattern).to.eql(/^.*foo$/);
         });
 
-        describe('security', function () {
+        travisNodeV4Skip('security', function () {
             describe('ReDoS', function () {
                 this.timeout(1500);
 

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -3,12 +3,7 @@ var expect = require('expect.js'),
     Url = require('../../').Url,
     PropertyList = require('../../').PropertyList,
     VariableList = require('../../').VariableList,
-    rawUrls = require('../fixtures/').rawUrls,
-
-    nodeVersion = process.env.TRAVIS_NODE_VERSION, // eslint-disable-line no-process-env
-    runningOnTravis = process.env.TRAVIS, // eslint-disable-line no-process-env
-    // to skip particular tests when running on travis with node version 4.x
-    travisNodeV4Skip = (runningOnTravis && nodeVersion === '4') ? describe.skip : describe;
+    rawUrls = require('../fixtures/').rawUrls;
 
 /* global describe, it */
 describe('Url', function () {
@@ -811,7 +806,9 @@ describe('Url', function () {
     });
 
     describe('Security', function () {
-        travisNodeV4Skip('ReDoS', function () {
+        // This test fails on travis when running on node v4.x, so skipping it
+        (process.env.TRAVIS && process.env.TRAVIS_NODE_VERSION === '4' ? // eslint-disable-line no-process-env
+            describe.skip : describe)('ReDoS', function () {
             // as per NSP guidelines, anything that blocks the event loop for a second or more is a potential DOS threat
             this.timeout(2000);
 

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -3,7 +3,12 @@ var expect = require('expect.js'),
     Url = require('../../').Url,
     PropertyList = require('../../').PropertyList,
     VariableList = require('../../').VariableList,
-    rawUrls = require('../fixtures/').rawUrls;
+    rawUrls = require('../fixtures/').rawUrls,
+
+    nodeVersion = process.env.TRAVIS_NODE_VERSION, // eslint-disable-line no-process-env
+    runningOnTravis = process.env.TRAVIS, // eslint-disable-line no-process-env
+    // to skip particular tests when running on travis with node version 4.x
+    travisNodeV4Skip = (runningOnTravis && nodeVersion === '4') ? describe.skip : describe;
 
 /* global describe, it */
 describe('Url', function () {
@@ -806,7 +811,7 @@ describe('Url', function () {
     });
 
     describe('Security', function () {
-        describe('ReDOS', function () {
+        travisNodeV4Skip('ReDoS', function () {
             // as per NSP guidelines, anything that blocks the event loop for a second or more is a potential DOS threat
             this.timeout(2000);
 

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -642,22 +642,71 @@ describe('VariableScope', function () {
             });
         });
 
-        it('gives local scope highest order of precedence when resolving layers', function () {
-            var localValues = [{
-                    key: 'key3',
-                    value: 'val3'
+        it('gives correct order of precedence for "overrides" when resolving layers', function () {
+            var globalValues = [{
+                    key: 'foo',
+                    value: '1'
                 }, {
-                    key: 'key1',
-                    value: 'duplicated_key'
+                    key: 'bar',
+                    value: '1'
+                }, {
+                    key: 'baz',
+                    value: '1'
                 }],
-                globalScope = new VariableList(null, keyVals[0]),
-                envScope = new VariableList(null, keyVals[1]),
-                localScope = new VariableScope(localValues, [envScope, globalScope]);
+                localValues = [{
+                    key: 'bar',
+                    value: '2'
+                }, {
+                    key: 'baz',
+                    value: '2'
+                }],
+                envValues = [{
+                    key: 'baz',
+                    value: '3'
+                }],
+                globalScope = new VariableList(null, globalValues),
+                envScope = new VariableList(null, envValues),
+                localScope = new VariableList(null, localValues),
+                variableScope = new VariableScope(null, [envScope, localScope, globalScope]);
 
-            expect(localScope.toObject()).to.eql({
-                'key1': 'duplicated_key',
-                'key2': 'val2',
-                'key3': 'val3'
+            expect(variableScope.toObject()).to.eql({
+                'foo': '1',
+                'bar': '2',
+                'baz': '3'
+            });
+        });
+
+        it('"definition" should take the highest precedence when resolving layers', function () {
+            var globalValues = [{
+                    key: 'foo',
+                    value: '1'
+                }, {
+                    key: 'bar',
+                    value: '1'
+                }, {
+                    key: 'baz',
+                    value: '1'
+                }],
+                localValues = [{
+                    key: 'bar',
+                    value: '2'
+                }, {
+                    key: 'baz',
+                    value: '2'
+                }],
+                envValues = [{
+                    key: 'baz',
+                    value: '3'
+                }],
+                globalScope = new VariableList(null, globalValues),
+                envScope = new VariableList(null, envValues),
+                localScope = new VariableList(null, localValues),
+                variableScope = new VariableScope(envScope, [localScope, globalScope]);
+
+            expect(variableScope.toObject()).to.eql({
+                'foo': '1',
+                'bar': '2',
+                'baz': '3'
             });
         });
     });


### PR DESCRIPTION
while performing  `variableScope#toObject`

This was a bug since `variableScope#get` gives the first argument more precedence 