### PR TITLE
Add `ignoreOwnVariables` option to `Property.prototype.toObjectResolved`

### DIFF
--- a/lib/collection/property.js
+++ b/lib/collection/property.js
@@ -141,36 +141,54 @@ _.assign(Property.prototype, /** @lends Property.prototype */ {
     /**
      * Returns an object representation of the Property with its variable references substituted.
      *
+     * @example <caption>Resolve an object using variable definitions from itself and its parents</caption>
+     * property.toObjectResolved();
+     *
+     * @example <caption>Resolve an object using variable definitions on a different object</caption>
+     * property.toObjectResolved(item);
+     *
+     * @example <caption>Resolve an object using variables definitions as a flat list of variables</caption>
+     * property.toObjectResolved(null, [variablesDefinition1, variablesDefinition1], {ignoreOwnVariables: true});
+     *
      * @private
      * @draft
      * @param {?Item|ItemGroup=} [scope] - One can specifically provide an item or group with `.variables`. In
      * the event one is not provided, the variables are taken from this object or one from the parent tree.
      * @param {Array<Object>} overrides - additional objects to lookup for variable values
+     * @param {Object} [options]
+     * @param {Boolean} [options.ignoreOwnVariables] - if set to true, `.variables` on self(or scope)
+     * will not be used for variable resolution. Only variables in `overrides` will be used for resolution.
      * @returns {Object|undefined}
      * @throws {Error} If `variables` cannot be resolved up the parent chain.
      */
-    toObjectResolved: function (scope, overrides) {
-        // 1. if variables is passed as params, use it or fall back to oneself
-        // 2. for a source from point (1), and look for `.variables`
-        // 3. if `.variables` is not found, then rise up the parent to find first .variables
-
-        var variableSourceObj = scope || this,
+    toObjectResolved: function (scope, overrides, options) {
+        var ignoreOwnVariables = options && options.ignoreOwnVariables,
+            variableSourceObj,
             variables,
             reference;
 
+        // ensure you do not substitute variables itself!
+        reference = this.toJSON();
+        _.isArray(reference.variable) && (delete reference.variable);
+
+        // if `ignoreScopeVariables` is turned on, ignore `.variables` and resolve with only `overrides`
+        // otherwise find `.variables` on current object or `scope`
+        if (ignoreOwnVariables) {
+            return Property.replaceSubstitutionsIn(reference, overrides);
+        }
+
+        // 1. if variables is passed as params, use it or fall back to oneself
+        // 2. for a source from point (1), and look for `.variables`
+        // 3. if `.variables` is not found, then rise up the parent to find first .variables
+        variableSourceObj = scope || this;
         do {
             variables = variableSourceObj.variables;
             variableSourceObj = variableSourceObj.__parent;
         } while (!variables && variableSourceObj);
 
-
         if (!variables) { // worst case = no variable param and none detected in tree or object
             throw Error('Unable to resolve variables. Require a List type property for variable auto resolution.');
         }
-
-        // ensure you do not substitute variables itself!
-        reference = this.toJSON();
-        _.isArray(reference.variable) && (delete reference.variable);
 
         return variables.substitute(reference, overrides);
     }

--- a/test/unit/property.test.js
+++ b/test/unit/property.test.js
@@ -169,6 +169,47 @@ describe('Property', function () {
                 testProp2: 'substituted-parent-value-2'
             });
         });
+
+        it('should ignore own variables when `ignoreOwnVariables` is set', function () {
+            var property = new Property(),
+                variables = new VariableList({}, [{
+                    key: 'var1',
+                    value: 'value-1'
+                }]);
+
+            property.variables = new VariableList({}, [{
+                key: 'var1',
+                value: 'ignore_me_please'
+            }]);
+
+            property.testProp1 = 'prop-{{var1}}';
+
+            expect(property.toObjectResolved(null, [variables], { ignoreOwnVariables: true })).to.eql({
+                testProp1: 'prop-value-1'
+            });
+        });
+
+        it('should ignore scope variables when `ignoreOwnVariables` is set', function () {
+            var property = new Property(),
+                scope = new Property(),
+                variables = new VariableList({}, [{
+                    key: 'var1',
+                    value: 'value-1'
+                }]);
+
+            scope.variables = new VariableList({}, [{
+                key: 'var1',
+                value: 'ignore_me_please'
+            }]);
+
+            property.testProp1 = 'prop-{{var1}}';
+
+            // why on earth would anyone want to pass a scope and not use the scope,
+            // but you know we have tests to make sure even if someone did
+            expect(property.toObjectResolved(scope, [variables], { ignoreOwnVariables: true })).to.eql({
+                testProp1: 'prop-value-1'
+            });
+        });
     });
 
     describe('.replaceSubstitutions', function () {


### PR DESCRIPTION
Allows `toObjectResolved` to ignore own variables when used with an external source of variable definitions.