### PR TITLE
Add support for system property in query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Postman Collection SDK Changelog
 
+#### Unreleased
+* #502 Added support for system property in query parameters
+
 #### v3.0.3 (November 8, 2017)
 * :arrow_up: Updated dependencies.
 * #501 Fixed `Description~toString()` behaviour for falsy description contents. :bug:

--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -59,6 +59,7 @@ _.assign(QueryParam.prototype, /** @lends QueryParam.prototype */ {
             key: _.get(param, 'key'), // we do not replace falsey with blank string since null has a meaning
             value: _.get(param, 'value')
         });
+        _.has(param, 'system') && (this.system = param.system);
     },
 
     valueOf: function () {

--- a/test/unit/query-param.test.js
+++ b/test/unit/query-param.test.js
@@ -27,6 +27,27 @@ describe('QueryParam', function () {
             expect(qp).to.have.property('key', 'foo');
             expect(qp).to.have.property('value', 'bar');
         });
+
+        it('should handle system property correctly', function () {
+            var qp1 = new QueryParam({
+                    key: 'foo1',
+                    value: 'bar1',
+                    system: true
+                }),
+                qp2 = new QueryParam({
+                    key: 'foo2',
+                    value: 'bar2',
+                    system: false
+                }),
+                qp3 = new QueryParam({
+                    key: 'foo3',
+                    value: 'bar3'
+                });
+
+            expect(qp1).to.have.property('system', true);
+            expect(qp2).to.have.property('system', false);
+            expect(qp3).not.to.have.property('system');
+        });
     });
 
     describe('static helpers', function () {


### PR DESCRIPTION
This will be used by runtime in auth for setting query parameters
