### PR TITLE
Make `findParentContaining` fast again + jsDoc fixes

### DIFF
--- a/lib/collection/item.js
+++ b/lib/collection/item.js
@@ -11,6 +11,8 @@ var _ = require('../util').lodash,
     /**
      * Extracts `auth` from an entity. Checks if `auth` is present and it is not falsy type.
      *
+     * @private
+     *
      * @param {Object} [entity]
      */
     extractAuth = function (entity) {

--- a/lib/collection/property-base.js
+++ b/lib/collection/property-base.js
@@ -63,6 +63,8 @@ _.assign(PropertyBase.prototype, /** @lends PropertyBase.prototype */ {
      *
      * @param {String} property
      * @param {Function} [customizer]
+     *
+     * @returns {*|undefined}
      */
     findInParents: function (property, customizer) {
         var owner = this.findParentContaining(property, customizer);
@@ -76,21 +78,37 @@ _.assign(PropertyBase.prototype, /** @lends PropertyBase.prototype */ {
      *
      * @param {String} property
      * @param {Function} [customizer]
+     *
+     * @returns {PropertyBase|undefined}
      * @private
      */
     findParentContaining: function (property, customizer) {
         var parent = this;
 
-        do {
-            // if customizer is present test with it
-            // else check for existence
-            if (customizer ? customizer.call(this, parent) : parent[property]) {
-                return parent;
-            }
+        // if customizer is present test with it
+        if (customizer) {
+            customizer = customizer.bind(this);
 
-            // else travel up the parent chain
-            parent = parent.__parent;
-        } while (parent);
+            do {
+                // else check for existence
+                if (customizer(parent)) {
+                    return parent;
+                }
+
+                parent = parent.__parent;
+            } while (parent);
+        }
+
+        // else check for existence
+        else {
+            do {
+                if (parent[property]) {
+                    return parent;
+                }
+
+                parent = parent.__parent;
+            } while (parent);
+        }
     },
 
     /**

--- a/lib/collection/request.js
+++ b/lib/collection/request.js
@@ -51,11 +51,11 @@ _.inherit((
              */
             headers: new HeaderList(this, options && options.header),
 
+            // Although a similar check is being done in the .update call below, this handles falsy options as well.
             /**
              * @type {String}
              * @todo: Clean this up
              */
-            // Although a similar check is being done in the .update call below, this handles falsy options as well.
             method: ((options && options.method) || DEFAULT_REQ_METHOD).toUpperCase()
         });
 
@@ -90,11 +90,11 @@ _.assign(Request.prototype, /** @lends Request.prototype */ {
              */
             body: _.createDefined(options, 'body', RequestBody),
 
+            // auth is a special case, empty RequestAuth should not be created for falsy values
+            // to allow inheritance from parent
             /**
              * @type {RequestAuth}
              */
-            // auth is a special case, empty RequestAuth should not be created for falsy values
-            // to allow inheritance from parent
             auth: options.auth ? new RequestAuth(options.auth) : undefined,
 
             /**


### PR DESCRIPTION
* Added `@private` to internal functions
* Moved inline comments out to keep jsDoc and code closer
* Documented return type for `findInParents` and `findParentContaining`
* Moved `customizer` find flows out to reduce instructions in iterations
* Moved `bind` outside of iteration