### PR TITLE
Introduced `json` type for variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,21 @@
 # Postman Collection SDK Changelog
 
 #### Unreleased
+* :tada: Get and set objects in variables with `json` variable type
+```js
+var variable = new Variable({ type: 'json' });
+
+// set objects as values for `json types`
+variable.set({ version: 'v1' });
+
+// get object values
+console.log(variable.get()); // { version: 'v1' }
+console.log(typeof variable.get()); // object
+```
 * #502 Added support for system property in query parameters
 * #503 `request~toJSON` no longer converts `url` to string
 * Made sure all Script instances have an id
+* :bug: Fixed a bug where updating types in a variable removed value functions
 * :bug: `auth` is now included in `collection.toJSON`
 * :bug: Fixed a bug where `item.getAuth` would return an empty `RequestAuth`, instead of looking up in the parent
 * :bug: Fixed a bug where empty `auth` was created for `new {Request,ItemGroup,Collection}({auth: null})`. This affected the auth lookup in parents.

--- a/lib/collection/variable.js
+++ b/lib/collection/variable.js
@@ -75,7 +75,7 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
      * @returns {Variable.types}
      */
     get: function () {
-        return _.isFunction(this.value) ? this.castOut(this.value()) : this.castOut(this.value);
+        return this.castOut(this.value);
     },
 
     /**
@@ -268,7 +268,7 @@ _.assign(Variable, /** @lends Variable */ {
                     val = null;
                 }
 
-                return JSON.parse(val);
+                return val;
             }
         },
 

--- a/lib/collection/variable.js
+++ b/lib/collection/variable.js
@@ -153,10 +153,12 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
      */
     valueType: function (typeName, _noCast) {
         !_.isNil(typeName) && (typeName = typeName.toString().toLowerCase()); // sanitize
-
         if (!Variable.types[typeName]) {
             return this.type || ANY; // @todo: throw new Error('Invalid variable type.');
         }
+
+        // set type if it is valid
+        this.type = typeName;
 
         // 1. get the current value
         // 2. set the new type if it is valid and cast the stored value
@@ -165,7 +167,6 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
 
         if (!_noCast) {
             interstitialCastValue = this.get();
-            this.type = typeName;
             this.set(interstitialCastValue);
             interstitialCastValue = null; // just a precaution
         }
@@ -285,12 +286,12 @@ _.assign(Variable, /** @lends Variable */ {
             },
 
             /**
-         * @param {*} val
-         * @returns {*}
-         */
+             * @param {*} val
+             * @returns {*}
+             */
             out: function (val) {
-            return val; // pass through
-        }
+                return val; // pass through
+            }
         }
     },
 

--- a/lib/collection/variable.js
+++ b/lib/collection/variable.js
@@ -56,7 +56,7 @@ _.inherit((
             value: undefined
         });
 
-        if (!((definition === undefined) || (definition === null))) {
+        if (!_.isNil(definition)) {
             /**
              * The name of the variable. This is used for referencing this variable from other locations and scripts
              * @type {String}
@@ -75,7 +75,7 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
      * @returns {Variable.types}
      */
     get: function () {
-        return _.isFunction(this.value) ? this.cast(this.value()) : this.value;
+        return _.isFunction(this.value) ? this.castOut(this.value()) : this.castOut(this.value);
     },
 
     /**
@@ -85,7 +85,7 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
      */
     set: function (value) {
         // @todo - figure out how secure is this!
-        this.value = _.isFunction(value) ? value : this.cast(value);
+        this.value = _.isFunction(value) ? value : this.castIn(value);
     },
 
     /**
@@ -115,26 +115,62 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
      * @returns {*}
      */
     cast: function (value) {
-        return (Variable.types[this.type] || Variable.types.any)(value);
+        return this.castOut(value);
+    },
+
+    /**
+     * Typecasts a value to the {@link Variable.types} of this {@link Variable}. Returns the value of the variable
+     * converted to the type specified in {@link Variable#type}.
+     *
+     * @private
+     * @param {*} value
+     * @returns {*}
+     */
+    castIn: function (value) {
+        var handler = Variable.types[this.type] || Variable.types.any;
+        return _.isFunction(handler) ? handler(value) : handler.in(value);
+    },
+
+    /**
+     * Typecasts a value from the {@link Variable.types} of this {@link Variable}. Returns the value of the variable
+     * converted to the type specified in {@link Variable#type}.
+     *
+     * @private
+     * @param {*} value
+     * @returns {*}
+     */
+    castOut: function (value) {
+        var handler = Variable.types[this.type] || Variable.types.any;
+        return _.isFunction(handler) ? handler(value) : handler.out(value);
     },
 
     /**
      * Sets or gets the type of the value.
      *
      * @param {String} typeName
-     * @param {Boolean} _nocast
+     * @param {Boolean} _noCast
      * @returns {String} - returns the current type of the variable from the list of {@link Variable.types}
      */
-    valueType: function (typeName, _nocast) {
-        if (!typeName || !Variable.types[(typeName = typeName && typeName.toString().toLowerCase())]) {
+    valueType: function (typeName, _noCast) {
+        !_.isNil(typeName) && (typeName = typeName.toString().toLowerCase()); // sanitize
+
+        if (!Variable.types[typeName]) {
             return this.type || ANY; // @todo: throw new Error('Invalid variable type.');
         }
 
-        // set the new type if it is valid and cast the stored value
-        this.type = typeName;
-        !_nocast && (this.value = this.cast(this.value));
+        // 1. get the current value
+        // 2. set the new type if it is valid and cast the stored value
+        // 3. then set the interstitial value
+        var interstitialCastValue;
 
-        return typeName;
+        if (!_noCast) {
+            interstitialCastValue = this.get();
+            this.type = typeName;
+            this.set(interstitialCastValue);
+            interstitialCastValue = null; // just a precaution
+        }
+
+        return this.type;
     },
 
     /**
@@ -199,14 +235,62 @@ _.assign(Variable, /** @lends Variable */ {
         'number': Number,
 
         /**
+         * A "json" type value stores JSON data format
+         */
+        'json': {
+            /**
+             * @param {Object|Array} val
+             * @returns {String}
+             */
+            in: function (val) {
+                try {
+                    val = JSON.stringify(val);
+                }
+                catch (e) {
+                    val = 'null';
+                }
+
+                return val;
+            },
+
+            /**
+             * A "json" type value stores JSON data format
+             *
+             * @param {String} val
+             * @returns {Object}
+             */
+            out: function (val) {
+                try {
+                    val = JSON.parse(val);
+                }
+                catch (e) {
+                    val = null;
+                }
+
+                return JSON.parse(val);
+            }
+        },
+
+        /**
          * Free-form type of a value. This is the default for any variable, unless specified otherwise. It ensures that
          * the variable can store data in any type and no conversion is done while using {@link Variable#get}.
-         *
+         */
+        'any': {
+            /**
+             * @param {*} val
+             * @returns {*}
+             */
+            in: function (val) {
+                return val; // pass through
+            },
+
+            /**
          * @param {*} val
          * @returns {*}
          */
-        'any': function (val) {
+            out: function (val) {
             return val; // pass through
+        }
         }
     },
 

--- a/lib/collection/variable.js
+++ b/lib/collection/variable.js
@@ -166,7 +166,8 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
         // 3. then set the interstitial value
         var interstitialCastValue;
 
-        if (!_noCast) {
+        // do not touch value functions
+        if (!(_noCast || _.isFunction(this.value))) {
             interstitialCastValue = this.get();
             this.set(interstitialCastValue);
             interstitialCastValue = null; // just a precaution

--- a/lib/collection/variable.js
+++ b/lib/collection/variable.js
@@ -75,7 +75,7 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
      * @returns {Variable.types}
      */
     get: function () {
-        return this.castOut(this.value);
+        return _.isFunction(this.value) ? this.castOut(this.value()) : this.castOut(this.value);
     },
 
     /**

--- a/lib/collection/variable.js
+++ b/lib/collection/variable.js
@@ -3,6 +3,7 @@ var _ = require('../util').lodash,
 
     E = '',
     ANY = 'any',
+    STRING = 'string',
 
     Variable;
 
@@ -245,7 +246,8 @@ _.assign(Variable, /** @lends Variable */ {
              */
             in: function (val) {
                 try {
-                    val = JSON.stringify(val);
+                    // @todo: shoud we check if `val` is a valid JSON string?
+                    val = typeof val === STRING ? val : JSON.stringify(val);
                 }
                 catch (e) {
                     val = 'null';

--- a/test/unit/variable.test.js
+++ b/test/unit/variable.test.js
@@ -37,7 +37,7 @@ describe('Variable', function () {
         expect(v.system).to.be(false);
     });
 
-    it('should prepopulate value and type when passed to the constructor', function () {
+    it('should prepopulate value and type when passed to the constructor (string)', function () {
         var v = new Variable({
             value: 'Picard',
             type: 'string'
@@ -45,6 +45,48 @@ describe('Variable', function () {
 
         expect(v.value).to.be('Picard');
         expect(v.type).to.be('string');
+    });
+
+    it('should prepopulate value and type when passed to the constructor (number)', function () {
+        var v = new Variable({
+            value: 42,
+            type: 'number'
+        });
+
+        expect(v.value).to.be(42);
+        expect(v.type).to.be('number');
+    });
+
+    it('should prepopulate value and type when passed to the constructor (boolean)', function () {
+        var v = new Variable({
+            value: true,
+            type: 'boolean'
+        });
+
+        expect(v.value).to.be(true);
+        expect(v.type).to.be('boolean');
+    });
+
+    it('should prepopulate value and type when passed to the constructor (json)', function () {
+        var vValue = { foo: 'bar' },
+            v = new Variable({
+                value: vValue,
+                type: 'json'
+            });
+
+        expect(v.value).to.be(JSON.stringify(vValue));
+        expect(v.type).to.be('json');
+    });
+
+    it('should prepopulate value and type when passed to the constructor (json as string)', function () {
+        var vValue = JSON.stringify({ foo: 'bar' }),
+            v = new Variable({
+                value: vValue,
+                type: 'json'
+            });
+
+        expect(v.value).to.be(JSON.stringify(vValue));
+        expect(v.type).to.be('json');
     });
 
     it('should typecast value during construction when type is provided', function () {

--- a/test/unit/variable.test.js
+++ b/test/unit/variable.test.js
@@ -2,7 +2,7 @@ var expect = require('expect.js'),
     Variable = require('../../lib/index.js').Variable;
 
 /* global describe, it */
-describe.only('Variable', function () {
+describe('Variable', function () {
     it('should initialise variable of type `any` and value `undefined`', function () {
         var v = new Variable();
 
@@ -120,13 +120,17 @@ describe.only('Variable', function () {
     });
 
     it('should support any data type if type is set to `any`', function () {
-        var v = new Variable();
+        var v = new Variable(),
+            jsonValue = { iam: 'json' };
 
         v.set('Picard');
         expect(v.get()).to.be('Picard');
 
         v.set(3.142);
         expect(v.get()).to.be(3.142);
+
+        v.set(jsonValue);
+        expect(v.get()).to.be(jsonValue);
     });
 
     it('should type cast values to the specific type set', function () {
@@ -139,6 +143,9 @@ describe.only('Variable', function () {
 
         v.set(3.142);
         expect(v.get()).to.be('3.142');
+
+        v.set({ foo: 'bar' });
+        expect(v.get()).to.be('[object Object]');
     });
 
     it('should recast values when type is changed', function () {
@@ -153,10 +160,44 @@ describe.only('Variable', function () {
         expect(v.get()).to.be(3.142);
     });
 
+    it('should recast values when type is changed (json)', function () {
+        var v = new Variable({
+            type: 'string'
+        });
+
+        v.set({ foo: 'bar' });
+        expect(v.get()).to.be('[object Object]');
+
+        v.valueType('json');
+        expect(v.get()).to.be(null);
+    });
+
     it('should handle functions correctly', function () {
         var v = new Variable({ type: 'string', key: 'foo', value: function () { return 'bar'; } });
 
         expect(v.get()).to.be('bar');
+    });
+
+    it('should not touch value functions when type is changed', function () {
+        var v = new Variable({ type: 'string', key: 'foo', value: function () { return 'foo'; } });
+
+        expect(v.get()).to.be('foo');
+
+        v.valueType('boolean');
+
+        expect(v.value).to.be.a('function');
+        expect(v.get()).to.be(true);
+    });
+
+    it('should typecast returns of values as functions correctly', function () {
+        var v = new Variable({ type: 'number', key: 'foo', value: function () { return '3.14'; } }),
+            v2 = new Variable({ type: 'boolean', key: 'foo', value: function () { return 'bar'; } });
+
+        // number
+        expect(v.get()).to.be(3.14);
+
+        // boolean
+        expect(v2.get()).to.be(true);
     });
 
     describe('.set', function () {

--- a/test/unit/variable.test.js
+++ b/test/unit/variable.test.js
@@ -2,7 +2,7 @@ var expect = require('expect.js'),
     Variable = require('../../lib/index.js').Variable;
 
 /* global describe, it */
-describe('Variable', function () {
+describe.only('Variable', function () {
     it('should initialise variable of type `any` and value `undefined`', function () {
         var v = new Variable();
 
@@ -78,24 +78,45 @@ describe('Variable', function () {
         expect(v.type).to.be('json');
     });
 
-    it('should prepopulate value and type when passed to the constructor (json as string)', function () {
-        var vValue = JSON.stringify({ foo: 'bar' }),
-            v = new Variable({
-                value: vValue,
-                type: 'json'
-            });
-
-        expect(v.value).to.be(JSON.stringify(vValue));
-        expect(v.type).to.be('json');
-    });
-
-    it('should typecast value during construction when type is provided', function () {
+    it('should typecast value during construction when type is provided (number)', function () {
         var v = new Variable({
             value: '108',
             type: 'number'
         });
 
         expect(v.value).to.be(108);
+    });
+
+    it('should typecast value during construction when type is provided (string)', function () {
+        var v = new Variable({
+            value: true,
+            type: 'string'
+        });
+
+        expect(v.value).to.be('true');
+    });
+
+    it('should typecast value during construction when type is provided (boolean)', function () {
+        var v = new Variable({
+            value: 'foo',
+            type: 'boolean'
+        });
+
+        expect(v.value).to.be(true);
+    });
+
+    it('should typecast value during construction when type is provided (json)', function () {
+        var v = new Variable({
+                value: null,
+                type: 'json'
+            }),
+            v1 = new Variable({
+                value: '{"foo":"bar"}',
+                type: 'json'
+            });
+
+        expect(v.value).to.be('null');
+        expect(v1.value).to.be('{"foo":"bar"}');
     });
 
     it('should support any data type if type is set to `any`', function () {


### PR DESCRIPTION
**Changes**
* Added a `bi-directional` type casting functions to support custom types (@shamasis)
* Fixed a bug where `type` updates were removing `value` functions
* Improved tests around variable types in initializing and casting

**Trivia**
* `variable.set(JSON.stringify(object)) === variable.set(object)`
* `variable.valueType('json'); variable.toString() === '[object Object]'`