### PR TITLE
Update lodash to `4.17.4`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "http-reasons": "0.1.0",
     "iconv-lite": "0.4.19",
     "liquid-json": "0.3.1",
-    "lodash": "4.17.2",
+    "lodash": "4.17.4",
     "8fold-marked": "0.3.8",
     "mime-format": "2.0.0",
     "mime-types": "2.1.17",


### PR DESCRIPTION
Not sure why https://github.com/postmanlabs/postman-collection/pull/244 was closed, @kunagpal can give more context.

But `postman-runtime` is on `lodash@4.17.4`, so consumers are getting two copies of `lodash`.