### PR TITLE
Introduce `script.update` method to make updates without id changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Postman Collection SDK Changelog
 
 #### Unreleased
+* Added `update` method to `Script`
 
 #### v3.0.4 (November 20, 2017)
 * :tada: Get and set objects in variables with `json` variable type

--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -17,11 +17,42 @@ _.inherit((
      * @param {Object} options
      */
     Script = function PostmanScript (options) {
+        // this constructor is intended to inherit and as such the super constructor is required to be executed
+        Script.super_.apply(this, arguments);
+
+        options && this.update(options);
+    }), Property);
+
+_.assign(Script.prototype, /** @lends Script.prototype */ {
+    /**
+     * Defines whether this property instances requires an id
+     * @private
+     * @readOnly
+     * @type {Boolean}
+     */
+    _postman_propertyRequiresId: true,
+
+    /**
+     * Converts the script lines array to a single source string.
+     *
+     * @returns {String}
+     */
+    toSource: function () {
+        return this.exec ? this.exec.join('\n') : undefined;
+    },
+
+    /**
+     * Updates the properties of a Script.
+     *
+     * @param {Object} [options]
+     * @param {String} [options.type] Script type
+     * @param {String} [options.src] Script source url
+     * @param {Array<String>|String} [options.exec] Script to execute
+     */
+    update: function (options) {
         // no splitting is being done here, as string scripts are split right before assignment below anyway
         (_.isString(options) || _.isArray(options)) && (options = { exec: options });
 
-        // this constructor is intended to inherit and as such the super constructor is required to be executed
-        Script.super_.apply(this, arguments);
         if (!options) { return; } // in case definition object is missing, there is no point moving forward
 
         // create the request property
@@ -47,24 +78,6 @@ _.inherit((
             this.exec = _.isString(options.exec) ? options.exec.split(SCRIPT_NEWLINE_PATTERN) :
                 _.isArray(options.exec) ? options.exec : undefined;
         }
-    }), Property);
-
-_.assign(Script.prototype, /** @lends Script.prototype */ {
-    /**
-     * Defines whether this property instances requires an id
-     * @private
-     * @readOnly
-     * @type {Boolean}
-     */
-    _postman_propertyRequiresId: true,
-
-    /**
-     * Converts the script lines array to a single source string.
-     *
-     * @returns {String}
-     */
-    toSource: function () {
-        return this.exec ? this.exec.join('\n') : undefined;
     }
 });
 

--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -47,7 +47,7 @@ _.assign(Script.prototype, /** @lends Script.prototype */ {
      * @param {Object} [options]
      * @param {String} [options.type] Script type
      * @param {String} [options.src] Script source url
-     * @param {Array<String>|String} [options.exec] Script to execute
+     * @param {String[]|String} [options.exec] Script to execute
      */
     update: function (options) {
         // no splitting is being done here, as string scripts are split right before assignment below anyway

--- a/test/unit/event.test.js
+++ b/test/unit/event.test.js
@@ -135,7 +135,7 @@ describe('Event', function () {
 
             expect(beforeJSON.script.id).to.not.be(afterJSON.script.id);
             expect(afterJSON.script).to.have.property('id', 'my-new-script');
-            expect(afterJSON.script.exec).to.not.ok;
+            expect(afterJSON.script.exec).to.not.be.ok();
         });
     });
 });

--- a/test/unit/event.test.js
+++ b/test/unit/event.test.js
@@ -119,5 +119,23 @@ describe('Event', function () {
             expect(eventJSON.script).to.have.property('type', 'text/javascript');
             expect(eventJSON.script.exec).to.eql(['console.log("hello");']);
         });
+
+        it('should update script id', function () {
+            var event = new Event(rawEvent),
+                beforeJSON = event.toJSON(),
+                afterJSON;
+
+            expect(beforeJSON).to.have.property('script');
+            expect(beforeJSON.script).to.have.property('id');
+            expect(beforeJSON.script).to.have.property('type', 'text/javascript');
+            expect(beforeJSON.script.exec).to.eql(['console.log("hello");']);
+
+            event.update({ script: { id: 'my-new-script' } });
+            afterJSON = event.toJSON();
+
+            expect(beforeJSON.script.id).to.not.be(afterJSON.script.id);
+            expect(afterJSON.script).to.have.property('id', 'my-new-script');
+            expect(afterJSON.script.exec).to.not.ok;
+        });
     });
 });

--- a/test/unit/script.test.js
+++ b/test/unit/script.test.js
@@ -102,6 +102,73 @@ describe('Script', function () {
         });
     });
 
+    describe('updates', function () {
+        it('should not create new ids', function () {
+            var script1 = new Script('old script'),
+                script2 = new Script({ id: 'ID1' }),
+                script1BeforeId = script1.id,
+                script2BeforeId = script2.id;
+
+            script1.update('new script');
+            expect(script1BeforeId).to.be(script1.id);
+            script1.update({ exec: 'new script' });
+            expect(script1BeforeId).to.be(script1.id);
+
+            script2.update('new script');
+            expect(script2BeforeId).to.be(script2.id);
+            script2.update({ exec: 'new script' });
+            expect(script2BeforeId).to.be(script2.id);
+        });
+
+        it('should handle the src property correctly', function () {
+            var script = new Script();
+
+            script.update({
+                src: 'https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js'
+            });
+
+            expect(script).to.not.have.property('exec');
+            expect(Url.isUrl(script.src)).to.be(true);
+        });
+
+        it('should default to undefined for script code if neither an array of strings or a string is provided',
+            function () {
+                var script = new Script();
+
+                script.update({ exec: 123 });
+
+                expect(script).to.have.property('exec', undefined);
+            });
+
+        describe('Variadic formats', function () {
+            it('should support non-wrapped strings', function () {
+                var script = new Script(),
+                    scriptJSON;
+
+                script.update('console.log("This is a line of test script code");');
+                scriptJSON = script.toJSON();
+
+                expect(scriptJSON).to.have.property('id');
+                expect(scriptJSON).to.have.property('type', 'text/javascript');
+                expect(scriptJSON.exec).to.eql(['console.log("This is a line of test script code");']);
+            });
+
+            it('should support non-wrapped arrays', function () {
+                var script = new Script(),
+                    scriptJSON;
+
+                script.update(['console.log("This is a line of test script code");']);
+
+                scriptJSON = script.toJSON();
+
+                expect(scriptJSON).to.have.property('id');
+                expect(scriptJSON).to.have.property('type', 'text/javascript');
+                expect(scriptJSON.exec).to.eql(['console.log("This is a line of test script code");']);
+            });
+        });
+    });
+
+
     describe('.toSource', function () {
         it('should correctly unparse an array of exec strings', function () {
             var script = new Script({

--- a/test/unit/script.test.js
+++ b/test/unit/script.test.js
@@ -110,14 +110,14 @@ describe('Script', function () {
                 script2BeforeId = script2.id;
 
             script1.update('new script');
-            expect(script1BeforeId).to.be(script1.id);
+            expect(script1.id).to.be(script1BeforeId);
             script1.update({ exec: 'new script' });
-            expect(script1BeforeId).to.be(script1.id);
+            expect(script1.id).to.be(script1BeforeId);
 
             script2.update('new script');
-            expect(script2BeforeId).to.be(script2.id);
+            expect(script2.id).to.be(script2BeforeId);
             script2.update({ exec: 'new script' });
-            expect(script2BeforeId).to.be(script2.id);
+            expect(script2.id).to.be(script2BeforeId);
         });
 
         it('should handle the src property correctly', function () {


### PR DESCRIPTION
This allows making updates to scripts without having to recreate new instances. This preserves ids across updates.