### PR TITLE
Revert "Update sanitize-html to version 1.16.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "8fold-marked": "0.3.9",
     "mime-format": "2.0.0",
     "mime-types": "2.1.17",
-    "sanitize-html": "1.16.1",
+    "sanitize-html": "1.15.0",
     "semver": "5.4.1",
     "uuid": "3.1.0",
     "postman-url-encoder": "1.0.1"


### PR DESCRIPTION
Reverts postmanlabs/postman-collection#520

`sanitize-html` added `postcss` as a dependency. Seeing browserify configuration in `postcss` `package.json` not honoured in sandbox. This leads to failures in sandbox. Will take a look at the browserify options in sandbox before revisiting this.