### PR TITLE
toString with undefined causes exceptions

### DIFF
--- a/lib/collection/variable.js
+++ b/lib/collection/variable.js
@@ -105,7 +105,7 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
      */
     toString: function () {
         var value = this.valueOf();
-        return _.isFunction(value.toString) ? value.toString() : E;
+        return value && _.isFunction(value.toString) ? value.toString() : E;
     },
 
     /**


### PR DESCRIPTION
If the `value` is undefined, it would throw error on the `_.isFunction` test.

Not sure if this is a common state to get in, but it just happened to me.