### PR TITLE
Empty path variable fix

### DIFF
--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -102,7 +102,10 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
         }
 
         // expand string path name
-        _.isString(path) && (path = path.split(PATH_SEPARATOR));
+        if (_.isString(path)) {
+            (path[0] === PATH_SEPARATOR) && (path = path.slice(1));
+            path = path.split(PATH_SEPARATOR);
+        }
         // expand host string
         _.isString(host) && (host = host.split(regexes.splitDomain));
 
@@ -243,15 +246,16 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
             segmentArray = (options && options.unresolved) ? this.path : _.transform(this.path, function (res, segment) {
                 var variable;
 
-                if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER)) {
-                    variable = self.variables.one(segment.slice(1));
-                }
+                segment && (segment[0] === PATH_VARIABLE_IDENTIFIER) &&
+                    (variable = self.variables.one(segment.slice(1)));
 
                 variable = variable && variable.valueOf && variable.valueOf();
                 res.push(_.isString(variable) ? variable : segment);
             }, []),
             path = segmentArray.join(PATH_SEPARATOR);
-        return _.startsWith(path, PATH_SEPARATOR) ? path : PATH_SEPARATOR + path;
+
+        // an extra PATH_SEPARATOR has to be prefixed if the first path segment is empty
+        return (path[0] === PATH_SEPARATOR) && segmentArray[0] ? path : PATH_SEPARATOR + path;
     },
 
     /**

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -526,7 +526,7 @@ describe('Url', function () {
             expect(jsonified.protocol).to.eql(rawUrl.protocol);
             expect(jsonified.host).to.eql(rawUrl.host.split('.'));
             expect(jsonified.port).to.eql(rawUrl.port);
-            expect(jsonified.path).to.eql(rawUrl.path.split('/'));
+            expect(jsonified.path).to.eql(rawUrl.path.split('/').slice(1));
             expect(jsonified.query).to.eql(rawUrl.query);
             expect(jsonified.hash).to.eql(rawUrl.hash);
 
@@ -565,6 +565,20 @@ describe('Url', function () {
             });
 
             expect(url.getPath()).to.eql('/get/:beta/:gamma/:delta/:epsilon/:phi');
+        });
+
+        it('should be handled correctly for empty and non-existent values', function () {
+            var url = new Url({
+                protocol: 'https',
+                host: 'postman-echo.com',
+                path: [':alpha', 'beta', ':gamma', 'delta', ':epsilon', 'phi'],
+                variable: [
+                    { key: 'alpha', value: '' },
+                    { key: 'epsilon', value: '' }
+                ]
+            });
+
+            expect(url.getPath()).to.eql('//beta/:gamma/delta//phi');
         });
 
         it('should work correctly without the id field as well', function () {


### PR DESCRIPTION
Previously, path variables that resolved to empty values would effectively be ignored during path unparsing. The added unit test is one such case.

Performance improvements:
<img width="959" alt="screen shot 2018-01-18 at 9 01 38 pm" src="https://user-images.githubusercontent.com/7289840/35107971-58c13c30-fc98-11e7-8f99-fc290f23d9cf.png">
