### PR TITLE
Fixing broken link to the Postman Collections page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ accurately mirror your API. Requests can also store sample responses when saved 
 like name and description too so that all the information that a developer needs to use your API is available easily.
 
 To know more about Postman Collections, visit the 
-[collection documentation section on Postman Website](https://www.getpostman.com/docs/collections).
+[collection documentation section on Postman Website](https://www.getpostman.com/collection).
 
 > The new [Collection Format v2](http://blog.getpostman.com/2015/06/05/travelogue-of-postman-collection-format-v2/) 
 > builds a stronger foundation for improving your productivity while working with APIs. We want your feedback and iron 


### PR DESCRIPTION
Current URL redirects to https://www.getpostman.com/docs/v6/collections which does not exist