### PR TITLE
Update the content-type assertion for updated response header

### DIFF
--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -730,7 +730,7 @@ describe('Response', function () {
                         mime = response.mime(),
                         headers = new HeaderList(null, json.header);
 
-                    expect(mime._originalContentType).to.be('application/json');
+                    expect(mime._originalContentType).to.be('application/json; charset=utf-8');
                     expect(mime._sanitisedContentType).to.be('application/json');
 
                     expect(body.gzipped).to.be(true);


### PR DESCRIPTION
This test asserts on the original content type header on the response. The API used in this test has changed to return a different content-type header. I've updated the test to accommodate this.

I think a more reliable solution moving forward is to include the `echo` module as a dev dependency for tests.