### PR TITLE
Added support for tracking variable changes in VariableScopes

### DIFF
--- a/lib/collection/variable-changeset.js
+++ b/lib/collection/variable-changeset.js
@@ -1,0 +1,235 @@
+var _ = require('../util').lodash,
+    Property = require('./property').Property,
+
+    /**
+     * @private
+     * @const
+     * @type {Object}
+     */
+    INSTRUCTION = {
+        SET: 'set',
+        UNSET: 'unset'
+    },
+
+    /**
+     * @private
+     * @const
+     * @type {String}
+     */
+    POSTMAN_PROPERTY_NAME = '_postman_propertyName',
+
+    /**
+     * @private
+     * @const
+     * @type {String}
+     */
+    VARIABLE_SCOPE = 'VariableScope',
+
+    /**
+     * Checks if the instance is a VariableScope. Defined here to avoid importing VariableScope and causing a
+     * circular dependency.
+     *
+     * @private
+     * @param {*} obj the object that needs to be validated
+     */
+    isVariableScope = function (obj) {
+        return Boolean(obj) && (_.inSuperChain(obj.constructor, POSTMAN_PROPERTY_NAME,
+            VARIABLE_SCOPE));
+    },
+
+    /**
+     * Converts a variable changeset in the form of a JSON Delta stanza to an object format.
+     *
+     * @private
+     * @param {VariableChangeset~serialized} serialized A serialized variable changeset
+     */
+    deserializeChangeset = function (serialized) {
+        // bail out - empty or invalid
+        if (!(serialized && serialized.length > 1)) {
+            return {};
+        }
+
+        var deserialized = {
+            id: serialized[0],
+            key: serialized[1],
+            type: INSTRUCTION.UNSET // set default changeset type to `unset`
+        };
+
+        // if the serialized changeset has three parameters, it represents a set changeset
+        // @note: The third parameter should be honoured if present even if it is `nil` or `falsy`
+        if (serialized.length > 2) {
+            deserialized.type = INSTRUCTION.SET;
+            deserialized.value = serialized[2];
+        }
+
+        return deserialized;
+    },
+
+    VariableChangeset;
+
+/**
+ * JSON definition for a variable changeset.
+ *
+ * @typedef VariableChangeset~definition
+ *
+ * @property {String} id changeset id
+ * @property {String} type changeset type, one of ['set', 'unset']
+ * @property {String} key variable key
+ * @property {*} value variable value
+ *
+ * @example <caption>JSON definition of a VariableChangeset</caption>
+ * {
+ *   "id": "raw",
+ *   "type": "set",
+ *   "key": "name",
+ *   "value": "Bob"
+ * }
+ */
+
+/**
+ * A serialized version of JSON changeset. This format is extended from the JSON delta specification.
+ *
+ * This format allows capturing variable creates, updates and deletes in a very minimal and consistent format.
+ * It has 3 parts.
+ *  ID
+ *  Key path
+ *  Value
+ *
+ * This format diverges from the original JSON delta format by adding an id segment. This is to allow mapping meta data
+ * to changes later.
+ *
+ * For example ['1', ['name'], 'Bob'] represents an update on the variable `name` to `Bob`. This can be extended for
+ * other types of changes as well. So ['1', ['description'], 'Hi there!'] could mean an addition if `description`
+ * is not present already.
+ *
+ * Unset, or delete of a variable can be captured by not specifying the `value` segment. e.g. ['1', ['age']] would mean
+ * a delete for the variable `age`.
+ *
+ *
+ * See {@link http://json-delta.readthedocs.io/en/latest/philosophy.html} for more info.
+ *
+ * @typedef {Array} VariableChangeset~serialized
+ *
+ * @property {Number|String} 0
+ * @property {String[]} 1
+ * @property {*} 2
+ */
+_.inherit((
+
+    /**
+     * An instruction representing a change to a variable.
+     *
+     * @constructor
+     * @param {VariableChangeset~definition|VariableChangeset~serialized} [definition]
+     */
+    VariableChangeset = function VariableChangeset (definition) {
+        definition = definition || {};
+
+        // definition is a serialized changeset
+        if (_.isArray(definition)) {
+            definition = deserializeChangeset(definition);
+        }
+
+        // this constructor is intended to inherit and as such the super constructor is required to be executed
+        VariableChangeset.super_.call(this, definition);
+
+        // import definition
+        this.update(definition);
+    }
+), Property);
+
+_.assign(VariableChangeset.prototype, /** @lends VariableChangeset.prototype */ {
+    /**
+     * Defines that this property requires an ID field
+     * @private
+     * @readOnly
+     */
+    _postman_propertyRequiresId: true,
+
+    /**
+     * Updates the variable changeset.
+     *
+     * @param {VariableChangeset~definition} definition
+     */
+    update: function (definition) {
+        _.mergeDefined(this, /** @lends VariableChangeset.prototype */ {
+            /**
+             * @property {String[]}
+             */
+            key: _.isArray(definition.key) ? definition.key.join('.') : definition.key || '',
+
+            /**
+             * @property {String}
+             */
+            type: definition.type || INSTRUCTION.UNSET,
+
+            /**
+             * @property {*}
+             */
+            value: definition.type === INSTRUCTION.SET ? definition.value : undefined
+        });
+    },
+
+    /**
+     * Applies the changeset on a variable scope
+     *
+     * @param {VariableScope} scope
+     */
+    applyOn: function (scope) {
+        if (!(scope && isVariableScope(scope))) {
+            return;
+        }
+
+        var op = this.type;
+
+        switch (op) {
+            case INSTRUCTION.SET:
+                scope.set(this.key, this.value);
+                break;
+            case INSTRUCTION.UNSET:
+                scope.unset(this.key);
+                break;
+            default:
+                break; // unknown type, do nothing
+        }
+    },
+
+    /**
+     * Serializes the variable changeset.
+     *
+     * @returns {VariableChangeset~serialized}
+     */
+    toJSON: function () {
+        var serialized = [this.id, this.key.split('.')];
+
+        // add value only if the instruction is a `set` instruction
+        (this.type === INSTRUCTION.SET) && (serialized.push(this.value));
+
+        return serialized;
+    }
+});
+
+_.assign(VariableChangeset, /** @lends VariableChangeset */ {
+    /**
+     * Defines the name of this property for internal use.
+     * @private
+     * @readOnly
+     * @type {String}
+     */
+    _postman_propertyName: 'VariableChangeset',
+
+    /**
+     * Check whether an object is an instance of {@link VariableChangeset}.
+     *
+     * @param {*} obj
+     * @returns {Boolean}
+     */
+    isVariableChangeset: function (obj) {
+        return Boolean(obj) && ((obj instanceof VariableChangeset) ||
+            _.inSuperChain(obj.constructor, '_postman_propertyName', VariableChangeset._postman_propertyName));
+    }
+});
+
+module.exports = {
+    VariableChangeset: VariableChangeset
+};

--- a/lib/collection/variable-scope-diff.js
+++ b/lib/collection/variable-scope-diff.js
@@ -1,0 +1,299 @@
+var _ = require('../util').lodash,
+    Property = require('./property').Property,
+    VariableChangeset = require('./variable-changeset').VariableChangeset,
+
+    /**
+     * @private
+     * @const
+     * @type {Object}
+     */
+    MODE = {
+        RAW: 'raw',
+        COMPRESSED: 'compressed'
+    },
+
+    /**
+     * Flattens all the changesets. Accounts for both the modes(compressed and raw). The changeset could be a JSON
+     * definition or a VariableChangeset instance.
+     *
+     * @private
+     *
+     * @param {Object} root a VariableScopeDiff JSON definition or a VariableScopeDiff instance.
+     */
+    flattenChangesets = function (root) {
+        var changesets;
+
+        // root could be a JSON definition as well, so checking by `compressed` property
+        // is more accurate than `isCompressed`
+        if (root.compressed) {
+            changesets = _.reduce(root.compressed, function (acc, compressedChange) {
+                acc.push(compressedChange);
+                return acc;
+            }, []);
+        }
+        else if (root.raw) {
+            changesets = root.raw;
+        }
+
+        return changesets || [];
+    },
+
+    VariableScopeDiff;
+
+/**
+ * @typedef VariableScopeDiff~definition
+ *
+ * @property {String} mode Diff mode - `compressed` or `raw`
+ * @property {Object} [compressed] compressed set of changesets organized by key
+ * @property {Array.<VariableChangeset~serialized>} [raw] raw list of changesets
+ *
+ * @example <caption>JSON definition of a VariableScopeDiff</caption>
+ * {
+ *   "mode": "raw",
+ *   "raw": [
+ *      ["1", ["name"], "Bob"]
+ *   ]
+ * }
+ *
+ * @example <caption>JSON definition of a VariableScopeDiff in compressed mode</caption>
+ * {
+ *   "mode": "compressed",
+ *   "compressed": {
+ *      "name": ["1", ["name"], "Bob"]
+ *   }
+ * }
+ */
+_.inherit((
+
+    /**
+     * A `VariableScopeDiff` is a place to track a set of variable changes - see {@link VariableChangeset}. This could
+     * be used in a {@link VariableScope} for tracking changes. `VariableScopeDiff` gives you helpers to manage a set of
+     * changesets, like compressing them, iterating over them or applying them on a different `VariableScope`.å
+     *
+     * @constructor
+     *
+     * @param {VariableScopeDiff~definition} [definition]
+     * @param {Object} [options]
+     */
+    VariableScopeDiff = function VariableScopeDiff (definition, options) {
+        // this constructor is intended to inherit and as such the super constructor is required to be executed
+        VariableScopeDiff.super_.call(this, definition);
+
+        // initialize a default definition
+        definition = definition || {};
+
+        // look for compression mode in options
+        // if not found, detect from definition
+        // if not found, fall back to default `raw` mode
+        var mode = (options && options.compress) ? MODE.COMPRESSED : definition.mode || MODE.RAW,
+            changesets;
+
+        this.mode = mode;
+
+        // initialize changeset buckets
+        if (mode === MODE.COMPRESSED) {
+            /**
+             * Holds compressed set of variable changesets.
+             *
+             * @private
+             * @memberOf VariableScope.prototype
+             */
+            this.compressed = {};
+        }
+        else {
+            /**
+             * Holds set of raw variable changesets.
+             *
+             * @private
+             * @memberOf VariableScope.prototype
+             */
+            this.raw = [];
+        }
+
+        // load changesets from definition
+        // the definition and the selected mode might be different
+        // so we always look to restore both possibilities
+        changesets = flattenChangesets(definition);
+
+        // import changesets
+        _.forEach(changesets, this.registerChangeset.bind(this));
+    }
+), Property);
+
+_.assign(VariableScopeDiff.prototype, /** @lends VariableScopeDiff.prototype */ {
+
+    /**
+     * Logs a changeset. Handles bucketing changesets based on selected mode.
+     *
+     * @private
+     * @param {VariableChangeset} changeset
+     */
+    registerChangeset: function (changeset) {
+        if (!changeset) {
+            return;
+        }
+
+        // convert changeset to instance if not one
+        changeset = VariableChangeset.isVariableChangeset(changeset) ? changeset :
+            new VariableChangeset(changeset);
+
+        var key = changeset.key;
+
+        if (this.isCompressed()) {
+            this.compressed[key] = changeset;
+        }
+
+        else {
+            this.raw.push(changeset);
+        }
+    },
+
+    /**
+     * Track a variable change.
+     *
+     * @param {String} type change type, one of ['set', 'unset']
+     * @param {String} key key for the change
+     * @param {*} [value] value, only for `set` changes
+     */
+    track: function (type, key, value) {
+        // bail out
+        if (!(type && key)) {
+            return;
+        }
+
+        var changeset = new VariableChangeset({ key: key, type: type, value: value });
+
+        this.registerChangeset(changeset);
+    },
+
+    /**
+     * Checks if the changeset compression is enabled.
+     *
+     * @private
+     *
+     * @returns {Boolean}
+    */
+    isCompressed: function () {
+        return this.mode === MODE.COMPRESSED;
+    },
+
+    /**
+     * Iterates over all the tracked changesets.
+     *
+     * @private
+     * @param {Function} iterator
+     */
+    each: function (iterator) {
+        this.all().forEach(iterator);
+    },
+
+    /**
+     * Returns a flat array of all the tracked changesets.
+     *
+     * @returns {Array.<VariableChangeset>}
+     */
+    all: function () {
+        return flattenChangesets(this);
+    },
+
+    /**
+     * Returns the count of all the tracked changesets.
+     *
+     * @returns {Number}
+     */
+    count: function () {
+        return this.all().length;
+    },
+
+    /**
+     * Applies the tracked changes on a given variable scope.
+     *
+     * @param {VariableScope} scope
+     */
+    applyOn: function (scope) {
+        if (!scope) {
+            return;
+        }
+
+        this.each(function (changeset) {
+            changeset.applyOn(scope);
+        });
+    },
+
+    /**
+     * Imports a tracked changes from another diff instance.
+     *
+     * @param {VariableScopeDiff|VariableScopeDiff~definition} diff
+     */
+    import: function (diff) {
+        var changesets = flattenChangesets(diff);
+
+        changesets.forEach(function (changeset) {
+            if (!changeset) {
+                return;
+            }
+
+            // clone the changeset
+            changeset = VariableChangeset.isVariableChangeset(changeset) ? changeset.toJSON() : changeset;
+
+            this.registerChangeset(changeset);
+        }.bind(this));
+    },
+
+    /**
+     * Reset tracked changes.
+     */
+    reset: function () {
+        if (this.isCompressed()) {
+            this.compressed = {};
+        }
+        else {
+            this.raw = [];
+        }
+    },
+
+    /**
+     * Change the tracking mode to `compressed`. And compress tracked changes as well.
+     */
+    compress: function () {
+        // already compressed
+        if (this.isCompressed()) {
+            return;
+        }
+
+        // copy all the changesets
+        var changesets = flattenChangesets(this);
+
+        // change mode to compressed
+        this.mode = MODE.COMPRESSED;
+        this.compressed = {};
+
+        // now push all the changesets again, this will compress the changesets in the process
+        changesets.forEach(this.registerChangeset.bind(this));
+    }
+});
+
+_.assign(VariableScopeDiff, {
+    /**
+     * Defines the name of this property for internal use.
+     * @private
+     * @readOnly
+     * @type {String}
+     */
+    _postman_propertyName: 'VariableScopeDiff',
+
+    /**
+     * Check whether an object is an instance of {@link VariableScopeDiff}.
+     *
+     * @param {*} obj
+     * @returns {Boolean}
+     */
+    isVariableScopeDiff: function (obj) {
+        return Boolean(obj) && ((obj instanceof VariableScopeDiff) ||
+            _.inSuperChain(obj.constructor, '_postman_propertyName', VariableScopeDiff._postman_propertyName));
+    }
+});
+
+module.exports = {
+    VariableScopeDiff: VariableScopeDiff
+};

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -2,6 +2,7 @@ var _ = require('../util').lodash,
     Property = require('./property').Property,
     PropertyBase = require('./property-base').PropertyBase,
     VariableList = require('./variable-list').VariableList,
+    VariableScopeDiff = require('./variable-scope-diff').VariableScopeDiff,
 
     VariableScope;
 
@@ -14,7 +15,7 @@ var _ = require('../util').lodash,
  * @property {String} [id] ID of the scope
  * @property {String} [name] A name of the scope
  * @property {Array.<Variable~definition>} [values] A list of variables defined in an array in form of `{name:String,
- * value:String}`
+ * @property {VariableScopeDiff~definition} [changes] A series of variable changes that were tracked
  *
  * @example <caption>JSON definition of a VariableScope (environment, globals, etc)</caption>
  * {
@@ -40,7 +41,13 @@ _.inherit((
      *
      * @param {VariableScope~definition} definition The constructor accepts an initial set of values for initialising
      * the scope
-     * @param {Array<VariableList>=} layers Additional parent scopes to search for and resolve variables
+     * @param {Array<VariableList>} [layers] Additional parent scopes to search for and resolve variables
+     * @param {Object} [options] Additional options
+     * @param {Boolean} [options.enableTracking] This option can be used to track changes to values.
+     * If set to `true`, tracking is enabled with default options.
+     * Note that, if tracking is enabled, any existing changes in the definition will be reset.
+     * @param {Object} [options.trackingOptions] Options for tracking variable changes. Use this with `enableTracking`.
+     * See {@link VariableScope.prototype.enableTracking}
      *
      * @example <caption>Load a environment from file, modify and save back</caption>
      * var fs = require('fs'), // assuming NodeJS
@@ -57,7 +64,7 @@ _.inherit((
      * env.set('sum', sum, 'number');
      * fs.writeFileSync('./sum-of-vars.postman_environment', JSON.stringify(env.toJSON()));
      */
-    VariableScope = function PostmanVariableScope (definition, layers) {
+    VariableScope = function PostmanVariableScope (definition, layers, options) {
         // in case the definition is an array (legacy format) or existing as list, we convert to actual format
         if (_.isArray(definition) || VariableList.isVariableList(definition)) {
             definition = { values: definition };
@@ -71,8 +78,10 @@ _.inherit((
         VariableScope.super_.call(this, definition);
 
         var values = definition && definition.values, // access the values (need this var to reuse access)
-            i,
-            ii;
+            isTrackingEnabled = options && options.enableTracking,
+            preExistingChanges = definition && definition.changes,
+            ii,
+            i;
 
         /**
          * @memberOf VariableScope.prototype
@@ -88,6 +97,11 @@ _.inherit((
             for (i = 0, ii = layers.length; i < ii; i++) {
                 VariableList.isVariableList(layers[i]) && this._layers.push(layers[i]);
             }
+        }
+
+        // enable tracking if option is set or if definition has changes
+        if (isTrackingEnabled || preExistingChanges) {
+            this.enableTracking(options && options.trackingOptions, preExistingChanges);
         }
     }), Property);
 
@@ -205,9 +219,15 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
         _.isString(type) && (update.type = type);
 
         // If a variable by the name key exists, update it's value and return.
-        if (variable) { return variable.update(update); }
+        if (variable) {
+            variable.update(update);
+        }
+        else {
+            this.values.add(update);
+        }
 
-        this.values.add(update);
+        // track the set changeset
+        this._postman_enableTracking && this.changes.track('set', key, value);
     },
 
     /**
@@ -216,14 +236,85 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      * @param {String} key
      */
     unset: function (key) {
+        if (!(key && this.values.has(key))) {
+            return;
+        }
+
         this.values.remove(key);
+
+        // track the unset changeset
+        this._postman_enableTracking && this.changes.track('unset', key);
     },
 
     /**
      * Removes *all* variables from the current scope. This is a destructive action.
      */
     clear: function () {
+        // if change tracking is enabled, track the changes first, then remove the keys.
+        if (this._postman_enableTracking) {
+            // track clear as delete for each key
+            this.values.each(function (variable) {
+                this.changes.track('unset', variable.key);
+            }.bind(this));
+        }
+
         this.values.clear();
+    },
+
+    /**
+     * Enables change tracking. Any future, variable changes through setters (set, unset, clear)
+     * will be tracked. The tracked changes are available on the `changes` attribute {@link VariableScopeDiff}
+     *
+     * *note:* If tracking is already enabled, this will have no effect.
+     * *note:* If tracking is not enabled already, any existing changes will be reset.
+     *
+     * @param {Object} [options] tracking options
+     * @param {String} [options.compress] when set to true, only latest change for a key will be recorded
+     * @param {VariableScopeDiff~definition} [preFill] an initial set of changes
+     */
+    enableTracking: function (options, preFill) {
+        if (this._postman_enableTracking) {
+            return;
+        }
+
+        this._postman_enableTracking = true;
+
+        /**
+         * Holds all the changes that have been applied on this instance.
+         *
+         * @memberOf VariableScope.prototype
+         * @type {VariableScopeDiff}
+         */
+        this.changes = new VariableScopeDiff(preFill, options); // wipe existing changes
+    },
+
+    /**
+     * Disables change tracking.
+     * *note:* Any previously tracked changes will also be reset at this point.
+     */
+    disableTracking: function () {
+        this.changes = null;
+
+        if (this._postman_enableTracking) {
+            this._postman_enableTracking = false;
+        }
+    },
+
+    /**
+     * Applies a variable diff. See {@link VariableScopeDiff}.
+     * *note:* This operation mutates the instance.
+     *
+     * @param {VariableScopeDiff} diff
+     */
+    patch (diff) {
+        if (!diff) {
+            return;
+        }
+
+        // convert the diff to variable scope instance if not already
+        !VariableScopeDiff.isVariableScopeDiff(diff) && (diff = new VariableScopeDiff(diff));
+
+        diff.applyOn(this);
     },
 
     /**
@@ -268,6 +359,11 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
         // being a pointless object post JSONification.
         if (obj._layers) {
             delete obj._layers;
+        }
+
+        // remove internal variable for change tracking
+        if (obj._postman_enableTracking) {
+            delete obj._postman_enableTracking;
         }
 
         return obj;

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,8 +25,10 @@ module.exports = {
     UrlMatchPattern: require('./url-pattern/url-match-pattern').UrlMatchPattern,
     UrlMatchPatternList: require('./url-pattern/url-match-pattern-list').UrlMatchPatternList,
     Variable: require('./collection/variable').Variable,
+    VariableChangeset: require('./collection/variable-changeset').VariableChangeset,
     VariableList: require('./collection/variable-list').VariableList,
     VariableScope: require('./collection/variable-scope').VariableScope,
+    VariableScopeDiff: require('./collection/variable-scope-diff').VariableScopeDiff,
     ProxyConfig: require('./collection/proxy-config').ProxyConfig,
     ProxyConfigList: require('./collection/proxy-config-list').ProxyConfigList,
     Version: require('./collection/version').Version

--- a/test/system/source-modules.test.js
+++ b/test/system/source-modules.test.js
@@ -9,7 +9,8 @@ var fs = require('fs'),
 
     BASELESS_MODULES = ['Description'],
     SCHEMALESS_MODULES = ['EventList', 'FormParam', 'PropertyBase', 'PropertyList', 'Property', 'ProxyConfigList',
-        'QueryParam', 'RequestAuth', 'RequestBody', 'VariableList', 'VariableScope', 'RequestAuthBase'];
+        'QueryParam', 'RequestAuth', 'RequestBody', 'RequestAuthBase',
+        'VariableList', 'VariableScope', 'VariableChangeset', 'VariableScopeDiff'];
 
 describe('collection module', function () {
     var modules = require('require-all')({

--- a/test/unit/variable-changeset.test.js
+++ b/test/unit/variable-changeset.test.js
@@ -1,0 +1,191 @@
+var expect = require('expect.js'),
+    VariableChangeset = require('../../').VariableChangeset,
+    VariableScope = require('../../').VariableScope;
+
+/* global describe, it */
+describe('VariableChangeset', function () {
+    describe('constructor', function () {
+        it('should initialize with definition for set instruction', function () {
+            var changesetDefinition = {
+                    id: '1',
+                    key: 'foo',
+                    type: 'set',
+                    value: 'fooValue'
+                },
+                changeset = new VariableChangeset(changesetDefinition);
+
+            expect(changeset).to.have.property('id', changesetDefinition.id);
+            expect(changeset).to.have.property('key', changesetDefinition.key);
+            expect(changeset).to.have.property('type', changesetDefinition.type);
+            expect(changeset).to.have.property('value', changesetDefinition.value);
+        });
+
+        it('should initialize with definition for unset instruction', function () {
+            var changesetDefinition = {
+                    id: '1',
+                    key: 'foo',
+                    type: 'unset'
+                },
+                changeset = new VariableChangeset(changesetDefinition);
+
+            expect(changeset).to.have.property('id', changesetDefinition.id);
+            expect(changeset).to.have.property('key', changesetDefinition.key);
+            expect(changeset).to.have.property('type', changesetDefinition.type);
+            expect(changeset).to.not.have.property('value');
+        });
+
+        it('should initialize with serialized definition for set instruction', function () {
+            var changesetDefinition = {
+                    id: '1',
+                    key: 'foo',
+                    type: 'set',
+                    value: 'fooValue'
+                },
+                serializedDefinition = [changesetDefinition.id, changesetDefinition.key, changesetDefinition.value],
+                changeset = new VariableChangeset(serializedDefinition);
+
+            expect(changeset).to.have.property('id', changesetDefinition.id);
+            expect(changeset).to.have.property('key', changesetDefinition.key);
+            expect(changeset).to.have.property('type', changesetDefinition.type);
+            expect(changeset).to.have.property('value', changesetDefinition.value);
+        });
+
+        it('should initialize with serialized definition for unset instruction', function () {
+            var changesetDefinition = {
+                    id: '1',
+                    key: 'foo',
+                    type: 'unset'
+                },
+                serializedDefinition = [changesetDefinition.id, changesetDefinition.key],
+                changeset = new VariableChangeset(serializedDefinition);
+
+            expect(changeset).to.have.property('id', changesetDefinition.id);
+            expect(changeset).to.have.property('key', changesetDefinition.key);
+            expect(changeset).to.have.property('type', changesetDefinition.type);
+            expect(changeset).to.not.have.property('value');
+        });
+
+        it('should initialize by auto creating id', function () {
+            var changesetDefinition = {
+                    key: 'foo',
+                    type: 'unset'
+                },
+                serializedDefinition = [changesetDefinition.id, changesetDefinition.key],
+                changeset = new VariableChangeset(serializedDefinition);
+
+            expect(changeset).to.have.property('id');
+            expect(changeset).to.have.property('key', changesetDefinition.key);
+            expect(changeset).to.have.property('type', changesetDefinition.type);
+            expect(changeset).to.not.have.property('value');
+        });
+    });
+
+    describe('applying', function () {
+        it('should apply set changeset on variable scope for create', function () {
+            var changeset = new VariableChangeset({
+                    id: 1,
+                    key: 'foo',
+                    type: 'set',
+                    value: 'value'
+                }),
+                scope = new VariableScope();
+
+            changeset.applyOn(scope);
+
+            expect(scope.get('foo')).to.eql('value');
+        });
+
+        it('should apply set changeset on variable scope for update', function () {
+            var changeset = new VariableChangeset({
+                    id: 1,
+                    key: 'foo',
+                    type: 'set',
+                    value: 'value'
+                }),
+                scope = new VariableScope({
+                    values: [{
+                        key: 'foo',
+                        value: 'oldValue'
+                    }]
+                });
+
+            changeset.applyOn(scope);
+
+            expect(scope.get('foo')).to.eql('value');
+        });
+
+        it('should apply unset changeset on variable scope', function () {
+            var changeset = new VariableChangeset({
+                    id: 1,
+                    key: 'foo',
+                    type: 'unset'
+                }),
+                scope = new VariableScope({
+                    values: [{
+                        key: 'foo',
+                        value: 'oldValue'
+                    }]
+                });
+
+            changeset.applyOn(scope);
+
+            expect(scope.has('foo')).to.eql(false);
+        });
+
+        it('should ignore unknown operation type', function () {
+            var changeset = new VariableChangeset({
+                    id: 1,
+                    key: 'foo',
+                    type: 'lolol'
+                }),
+                scope = new VariableScope({
+                    values: [{
+                        key: 'foo',
+                        value: 'oldValue'
+                    }]
+                });
+
+            changeset.applyOn(scope);
+
+            expect(scope.get('foo')).to.eql('oldValue');
+        });
+
+        it('should bail for anything other than variable scope', function () {
+            var changeset = new VariableChangeset({
+                id: 1,
+                key: 'foo',
+                type: 'lolol'
+            });
+
+            // apply on does not return anything, we're okay with that
+            // we're just making sure there are no errors
+            expect(changeset.applyOn({})).to.not.be.ok();
+            expect(changeset.applyOn()).to.not.be.ok();
+            expect(changeset.applyOn(null)).to.not.be.ok();
+            expect(changeset.applyOn(new VariableChangeset())).to.not.be.ok();
+        });
+    });
+
+    describe('toJSON', function () {
+        it('should generate serialized set changeset', function () {
+            var changeset = new VariableChangeset({
+                id: '1',
+                key: 'foo',
+                type: 'set',
+                value: 'fooValue'
+            });
+
+            expect(changeset.toJSON()).to.eql(['1', ['foo'], 'fooValue']);
+        });
+
+        it('should generate serialized unset changeset', function () {
+            var changeset = new VariableChangeset({
+                id: '1',
+                key: 'foo',
+                type: 'unset'
+            });
+
+            expect(changeset.toJSON()).to.eql(['1', ['foo']]);
+        });
+    });
+});

--- a/test/unit/variable-scop-diff.test.js
+++ b/test/unit/variable-scop-diff.test.js
@@ -1,0 +1,338 @@
+var expect = require('expect.js'),
+    VariableScopeDiff = require('../../').VariableScopeDiff,
+    VariableScope = require('../../').VariableScope;
+
+/* global describe, it */
+describe('VariableScopeDiff', function () {
+    describe('constructor', function () {
+        it('should initialize with raw mode by default', function () {
+            var diff = new VariableScopeDiff();
+
+            expect(diff).to.have.property('mode', 'raw');
+        });
+
+        it('should initialize with raw mode when specified', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'raw',
+                raw: [['1', ['foo'], 'bar']]
+            });
+
+            expect(diff).to.have.property('mode', 'raw');
+            expect(diff).to.not.have.property('compressed');
+            expect(diff).to.have.property('raw');
+            expect(diff.raw).to.have.length(1);
+        });
+
+        it('should initialize with compressed mode when specified', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'compressed',
+                compressed: {
+                    foo: ['1', ['foo'], 'bar']
+                }
+            });
+
+            expect(diff).to.have.property('mode', 'compressed');
+            expect(diff).to.have.property('compressed');
+            expect(diff).to.not.have.property('raw');
+        });
+
+        it('should initialize with options', function () {
+            var diff = new VariableScopeDiff({}, { compress: true });
+
+            expect(diff.isCompressed()).to.eql(true);
+        });
+
+        it('should take compression mode from options in case of conflict (prefer compress)', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'raw',
+                raw: [['1', ['foo'], 'bar']]
+            }, { compress: true });
+
+            expect(diff.isCompressed()).to.eql(true);
+            expect(diff.all()).to.have.length(1);
+        });
+    });
+
+    describe('track', function () {
+        it('should track set changesets in raw mode', function () {
+            var diff = new VariableScopeDiff({});
+
+            diff.track('set', 'foo', 'value');
+
+            expect(diff).to.have.property('raw');
+            expect(diff.raw).to.have.length(1);
+        });
+
+        it('should track set changesets in compressed mode', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'compressed'
+            });
+
+            diff.track('set', 'foo', 'value');
+
+            expect(diff).to.have.property('compressed');
+            expect(diff).to.not.have.property('raw');
+            expect(diff.compressed).to.have.property('foo');
+        });
+
+        it('should compress changesets in compressed mode', function () {
+            var diff = new VariableScopeDiff({
+                    mode: 'compressed'
+                }),
+                changeset;
+
+            diff.track('set', 'foo', 'value');
+            diff.track('set', 'foo', 'value1');
+
+            expect(diff).to.have.property('compressed');
+            expect(diff).to.not.have.property('raw');
+            expect(diff.compressed).to.have.property('foo');
+
+            // drop changeset id
+            changeset = diff.compressed.foo.toJSON();
+            changeset.shift();
+
+            // make sure changeset has the latest value
+            expect(changeset).to.eql([['foo'], 'value1']);
+        });
+    });
+
+    describe('all', function () {
+        it('should return all changesets in raw mode', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'raw',
+                raw: [['1', ['foo'], 'fooValue'], ['2', ['bar'], 'barValue']]
+            });
+
+            expect(diff.all()).to.have.length(2);
+        });
+
+        it('should return all changesets in compressed mode', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'compressed'
+            });
+
+            diff.track('set', 'foo', 'fooValue');
+            diff.track('set', 'foo', 'fooValue1');
+            diff.track('unset', 'bar', 'barValue');
+
+            expect(diff.all()).to.have.length(2);
+        });
+    });
+
+    describe('count', function () {
+        it('should return count in raw mode', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'raw',
+                raw: [['1', ['foo'], 'fooValue'], ['2', ['bar'], 'barValue']]
+            });
+
+            expect(diff.count()).to.equal(2);
+        });
+
+        it('should return count in compressed mode', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'compressed'
+            });
+
+            diff.track('set', 'foo', 'fooValue');
+            diff.track('set', 'foo', 'fooValue1');
+            diff.track('unset', 'bar', 'barValue');
+
+            expect(diff.count()).to.equal(2);
+        });
+    });
+
+    describe('applying', function () {
+        it('should apply changes in raw mode', function () {
+            var diff = new VariableScopeDiff({
+                    mode: 'raw',
+                    raw: [[1, ['foo'], 'fooValue'], [2, ['bar'], 'barValue']]
+                }),
+                scope = new VariableScope();
+
+            diff.applyOn(scope);
+
+            expect(scope.get('foo')).to.eql('fooValue');
+            expect(scope.get('bar')).to.eql('barValue');
+        });
+
+        it('should apply changes in compressed mode', function () {
+            var diff = new VariableScopeDiff({
+                    mode: 'compressed'
+                }),
+                scope = new VariableScope();
+
+            diff.track('set', 'foo', 'fooValue');
+            diff.track('set', 'bar', 'barValue');
+
+            diff.applyOn(scope);
+
+            expect(scope.get('foo')).to.eql('fooValue');
+            expect(scope.get('bar')).to.eql('barValue');
+        });
+
+        it('should bail for anything other than variable scope', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'compressed'
+            });
+
+            // apply on does not return anything, we're okay with that
+            // we're just making sure there are no errors
+            expect(diff.applyOn({})).to.not.be.ok();
+            expect(diff.applyOn()).to.not.be.ok();
+            expect(diff.applyOn(null)).to.not.be.ok();
+            expect(diff.applyOn(new VariableScopeDiff())).to.not.be.ok();
+        });
+    });
+
+    describe('import', function () {
+        it('should import raw mode changesets into raw mode', function () {
+            var diff1 = new VariableScopeDiff({
+                    mode: 'raw'
+                }),
+                diff2 = new VariableScopeDiff({
+                    mode: 'raw'
+                });
+
+            diff1.track('set', 'foo', 'fooValue');
+            diff1.track('set', 'bar', 'barValue');
+
+            diff2.track('set', 'foo1', 'fooValue');
+            diff2.track('set', 'bar1', 'barValue');
+
+            diff1.import(diff2);
+
+            expect(diff1.all()).to.have.length(4);
+        });
+
+        it('should import raw mode changesets into compressed mode', function () {
+            var diff1 = new VariableScopeDiff({
+                    mode: 'compressed'
+                }),
+                diff2 = new VariableScopeDiff({
+                    mode: 'raw'
+                });
+
+            diff1.track('set', 'foo', 'fooValue');
+            diff1.track('set', 'bar', 'barValue');
+
+            diff2.track('set', 'foo1', 'fooValue');
+            diff2.track('set', 'bar1', 'barValue');
+
+            diff1.import(diff2);
+
+            expect(diff1.all()).to.have.length(4);
+        });
+
+        it('should import compressed mode changesets into raw mode', function () {
+            var diff1 = new VariableScopeDiff({
+                    mode: 'raw'
+                }),
+                diff2 = new VariableScopeDiff({
+                    mode: 'compressed'
+                });
+
+            diff1.track('set', 'foo', 'fooValue');
+            diff1.track('set', 'bar', 'barValue');
+
+            diff2.track('set', 'foo1', 'fooValue');
+            diff2.track('set', 'bar1', 'barValue');
+
+            diff1.import(diff2);
+
+            expect(diff1.all()).to.have.length(4);
+        });
+
+        it('should import compressed mode changesets into compressed mode', function () {
+            var diff1 = new VariableScopeDiff({
+                    mode: 'raw'
+                }),
+                diff2 = new VariableScopeDiff({
+                    mode: 'compressed'
+                });
+
+            diff1.track('set', 'foo', 'fooValue');
+            diff1.track('set', 'bar', 'barValue');
+
+            diff2.track('set', 'foo1', 'fooValue');
+            diff2.track('set', 'bar1', 'barValue');
+
+            diff1.import(diff2);
+
+            expect(diff1.all()).to.have.length(4);
+        });
+
+        it('should import changesets from a JSON definition', function () {
+            var diff1 = new VariableScopeDiff({
+                    mode: 'raw'
+                }),
+                diff2 = new VariableScopeDiff({
+                    mode: 'compressed'
+                });
+
+            diff1.track('set', 'foo', 'fooValue');
+            diff1.track('set', 'bar', 'barValue');
+
+            diff2.track('set', 'foo1', 'fooValue');
+            diff2.track('set', 'bar1', 'barValue');
+
+            diff1.import(diff2.toJSON());
+
+            expect(diff1.all()).to.have.length(4);
+        });
+    });
+
+    describe('reset', function () {
+        it('should reset raw changesets', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'raw',
+                raw: [[5, ['foo'], 'fooValue']]
+            });
+
+            diff.reset();
+
+            expect(diff.raw).to.eql([]);
+        });
+
+        it('should reset compressed changesets', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'compressed',
+                compressed: {
+                    foo: [5, ['foo'], 'fooValue']
+                }
+            });
+
+            diff.reset();
+
+            expect(diff.compressed).to.eql({});
+        });
+    });
+
+    describe('compress', function () {
+        it('should compress do nothing if already compressed', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'compressed',
+                compressed: {
+                    foo: ['1', ['foo'], 'fooValue']
+                }
+            });
+
+            diff.compress();
+
+            expect(diff.compressed.foo.toJSON()).to.eql(['1', ['foo'], 'fooValue']);
+        });
+
+        it('should compress raw mode changesets', function () {
+            var diff = new VariableScopeDiff({
+                mode: 'raw',
+                raw: [['1', ['foo'], 'fooValue'], ['2', ['foo'], 'fooValue1'], ['3', ['bar'], 'barValue']]
+            });
+
+            diff.compress();
+
+            expect(diff.compressed.foo.toJSON()).to.eql([2, ['foo'], 'fooValue1']);
+            expect(diff.compressed.bar.toJSON()).to.eql([3, ['bar'], 'barValue']);
+        });
+    });
+});


### PR DESCRIPTION
* Added `VariableChangeset`
* Added `VariableScopeDiff`
* Added `enableTracking` flag to `VariableScope`
* Added `VariableScope#enableTracking` and `VariableScope#disableTracking`

Will add a proper changelog if there are no API changes requested.