### PR TITLE
JSDoc: Fix `Description~definition` property

### DIFF
--- a/lib/collection/description.js
+++ b/lib/collection/description.js
@@ -35,7 +35,7 @@ marked.setOptions(MARKDOWN_DEFAULT_OPTIONS);
 /**
  * @typedef Description~definition
  * @property {String} content
- * @property {String} format
+ * @property {String} type
  */
 /**
  * This is one of the properties that are (if provided) processed by all other properties. Any property can have an
@@ -47,7 +47,7 @@ marked.setOptions(MARKDOWN_DEFAULT_OPTIONS);
  *
  * @param {Description~definition|String} [definition] The content of the description can be passed as a string when it
  * is in `text/plain` format or otherwise be sent as part of an object adhering to the {@link Description~definition}
- * structure having `content` and `format`.
+ * structure having `content` and `type`.
  *
  * @example <caption>Add a description to an instance of Collection</caption>
  *  var SDK = require('postman-collection'),


### PR DESCRIPTION
Fixes #592 