### PR TITLE
Revert "Added node 10 to test CI matrix and removed node 4"

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -9,9 +9,9 @@ init:
 # environment variables
 environment:
   matrix:
+    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
-    - nodejs_version: "10"
 
 # scripts that run after cloning repository
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 dist: 'trusty'
 language: node_js
 node_js:
+- '4'
 - '6'
 - '8'
-- '10'
 addons:
   apt:
     packages:

--- a/lib/collection/mutation-tracker.js
+++ b/lib/collection/mutation-tracker.js
@@ -182,7 +182,7 @@ _.assign(MutationTracker.prototype, /** @lends MutationTracker.prototype */ {
     count: function () {
         // the total count of mutations is the sum of
         // mutations in the stream
-        let mutationCount = this.stream.length;
+        var mutationCount = this.stream.length;
 
         // and the compacted mutations
         mutationCount += Object.keys(this.compacted).length;

--- a/lib/collection/mutation-tracker.js
+++ b/lib/collection/mutation-tracker.js
@@ -40,7 +40,10 @@ var _ = require('../util').lodash,
         var operation = mutation.length > 1 ? PRIMITIVE_MUTATIONS.SET : PRIMITIVE_MUTATIONS.UNSET;
 
         // now hand over applying mutation to the target
-        target.applyMutation(operation, ...mutation);
+        // @todo: primitive mutations have not more than two items
+        // though spread would be more future proof
+        // switch to array spread once we drop support for node v4
+        target.applyMutation(operation, mutation[0], mutation[1]);
     },
 
     MutationTracker;
@@ -141,7 +144,10 @@ _.assign(MutationTracker.prototype, /** @lends MutationTracker.prototype */ {
      *
      * @param {String} instruction the type of mutation
      */
-    track: function (instruction, ...payload) {
+    track: function (instruction) {
+        // @todo: use argument spread here once we drop support for node v4
+        var payload = Array.prototype.slice.call(arguments, 1);
+
         // invalid call
         if (!(instruction && payload)) {
             return;

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -314,11 +314,13 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      *
      * @param {String} instruction Instruction identifying the type of the mutation, e.g. `set`, `unset`
      */
-    applyMutation: function (instruction, ...payload) {
+    applyMutation: function (instruction, key, value) {
         // we know that `set` and `unset` are the only supported instructions
         // and we know the parameter signature of both is the same as the items in a mutation
         if (this[instruction]) {
-            this[instruction](...payload);
+
+            // @todo: use argument spread here, once node v4 support is dropped
+            this[instruction](key, value);
         }
     },
 

--- a/test/system/travis-yml.test.js
+++ b/test/system/travis-yml.test.js
@@ -30,7 +30,7 @@ describe('travis.yml', function () {
 
         it('language must be set to node', function () {
             expect(travisYAML.language).to.be('node_js');
-            expect(travisYAML.node_js).to.eql(['6', '8', '10']);
+            expect(travisYAML.node_js).to.eql(['4', '6', '8']);
         });
 
         it('should have a valid before_install sequence', function () {


### PR DESCRIPTION
Reverts postmanlabs/postman-collection#662

Added support for node v4. Waiting until the next major release of `postman-runtime` to drop support for node v4.