### PR TITLE
Remove console warn statement in variable scope

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
     "no-await-in-loop": "error",
     "no-compare-neg-zero": "error",
     "no-cond-assign": "error",
-    "no-console": "off",
+    "no-console": "error",
     "no-constant-condition": "error",
     "no-control-regex": "error",
     "no-debugger": "error",

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -293,11 +293,7 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
 
         // we don't want to add more mutations to existing mutations
         // that will lead to mutations not capturing the correct state
-        // so we reset this with the new instance, and warn
-        if (this.mutations) {
-            console.warn('VariableScope~enableTracking: Dropping existing mutations to enable fresh tracking.');
-        }
-
+        // so we reset this with the new instance
         this.mutations = new MutationTracker(options);
     },
 

--- a/npm/.eslintrc
+++ b/npm/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+      "no-console": "off"
+  }
+}


### PR DESCRIPTION
Postman Collection SDK executes in multiple environments where sometimes `console` is not available like `postman-sandbox` bootcode before sandbox is completely initialized.

I've removed the runtime warning. The docs still communicate this.

Enabled lint rule to prevent console statements from being added.