### PR TITLE
Fix URL `path` parsing

### DIFF
--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -102,7 +102,12 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
         }
 
         // expand string path name
-        _.isString(path) && (path = path.split(PATH_SEPARATOR));
+        if (_.isString(path)) {
+            path && (path = path.replace(regexes.trimPath, MATCH_1)); // remove leading slash for valid path
+            // if path is blank string, we set it to undefined, if '/' then single blank string array
+            path = !path ? undefined : (path === PATH_SEPARATOR ? [E] : path.split(PATH_SEPARATOR));
+        }
+
         // expand host string
         _.isString(host) && (host = host.split(regexes.splitDomain));
 
@@ -251,7 +256,7 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
                 res.push(_.isString(variable) ? variable : segment);
             }, []),
             path = segmentArray.join(PATH_SEPARATOR);
-        return _.startsWith(path, PATH_SEPARATOR) ? path : PATH_SEPARATOR + path;
+        return PATH_SEPARATOR + path; // add leading slash
     },
 
     /**

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -105,7 +105,7 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
         if (_.isString(path)) {
             path && (path = path.replace(regexes.trimPath, MATCH_1)); // remove leading slash for valid path
             // if path is blank string, we set it to undefined, if '/' then single blank string array
-            path = !path ? undefined : (path === PATH_SEPARATOR ? [E] : path.split(PATH_SEPARATOR));
+            path = path ? (path === PATH_SEPARATOR ? [E] : path.split(PATH_SEPARATOR)) : undefined;
         }
 
         // expand host string
@@ -396,7 +396,7 @@ _.assign(Url, /** @lends Url */ {
             url = url.substr(p.path.length);
             p.path && (p.path = p.path.replace(regexes.trimPath, MATCH_1)); // remove leading slash for valid path
             // if path is blank string, we set it to undefined, if '/' then single blank string array
-            p.path = !p.path ? undefined : (p.path === PATH_SEPARATOR ? [E] : p.path.split(PATH_SEPARATOR));
+            p.path = p.path ? (p.path === PATH_SEPARATOR ? [E] : p.path.split(PATH_SEPARATOR)) : undefined;
         }
 
         // extract the query string


### PR DESCRIPTION
Fixes postmanlabs/postman-app-support#4663

- Handle empty path issue
- Properly parse string path in JSON representation