### PR TITLE
Url.parse: Add `variable` property in parsed Url

### DIFF
--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -243,7 +243,7 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
             segmentArray = (options && options.unresolved) ? this.path : _.transform(this.path, function (res, segment) {
                 var variable;
 
-                if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER)) {
+                if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER) && segment.length > 1) {
                     variable = self.variables.one(segment.slice(1));
                 }
 
@@ -400,6 +400,13 @@ _.assign(Url, /** @lends Url */ {
 
         // extract the hash
         p.hash = _.get(url.match(regexes.extractSearch), GET_1);
+
+        p.variable = _.transform(p.path, function (res, segment) {
+            if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER) && segment.length > 1) {
+                res.push({ key: segment.slice(1) });
+            }
+        }, []);
+
         return p;
     },
 

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -242,9 +242,10 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
             // eslint-disable-next-line max-len
             segmentArray = (options && options.unresolved) ? this.path : _.transform(this.path, function (res, segment) {
                 var variable;
-
+                // check if segment has path variable prefix and,
+                // its length is > 1 to avoid segment like `:`.
                 if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER) && segment.length > 1) {
-                    variable = self.variables.one(segment.slice(1));
+                    variable = self.variables.one(segment.slice(1)); // remove path variable prefix.
                 }
 
                 variable = variable && variable.valueOf && variable.valueOf();
@@ -402,8 +403,10 @@ _.assign(Url, /** @lends Url */ {
         p.hash = _.get(url.match(regexes.extractSearch), GET_1);
 
         p.variable = _.transform(p.path, function (res, segment) {
+            // check if segment has path variable prefix and,
+            // its length is > 1 to avoid segment like `:`.
             if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER) && segment.length > 1) {
-                res.push({ key: segment.slice(1) });
+                res.push({ key: segment.slice(1) }); // remove path variable prefix.
             }
         }, []);
 

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -242,9 +242,8 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
             // eslint-disable-next-line max-len
             segmentArray = (options && options.unresolved) ? this.path : _.transform(this.path, function (res, segment) {
                 var variable;
-                // check if segment has path variable prefix and,
-                // its length is > 1 to avoid segment like `:`.
-                if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER) && segment.length > 1) {
+                // check if the segment has path variable prefix followed by the variable name.
+                if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER) && segment !== PATH_VARIABLE_IDENTIFIER) {
                     variable = self.variables.one(segment.slice(1)); // remove path variable prefix.
                 }
 
@@ -403,9 +402,8 @@ _.assign(Url, /** @lends Url */ {
         p.hash = _.get(url.match(regexes.extractSearch), GET_1);
 
         p.variable = _.transform(p.path, function (res, segment) {
-            // check if segment has path variable prefix and,
-            // its length is > 1 to avoid segment like `:`.
-            if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER) && segment.length > 1) {
+            // check if the segment has path variable prefix followed by the variable name.
+            if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER) && segment !== PATH_VARIABLE_IDENTIFIER) {
                 res.push({ key: segment.slice(1) }); // remove path variable prefix.
             }
         }, []);

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -435,6 +435,15 @@ describe('Url', function () {
             expect(subject.port).to.be(undefined);
         });
 
+        it('should parse path variables properly', function () {
+            var subject = Url.parse('http://127.0.0.1/:a/:ab.json/:a+b');
+            expect(subject).to.have.property('variable');
+            expect(subject.variable).to.have.length(3);
+            expect(subject.variable).to.eql([
+                { key: 'a' }, { key: 'ab.json' }, { key: 'a+b' }
+            ]);
+        });
+
         it('should not parse empty path variables', function () {
             var subject = Url.parse('http://127.0.0.1/:/:/:var');
             expect(subject.path).to.eql([':', ':', ':var']);

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -434,6 +434,13 @@ describe('Url', function () {
             expect(subject.path).to.eql(['', '..', 'etc', 'hosts']);
             expect(subject.port).to.be(undefined);
         });
+
+        it('should not parse empty path variables', function () {
+            var subject = Url.parse('http://127.0.0.1/:/:/:var');
+            expect(subject.path).to.eql([':', ':', ':var']);
+            expect(subject.variable).to.have.length(1);
+            expect(subject.variable).to.eql([{ key: 'var' }]);
+        });
     });
 
     describe('unparsing', function () {


### PR DESCRIPTION
- Add `variable` property in parsed Url.
- Fix undefined path variable key name issue from `/:/:/`.

> `variable` property will help App to identify path variables from the raw URL.