### PR TITLE
Fixed Non-String Request Methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Postman Collection SDK Changelog
 
+#### Unreleased
+* #699 Handle non-string request method correctly
+* Updated dependencies
+
 #### v3.2.0 (August 20, 2018)
 * #694 Updated dependencies :arrow_up:
 * #689 Added support for `contentType` to form data request bodies.

--- a/lib/collection/request.js
+++ b/lib/collection/request.js
@@ -56,6 +56,7 @@ _.inherit((
              * @type {String}
              * @todo: Clean this up
              */
+            // the negated condition is required to keep DEFAULT_REQ_METHOD as a fallback
             method: _.has(options, 'method') && !_.isNil(options.method) ?
                 String(options.method).toUpperCase() : DEFAULT_REQ_METHOD
         });
@@ -81,8 +82,8 @@ _.assign(Request.prototype, /** @lends Request.prototype */ {
         options.header && this.headers.repopulate(options.header);
 
         // Only update the method if one is provided.
-        _.has(options, 'method') && (this.method = !_.isNil(options.method) ?
-            String(options.method).toUpperCase() : DEFAULT_REQ_METHOD);
+        _.has(options, 'method') && (this.method = _.isNil(options.method) ?
+            DEFAULT_REQ_METHOD : String(options.method).toUpperCase());
 
         // The rest of the properties are not assumed to exist so we merge in the defined ones.
         _.mergeDefined(this, /** @lends Request.prototype */ {

--- a/lib/collection/request.js
+++ b/lib/collection/request.js
@@ -56,7 +56,8 @@ _.inherit((
              * @type {String}
              * @todo: Clean this up
              */
-            method: ((options && options.method) || DEFAULT_REQ_METHOD).toUpperCase()
+            method: _.has(options, 'method') && !_.isNil(options.method) ?
+                String(options.method).toUpperCase() : DEFAULT_REQ_METHOD
         });
 
         this.update(options);
@@ -80,8 +81,8 @@ _.assign(Request.prototype, /** @lends Request.prototype */ {
         options.header && this.headers.repopulate(options.header);
 
         // Only update the method if one is provided.
-        _.has(options, 'method') && (this.method = _.isString(options.method) ? options.method.toUpperCase() :
-            (options.method || DEFAULT_REQ_METHOD));
+        _.has(options, 'method') && (this.method = !_.isNil(options.method) ?
+            String(options.method).toUpperCase() : DEFAULT_REQ_METHOD);
 
         // The rest of the properties are not assumed to exist so we merge in the defined ones.
         _.mergeDefined(this, /** @lends Request.prototype */ {

--- a/test/unit/request.test.js
+++ b/test/unit/request.test.js
@@ -85,13 +85,13 @@ describe('Request', function () {
                 certificate: {}
             });
 
-            expect(req.method).to.be('GET');
+            expect(req).to.have.property('method', 'GET');
             expect(sdk.ProxyConfig.isProxyConfig(req.proxy)).to.be(true);
             expect(sdk.Certificate.isCertificate(req.certificate)).to.be(true);
 
-            req.update({ method: { name: 'GET' } });
+            req.update({ method: 'POST' });
 
-            expect(req.method).to.eql({ name: 'GET' });
+            expect(req).to.have.property('method', 'POST');
             expect(req.toJSON()).to.have.keys(['certificate', 'proxy', 'url']);
         });
 
@@ -101,7 +101,20 @@ describe('Request', function () {
                 url: 'https://postman-echo.com/:path'
             });
 
-            expect(req.method).to.be('GET');
+            expect(req).to.have.property('method', 'GET');
+        });
+
+        it('should handle non-string request methods correctly', function () {
+            var req = new Request({
+                method: 12345,
+                url: 'https://postman-echo.com/:path'
+            });
+
+            expect(req).to.have.property('method', '12345');
+
+            req.update({ method: false });
+
+            expect(req).to.have.property('method', 'FALSE');
         });
 
         it('should handle falsy request options correctly', function () {

--- a/test/unit/request.test.js
+++ b/test/unit/request.test.js
@@ -95,30 +95,49 @@ describe('Request', function () {
             expect(req.toJSON()).to.have.keys(['certificate', 'proxy', 'url']);
         });
 
-        it('should handle falsy request methods correctly', function () {
-            var req = new Request({
-                method: null,
-                url: 'https://postman-echo.com/:path'
+        describe('request method', function () {
+            it('should defaults to GET', function () {
+                expect(new Request()).to.have.property('method', 'GET');
             });
 
-            expect(req).to.have.property('method', 'GET');
-        });
+            it('should handle null & undefined correctly', function () {
+                var req = new Request({
+                    method: null,
+                    url: 'https://postman-echo.com/:path'
+                });
 
-        it('should handle non-string request methods correctly', function () {
-            var req = new Request({
-                method: 12345,
-                url: 'https://postman-echo.com/:path'
+                expect(req).to.have.property('method', 'GET');
+
+                req.update({ method: undefined });
+                expect(req).to.have.property('method', 'GET');
             });
 
-            expect(req).to.have.property('method', '12345');
+            it('should handle non-string correctly', function () {
+                var req = new Request({
+                    method: 12345,
+                    url: 'https://postman-echo.com/:path'
+                });
 
-            req.update({ method: false });
+                expect(req).to.have.property('method', '12345');
 
-            expect(req).to.have.property('method', 'FALSE');
-        });
+                req.update({ method: false });
+                expect(req).to.have.property('method', 'FALSE');
+            });
 
-        it('should handle falsy request options correctly', function () {
-            expect(new Request()).to.have.property('method', 'GET');
+            it('should handle object & function correctly', function () {
+                var req = new Request({
+                    method: { name: 'GET' },
+                    url: 'https://postman-echo.com/:path'
+                });
+
+                expect(req).to.have.property('method', '[OBJECT OBJECT]');
+
+                req.update({ method: function () { return 0; } });
+                expect(req).to.have.property('method', 'FUNCTION () { RETURN 0; }');
+
+                req.update({ method: [1, 2, 3] });
+                expect(req).to.have.property('method', '1,2,3');
+            });
         });
 
         describe('has property', function () {

--- a/test/unit/request.test.js
+++ b/test/unit/request.test.js
@@ -96,7 +96,7 @@ describe('Request', function () {
         });
 
         describe('request method', function () {
-            it('should defaults to GET', function () {
+            it('should default to GET', function () {
                 expect(new Request()).to.have.property('method', 'GET');
             });
 


### PR DESCRIPTION
- Fixes bug where non-string request method throws an error because of `toUpperCase`.
- Also, bring the request's `update` method in parity with the constructor.