### PR TITLE
Inherit propertySanitizeKeys option in PropertyList

### DIFF
--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -58,7 +58,7 @@ _.inherit((
         _.getOwn(type, '_postman_propertyAllowsMultipleValues') && (this._postman_listAllowsMultipleValues =
             type._postman_propertyAllowsMultipleValues);
 
-        // if the type don't allow falsy key, set the flag
+        // if the type doesn't allow falsy key, set the flag
         _.getOwn(type, '_postman_propertySanitizeKeys') && (this._postman_listSanitizeKeys =
             type._postman_propertySanitizeKeys);
 

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -5,6 +5,7 @@ var _ = require('../util').lodash,
     DEFAULT_INDEX_ATTR = 'id',
     DEFAULT_INDEXCASE_ATTR = false,
     DEFAULT_INDEXMULTI_ATTR = false,
+    DEFAULT_INDEXSANITIZE_ATTR = false,
 
     PropertyList;
 
@@ -57,6 +58,10 @@ _.inherit((
         _.getOwn(type, '_postman_propertyAllowsMultipleValues') && (this._postman_listAllowsMultipleValues =
             type._postman_propertyAllowsMultipleValues);
 
+        // if the type don't allow falsy key, set the flag
+        _.getOwn(type, '_postman_propertySanitizeKeys') && (this._postman_listSanitizeKeys =
+            type._postman_propertySanitizeKeys);
+
         // prepopulate
         populate && this.populate(populate);
     }), PropertyBase);
@@ -92,6 +97,14 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
      * @type {String}
      */
     _postman_listAllowsMultipleValues: DEFAULT_INDEXMULTI_ATTR,
+
+    /**
+     * Holds the attribute whether indexing of falsy index is allowed or not
+     *
+     * @private
+     * @type {String}
+     */
+    _postman_listSanitizeKeys: DEFAULT_INDEXSANITIZE_ATTR,
 
     /**
      * Insert an element at the end of this list. When a reference member specified via second parameter is found, the
@@ -545,7 +558,7 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
 
             // gather all the switches of the list
             key = this._postman_listIndexKey,
-            sanitiseKeys = this._postman_sanitizeKeys || sanitizeKeys,
+            sanitiseKeys = this._postman_listSanitizeKeys || sanitizeKeys,
             sensitive = !this._postman_listIndexCaseInsensitive || caseSensitive,
             multivalue = this._postman_listAllowsMultipleValues || multiValue;
 

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -510,8 +510,8 @@ describe('PropertyList', function () {
                 this.disabled = options.disabled;
             };
 
-            FakeType._postman_sanitizeKeys = false;
             FakeType._postman_propertyIndexKey = 'keyAttr';
+            FakeType._postman_propertySanitizeKeys = false;
             FakeType._postman_propertyIndexCaseInsensitive = true;
             FakeType._postman_propertyAllowsMultipleValues = false;
             FakeType.prototype.valueOf = function () {
@@ -622,6 +622,23 @@ describe('PropertyList', function () {
             }]);
 
             expect(list.toObject(false, false, false, true)).to.eql({ key1: 'val2' });
+        });
+
+        it('should correctly handle the falsy keys with the sanitize option', function () {
+            FakeType._postman_propertySanitizeKeys = true;
+
+            var list = new PropertyList(FakeType, {}, [{
+                keyAttr: '',
+                value: 'val1'
+            }, {
+                keyAttr: 'key1',
+                value: 'val2'
+            }, {
+                keyAttr: null,
+                value: 'val3'
+            }]);
+
+            expect(list.toObject()).to.eql({ key1: 'val2' });
         });
     });
 

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -636,6 +636,18 @@ describe('PropertyList', function () {
             }, {
                 keyAttr: null,
                 value: 'val3'
+            }, {
+                keyAttr: 0,
+                value: 'val4'
+            }, {
+                keyAttr: false,
+                value: 'val5'
+            }, {
+                keyAttr: undefined,
+                value: 'val6'
+            }, {
+                keyAttr: NaN,
+                value: 'val7'
             }]);
 
             expect(list.toObject()).to.eql({ key1: 'val2' });


### PR DESCRIPTION
Extends #430

Using this `PropertyList` will inherit `propertySanitizeKeys` option which will be useful in cases like`HeaderList` or any other list where falsy keys are not allowed.

Property `_postman_listSanitizeKeys` used in following method:
- `toObject`