### PR TITLE
Added option to avoid falsy header keys in getHeaders method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Postman Collection SDK Changelog
 
+#### v3.4.2 (unreleased)
+* #769 Avoid substitution of disabled variables
+* #770 Added an option to exclude disabled listeners in `EventList~listeners` and `EventList~listenersOwn`
+* #773 Added an option to exclude headers with falsy keys in `Request~getHeaders`
+* Updated dependencies
+
 #### v3.4.1 (January 2, 2019)
 * #763 Fixed a bug where poly chained variables are not resolved correctly
 * Updated dependencies

--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -97,11 +97,13 @@ _.assign(Header.prototype, /** @lends Header.prototype */ {
      * Assigns the given properties to the Header
      *
      * @param {Object} options
+     * @todo check for allowed characters in header key-value or store encoded.
      */
     update: function (options) {
         /**
          * The header Key
          * @type {String}
+         * @todo avoid headers with falsy key.
          */
         this.key = _.get(options, 'key') || E;
 

--- a/lib/collection/request.js
+++ b/lib/collection/request.js
@@ -156,14 +156,19 @@ _.assign(Request.prototype, /** @lends Request.prototype */ {
      * @param {Boolean} options.ignoreCase When set to "true", will ensure that all the header keys are lower case.
      * @param {Boolean} options.enabled Only get the enabled headers
      * @param {Boolean} options.multiValue When set to "true", duplicate header values will be stored in an array
+     * @param {Boolean} options.sanitizeKeys When set to "true", headers with falsy keys are removed
      * @returns {Object}
      * @note If multiple headers are present in the same collection with same name, but different case
-     * (E.g "x-forward-port" and "X-Forward-Port", and `options.ignoreCase` is set to true, the result will contain
-     * the value of the header which occurs the last.
+     * (E.g "x-forward-port" and "X-Forward-Port", and `options.ignoreCase` is set to true,
+     * the values will be stored in an array.
      */
     getHeaders: function getHeaders (options) {
         !options && (options = {});
-        return this.headers.toObject(options.enabled, !options.ignoreCase, options.multiValue);
+
+        // @note: options.multiValue will not be respected since, Header._postman_propertyAllowsMultipleValues
+        // gets higher precedence in PropertyLists~toObject.
+        // @todo: sanitizeKeys for headers by default.
+        return this.headers.toObject(options.enabled, !options.ignoreCase, options.multiValue, options.sanitizeKeys);
     },
 
     /**


### PR DESCRIPTION
- Added option to avoid falsy header keys in `getHeaders` method
- Updated unit tests for `Request~getHeaders`
- Updated CHANGELOG