### PR TITLE
Revert "Inherit propertySanitizeKeys option in PropertyList"

### DIFF
--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -5,7 +5,6 @@ var _ = require('../util').lodash,
     DEFAULT_INDEX_ATTR = 'id',
     DEFAULT_INDEXCASE_ATTR = false,
     DEFAULT_INDEXMULTI_ATTR = false,
-    DEFAULT_INDEXSANITIZE_ATTR = false,
 
     PropertyList;
 
@@ -58,10 +57,6 @@ _.inherit((
         _.getOwn(type, '_postman_propertyAllowsMultipleValues') && (this._postman_listAllowsMultipleValues =
             type._postman_propertyAllowsMultipleValues);
 
-        // if the type doesn't allow falsy key, set the flag
-        _.getOwn(type, '_postman_propertySanitizeKeys') && (this._postman_listSanitizeKeys =
-            type._postman_propertySanitizeKeys);
-
         // prepopulate
         populate && this.populate(populate);
     }), PropertyBase);
@@ -97,14 +92,6 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
      * @type {String}
      */
     _postman_listAllowsMultipleValues: DEFAULT_INDEXMULTI_ATTR,
-
-    /**
-     * Holds the attribute whether indexing of falsy index is allowed or not
-     *
-     * @private
-     * @type {String}
-     */
-    _postman_listSanitizeKeys: DEFAULT_INDEXSANITIZE_ATTR,
 
     /**
      * Insert an element at the end of this list. When a reference member specified via second parameter is found, the
@@ -558,7 +545,7 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
 
             // gather all the switches of the list
             key = this._postman_listIndexKey,
-            sanitiseKeys = this._postman_listSanitizeKeys || sanitizeKeys,
+            sanitiseKeys = this._postman_sanitizeKeys || sanitizeKeys,
             sensitive = !this._postman_listIndexCaseInsensitive || caseSensitive,
             multivalue = this._postman_listAllowsMultipleValues || multiValue;
 

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -510,8 +510,8 @@ describe('PropertyList', function () {
                 this.disabled = options.disabled;
             };
 
+            FakeType._postman_sanitizeKeys = false;
             FakeType._postman_propertyIndexKey = 'keyAttr';
-            FakeType._postman_propertySanitizeKeys = false;
             FakeType._postman_propertyIndexCaseInsensitive = true;
             FakeType._postman_propertyAllowsMultipleValues = false;
             FakeType.prototype.valueOf = function () {
@@ -622,35 +622,6 @@ describe('PropertyList', function () {
             }]);
 
             expect(list.toObject(false, false, false, true)).to.eql({ key1: 'val2' });
-        });
-
-        it('should correctly handle the falsy keys with the sanitize option', function () {
-            FakeType._postman_propertySanitizeKeys = true;
-
-            var list = new PropertyList(FakeType, {}, [{
-                keyAttr: '',
-                value: 'val1'
-            }, {
-                keyAttr: 'key1',
-                value: 'val2'
-            }, {
-                keyAttr: null,
-                value: 'val3'
-            }, {
-                keyAttr: 0,
-                value: 'val4'
-            }, {
-                keyAttr: false,
-                value: 'val5'
-            }, {
-                keyAttr: undefined,
-                value: 'val6'
-            }, {
-                keyAttr: NaN,
-                value: 'val7'
-            }]);
-
-            expect(list.toObject()).to.eql({ key1: 'val2' });
         });
     });
 


### PR DESCRIPTION
Reverts postmanlabs/postman-collection#772

- Was merged prematurely
- Branch `feature/sanitizeKeys` is restored. DO NOT DELETE.