### PR TITLE
Handle disabled events by default

### DIFF
--- a/lib/collection/event-list.js
+++ b/lib/collection/event-list.js
@@ -27,8 +27,8 @@ _.assign(EventList.prototype, /** @lends EventList.prototype */ {
      * Returns an array of listeners filtered by the listener name
      *
      * @note
-     * If one needs to access disabled events, use {@link PropertyList.all} or
-     * any other similar method in {@link PropertyList}.
+     * If one needs to access disabled events, use {@link PropertyList#all} or
+     * any other similar {@link PropertyList} method.
      *
      * @param {String} name
      * @returns {Array<Event>}

--- a/lib/collection/event-list.js
+++ b/lib/collection/event-list.js
@@ -26,16 +26,18 @@ _.assign(EventList.prototype, /** @lends EventList.prototype */ {
     /**
      * Returns an array of listeners filtered by the listener name
      *
+     * @note
+     * If one needs to access disabled events, use {@link PropertyList.all} or
+     * any other similar method in {@link PropertyList}.
+     *
      * @param {String} name
-     * @param {?Object} options - Set of options
-     * @param {?Boolean} options.excludeDisabled - When set to true, disabled events are excluded
      * @returns {Array<Event>}
      */
-    listeners: function (name, options) {
+    listeners: function (name) {
         var all;
 
         // we first procure all matching events from this list
-        all = this.listenersOwn(name, options);
+        all = this.listenersOwn(name);
 
         this.eachParent(function (parent) {
             var parentEvents;
@@ -44,7 +46,7 @@ _.assign(EventList.prototype, /** @lends EventList.prototype */ {
             // valid `events` store and only if this store has events with specified listener, we push them to the
             // array we are compiling for return
             (parent !== this.__parent) && EventList.isEventList(parent.events) &&
-                (parentEvents = parent.events.listenersOwn(name, options)) && parentEvents.length &&
+                (parentEvents = parent.events.listenersOwn(name)) && parentEvents.length &&
                 all.unshift.apply(all, parentEvents); // eslint-disable-line prefer-spread
         }, this);
 
@@ -56,19 +58,11 @@ _.assign(EventList.prototype, /** @lends EventList.prototype */ {
      * procuring all inherited events
      *
      * @param {string} name
-     * @param {?Object} options - Set of options
-     * @param {?Boolean} options.excludeDisabled - When set to true, disabled events are excluded
      * @returns {Array<Event>}
      */
-    listenersOwn: function (name, options) {
-        if (options && options.excludeDisabled) {
-            return this.filter(function (event) {
-                return (!event.disabled && event.listen === name);
-            });
-        }
-
+    listenersOwn: function (name) {
         return this.filter(function (event) {
-            return (event.listen === name);
+            return (!event.disabled && event.listen === name);
         });
     }
 });

--- a/test/unit/event-list.test.js
+++ b/test/unit/event-list.test.js
@@ -214,9 +214,9 @@ describe('EventList', function () {
                 item.__parent = parent;
             });
 
-            it('should exclude disabled events if excludeDisabled is set', function () {
-                var testListeners = item.events.listeners('test', { excludeDisabled: true }),
-                    prScriptListeners = item.events.listeners('prerequest', { excludeDisabled: true });
+            it('should exclude disabled events correctly', function () {
+                var testListeners = item.events.listeners('test'),
+                    prScriptListeners = item.events.listeners('prerequest');
 
                 expect(testListeners).to.have.lengthOf(1);
 
@@ -333,9 +333,9 @@ describe('EventList', function () {
                 }]);
             });
 
-            it('should correctly filter disabled event listeners if excludeDisabled is set', function () {
-                var testListeners = item.events.listenersOwn('test', { excludeDisabled: true }),
-                    prScriptListeners = item.events.listenersOwn('prerequest', { excludeDisabled: true });
+            it('should filter disabled event listeners correctly', function () {
+                var testListeners = item.events.listenersOwn('test'),
+                    prScriptListeners = item.events.listenersOwn('prerequest');
 
                 expect(testListeners).to.have.lengthOf(1);
                 expect(testListeners[0]).to.have.property('listen', 'test');


### PR DESCRIPTION
Obsoletes #770 

- Remove options from `listenersOwn` & `listeners ` method.
- Handle disabled events by default.