### PR TITLE
Fix headers size calculation

### DIFF
--- a/lib/collection/header-list.js
+++ b/lib/collection/header-list.js
@@ -30,21 +30,15 @@ _.assign(HeaderList.prototype, /** @lends HeaderList.prototype */ {
      * @returns {Number}
      */
     contentSize: function () {
-        var raw = E,
+        var raw = this.reduce(function (acc, header) {
+            // unparse header only if it has a valid key and is not disabled
+            if (header && !header.disabled) {
+                // *( header-field CRLF )
+                acc += Header.unparseSingle(header) + CRLF;
+            }
 
-            headers = this.reduce(function (acc, header) {
-                // unparse header only if it has a valid key and is not disabled
-                if (header && !header.disabled) {
-                    acc.push(Header.unparseSingle(header));
-                }
-
-                return acc;
-            }, []);
-
-        if (headers.length) {
-            // *( header-field CRLF )
-            raw += headers.join(CRLF) + CRLF;
-        }
+            return acc;
+        }, E);
 
         return raw.length;
     }

--- a/lib/collection/header-list.js
+++ b/lib/collection/header-list.js
@@ -30,11 +30,20 @@ _.assign(HeaderList.prototype, /** @lends HeaderList.prototype */ {
      * @returns {Number}
      */
     contentSize: function () {
-        if (!this.count()) { return 0; }
-
         var raw = E;
-        raw += Header.unparse(this, CRLF);
-        raw += (CRLF + CRLF);
+
+        // *( header-field CRLF )
+        raw += this.reduce(function (acc, header) {
+            // unparse header only if it has a valid key and is not disabled
+            if (header && header.key && !header.disabled) {
+                acc.push(Header.unparseSingle(header));
+            }
+
+            return acc;
+        }, []).join(CRLF);
+
+        raw += CRLF;
+
         return raw.length;
     }
 });

--- a/lib/collection/header-list.js
+++ b/lib/collection/header-list.js
@@ -34,7 +34,7 @@ _.assign(HeaderList.prototype, /** @lends HeaderList.prototype */ {
 
             headers = this.reduce(function (acc, header) {
                 // unparse header only if it has a valid key and is not disabled
-                if (header && header.key && !header.disabled) {
+                if (header && !header.disabled) {
                     acc.push(Header.unparseSingle(header));
                 }
 

--- a/lib/collection/header-list.js
+++ b/lib/collection/header-list.js
@@ -30,19 +30,21 @@ _.assign(HeaderList.prototype, /** @lends HeaderList.prototype */ {
      * @returns {Number}
      */
     contentSize: function () {
-        var raw = E;
+        var raw = E,
 
-        // *( header-field CRLF )
-        raw += this.reduce(function (acc, header) {
-            // unparse header only if it has a valid key and is not disabled
-            if (header && header.key && !header.disabled) {
-                acc.push(Header.unparseSingle(header));
-            }
+            headers = this.reduce(function (acc, header) {
+                // unparse header only if it has a valid key and is not disabled
+                if (header && header.key && !header.disabled) {
+                    acc.push(Header.unparseSingle(header));
+                }
 
-            return acc;
-        }, []).join(CRLF);
+                return acc;
+            }, []);
 
-        raw += CRLF;
+        if (headers.length) {
+            // *( header-field CRLF )
+            raw += headers.join(CRLF) + CRLF;
+        }
 
         return raw.length;
     }

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -425,6 +425,17 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
     },
 
     /**
+     * Iterates over the property list and accumulates the result.
+     *
+     * @param {Function} iterator Function to call on each item.
+     * @param {*} accumulator Accumulator initial value
+     * @param {Object} context Optional context, defaults to the PropertyList itself.
+     */
+    reduce: function (iterator, accumulator, context) {
+        return _.reduce(this.members, _.isFunction(iterator) ? iterator.bind(context || this) : iterator, accumulator);
+    },
+
+    /**
      * Returns the length of the PropertyList
      *
      * @returns {Number}

--- a/lib/collection/response.js
+++ b/lib/collection/response.js
@@ -95,7 +95,21 @@ var util = require('../util'),
      * @const
      * @type {String}
      */
-    HTTP_X_X = 'HTTP/X.X ',
+    HTTP_X_X = 'HTTP/X.X',
+
+    /**
+     * @private
+     * @const
+     * @type {String}
+     */
+    SP = ' ',
+
+    /**
+     * @private
+     * @const
+     * @type {String}
+     */
+    CRLF = '\r\n',
 
     /**
      * @private
@@ -458,9 +472,13 @@ _.assign(Response.prototype, /** @lends Response.prototype */ {
         }
 
         // size of header is added
-        // https://tools.ietf.org/html/rfc7230#section-3.1.2
-        // status-line = HTTP-version SP status-code SP reason-phrase CRLF
-        sizeInfo.header = (HTTP_X_X + this.code + ' ' + this.reason() + '\r\n').length + this.headers.contentSize();
+        // https://tools.ietf.org/html/rfc7230#section-3
+        // HTTP-message   = start-line = HTTP-version SP status-code SP reason-phrase CRLF
+        //                  *( header-field CRLF )
+        //                  CRLF
+        //                  [ message-body ]
+        sizeInfo.header = (HTTP_X_X + SP + this.code + SP + this.reason() + CRLF + CRLF).length +
+            this.headers.contentSize();
 
         // compute the approximate total body size by adding size of header and body
         sizeInfo.total = (sizeInfo.body || 0) + (sizeInfo.header || 0);

--- a/test/unit/header-list.test.js
+++ b/test/unit/header-list.test.js
@@ -21,12 +21,24 @@ describe('HeaderList', function () {
     describe('.contentSize', function () {
         it('should be able to return header size', function () {
             var hl = new HeaderList(null, 'Accept: *\nContent-Type: text/html');
-            expect(hl.contentSize(200, 'OK')).to.equal(38);
+            expect(hl.contentSize(200, 'OK')).to.equal(36);
         });
 
-        it('should return 0 for an empty header set', function () {
+        it('should return 2 (CRLF) for an empty header set', function () {
             var hl = new HeaderList();
-            expect(hl.contentSize()).to.equal(0);
+            expect(hl.contentSize()).to.equal(2);
+        });
+
+        it('should should handle disabled and falsy headers correctly', function () {
+            var hl = new HeaderList(null, [{
+                key: undefined,
+                value: 'bar'
+            }, {
+                key: 'foo',
+                value: 'bar',
+                disabled: true
+            }]);
+            expect(hl.contentSize()).to.equal(2);
         });
     });
 

--- a/test/unit/header-list.test.js
+++ b/test/unit/header-list.test.js
@@ -24,9 +24,9 @@ describe('HeaderList', function () {
             expect(hl.contentSize(200, 'OK')).to.equal(36);
         });
 
-        it('should return 2 (CRLF) for an empty header set', function () {
+        it('should return 0 for an empty header set', function () {
             var hl = new HeaderList();
-            expect(hl.contentSize()).to.equal(2);
+            expect(hl.contentSize()).to.equal(0);
         });
 
         it('should should handle disabled and falsy headers correctly', function () {
@@ -38,7 +38,7 @@ describe('HeaderList', function () {
                 value: 'bar',
                 disabled: true
             }]);
-            expect(hl.contentSize()).to.equal(2);
+            expect(hl.contentSize()).to.equal(0);
         });
     });
 

--- a/test/unit/header-list.test.js
+++ b/test/unit/header-list.test.js
@@ -38,7 +38,7 @@ describe('HeaderList', function () {
                 value: 'bar',
                 disabled: true
             }]);
-            expect(hl.contentSize()).to.equal(0);
+            expect(hl.contentSize()).to.equal(7); // ": bar + CRLF"
         });
     });
 

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -319,7 +319,7 @@ describe('Response', function () {
         it('should handle blank responses correctly', function () {
             var response = new Response();
             expect(response.size()).to.eql({
-                body: 0, header: 34, total: 34
+                body: 0, header: 32, total: 32
             });
         });
     });

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -319,7 +319,7 @@ describe('Response', function () {
         it('should handle blank responses correctly', function () {
             var response = new Response();
             expect(response.size()).to.eql({
-                body: 0, header: 30, total: 30
+                body: 0, header: 34, total: 34
             });
         });
     });


### PR DESCRIPTION
- Fix HTTP Message calculation
- Handle disabled and falsy key headers 

Closes #787 

```
   [0]: join x 60,090,816 ops/sec ±0.18% (94 runs sampled)
   [0]: length + join x 181,755,451 ops/sec ±0.10% (96 runs sampled)
[1000]: join x 49,984 ops/sec ±0.94% (92 runs sampled)
[1000]: length + join x 50,851 ops/sec ±0.23% (92 runs sampled)
Fastest is [0]: length + join
```