### PR TITLE
Support variables with # in query parameters - Fixes Runtime 5779

### DIFF
--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -34,7 +34,7 @@ var _ = require('../util').lodash,
         extractPort: /:([^:]*)$/,
         extractPath: /.*?(?=\?|#|$)/,
         trimPath: /^\/((.+))$/,
-        extractQuery: /^\?((([^#]*[=&%()==@[\]?:/.!-]))([^#{]*)|(\{\{([^]*?)}}*))*/g,
+        extractQuery: /^\?((([^#]*[=&%()@[\]?:/.!-]))|(\{{2}([^]*?)*\}{2})|(\{*[^#]))*/g,
         extractSearch: /#(.+)$/,
         splitDomain: /\.(?![^{]*\}{2})/g
     },

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -34,7 +34,7 @@ var _ = require('../util').lodash,
         extractPort: /:([^:]*)$/,
         extractPath: /.*?(?=\?|#|$)/,
         trimPath: /^\/((.+))$/,
-        extractQuery: /^\?([^#]+)/,
+        extractQuery: /^\?((([^#]*[=&%()==@[\]?:/.!-]))([^#{]*)|(\{\{([^]*?)}}*))*/g,
         extractSearch: /#(.+)$/,
         splitDomain: /\.(?![^{]*\}{2})/g
     },
@@ -443,8 +443,9 @@ _.assign(Url, /** @lends Url */ {
         }
 
         // extract the query string
-        p.query = _.get(url.match(regexes.extractQuery), GET_1);
-        _.isString(p.query) && ((url = url.substr(p.query.length + 1)), (p.query = QueryParam.parse(p.query)));
+        p.query = _.get(url.match(regexes.extractQuery), GET_0);
+        _.isString(p.query) && (p.query = p.query.substring(p.query.indexOf('?') + 1)) &&
+            ((url = url.substr(p.query.length + 1)), (p.query = QueryParam.parse(p.query)));
 
         // extract the hash
         p.hash = _.get(url.match(regexes.extractSearch), GET_1);

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -1,6 +1,7 @@
 var expect = require('chai').expect,
     _ = require('lodash'),
     Url = require('../../').Url,
+    Collection = require('./../../').Collection,
     PropertyList = require('../../').PropertyList,
     VariableList = require('../../').VariableList,
     rawUrls = require('../fixtures/').rawUrls;
@@ -950,6 +951,27 @@ describe('Url', function () {
         it('must be able to convert query params to object', function () {
             var url = new Url('http://127.0.0.1/hello/world/?query=param&query2=param2#test-api');
             expect(url.query.toObject()).to.eql({ query: 'param', query2: 'param2' });
+        });
+
+        it('should ignore # in case of variables', function () {
+            var collection = new Collection({
+                item: [{
+                    request: 'https://postman-echo.com/get?foo=bar&hello={{#world}}'
+                }]
+            });
+
+            expect(collection.items.members[0].request.url.getQueryString()).to.equal('foo=bar&hello={{#world}}');
+        });
+
+        it('should ignore # in case of chained variables', function () {
+            var collection = new Collection({
+                item: [{
+                    request: 'https://postman-echo.com/get?foo=bar&test={{#world{{hello#}}}}'
+                }]
+            });
+
+            expect(collection.items.members[0].request.url.getQueryString()).to
+                .equal('foo=bar&test={{#world{{hello#}}}}');
         });
     });
 

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -1,7 +1,6 @@
 var expect = require('chai').expect,
     _ = require('lodash'),
     Url = require('../../').Url,
-    Collection = require('./../../').Collection,
     PropertyList = require('../../').PropertyList,
     VariableList = require('../../').VariableList,
     rawUrls = require('../fixtures/').rawUrls;
@@ -953,29 +952,7 @@ describe('Url', function () {
             expect(url.query.toObject()).to.eql({ query: 'param', query2: 'param2' });
         });
 
-        it('should ignore # in case of variables', function () {
-            var collection = new Collection({
-                item: [{
-                    request: 'https://postman-echo.com/get?foo=bar&hello={{#world}}'
-                }]
-            });
-
-            expect(collection.items.members[0].request.url.getQueryString()).to.equal('foo=bar&hello={{#world}}');
-        });
-
-        it('should ignore # in case of chained variables', function () {
-            var collection = new Collection({
-                item: [{
-                    request: 'https://postman-echo.com/get?foo=bar&test={{#world{{hello#}}}}'
-                }]
-            });
-
-            expect(collection.items.members[0].request.url.getQueryString()).to
-                .equal('foo=bar&test={{#world{{hello#}}}}');
-        });
-
         describe('with # in them', function () {
-
             it('should ignore # if used for variable names', function () {
                 var url = new Url('https://postman-echo.com/get?foo=bar&hello={{#world}}');
 

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -973,6 +973,48 @@ describe('Url', function () {
             expect(collection.items.members[0].request.url.getQueryString()).to
                 .equal('foo=bar&test={{#world{{hello#}}}}');
         });
+
+        describe('with # in them', function () {
+
+            it('should ignore # if used for variable names', function () {
+                var url = new Url('https://postman-echo.com/get?foo=bar&hello={{#world}}');
+
+                expect(url.query.toObject()).to.eql({ foo: 'bar', hello: '{{#world}}' });
+            });
+
+            it('should ignore # if multiple variables are chained containing #', function () {
+                var url = new Url('https://postman-echo.com/get?user={{user#1{{user#2{{user#3}}}}}}');
+
+                expect(url.query.toObject()).to.eql({ user: '{{user#1{{user#2{{user#3}}}}}}' });
+            });
+
+            it('should ignore # if multiple hashes are used in variable names', function () {
+                var url = new Url('https://postman-echo.com/get?foo=bar&hello={{#world}}&alice=bob&user={{user#1}}');
+
+                expect(url.query.toObject()).to.eql({ foo: 'bar', hello: '{{#world}}',
+                    alice: 'bob', user: '{{user#1}}' });
+            });
+
+            it('should ignore # if leading and trailing hashes are present in variable name', function () {
+                var url;
+                url = new Url('https://postman-echo.com/get?user={{#user1#}}&fo=ba&user2={{#user1}}&user3={{user3#}}');
+
+                expect(url.query.toObject()).to.eql({ user: '{{#user1#}}', fo: 'ba',
+                    user2: '{{#user1}}', user3: '{{user3#}}' });
+            });
+
+            it('should ignore # if used for variable name at middle position', function () {
+                var url = new Url('https://postman-echo.com/get?foo=bar&hello={{wor#ld}}');
+
+                expect(url.query.toObject()).to.eql({ foo: 'bar', hello: '{{wor#ld}}' });
+            });
+
+            it('should split at # if not a variable', function () {
+                var url = new Url('https://postman-echo.com/get?foo=bar#1&user={{user#1}}');
+
+                expect(url.query.toObject()).to.eql({ foo: 'bar' });
+            });
+        });
     });
 
     describe('Security', function () {

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -957,11 +957,9 @@ describe('Url', function () {
                 url2 = new Url('https://postman-echo.com/get?foo=bar&user=}}user'),
                 url3 = new Url('https://postman-echo.com/get?foo=bar&user={user#soemthing');
 
-
             expect(url1.query.toObject()).to.eql({ foo: 'bar', user: '{{user' });
             expect(url2.query.toObject()).to.eql({ foo: 'bar', user: '}}user' });
             expect(url3.query.toObject()).to.eql({ foo: 'bar', user: '{user' });
-
         });
 
         describe('Containing #', function () {

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -952,6 +952,18 @@ describe('Url', function () {
             expect(url.query.toObject()).to.eql({ query: 'param', query2: 'param2' });
         });
 
+        it('should allow { in query', function () {
+            var url1 = new Url('https://postman-echo.com/get?foo=bar&user={{user'),
+                url2 = new Url('https://postman-echo.com/get?foo=bar&user=}}user'),
+                url3 = new Url('https://postman-echo.com/get?foo=bar&user={user#soemthing');
+
+
+            expect(url1.query.toObject()).to.eql({ foo: 'bar', user: '{{user' });
+            expect(url2.query.toObject()).to.eql({ foo: 'bar', user: '}}user' });
+            expect(url3.query.toObject()).to.eql({ foo: 'bar', user: '{user' });
+
+        });
+
         describe('Containing #', function () {
             it('should not truncate variables with # in their names', function () {
                 var url = new Url('https://postman-echo.com/get?foo=bar&hello={{#world}}');

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -952,27 +952,27 @@ describe('Url', function () {
             expect(url.query.toObject()).to.eql({ query: 'param', query2: 'param2' });
         });
 
-        describe('with # in them', function () {
-            it('should ignore # if used for variable names', function () {
+        describe('Containing #', function () {
+            it('should not truncate variables with # in their names', function () {
                 var url = new Url('https://postman-echo.com/get?foo=bar&hello={{#world}}');
 
                 expect(url.query.toObject()).to.eql({ foo: 'bar', hello: '{{#world}}' });
             });
 
-            it('should ignore # if multiple variables are chained containing #', function () {
+            it('should not truncate multiple chained variables with # in their names', function () {
                 var url = new Url('https://postman-echo.com/get?user={{user#1{{user#2{{user#3}}}}}}');
 
                 expect(url.query.toObject()).to.eql({ user: '{{user#1{{user#2{{user#3}}}}}}' });
             });
 
-            it('should ignore # if multiple hashes are used in variable names', function () {
+            it('should not truncate variables with multiple # in their names', function () {
                 var url = new Url('https://postman-echo.com/get?foo=bar&hello={{#world}}&alice=bob&user={{user#1}}');
 
                 expect(url.query.toObject()).to.eql({ foo: 'bar', hello: '{{#world}}',
                     alice: 'bob', user: '{{user#1}}' });
             });
 
-            it('should ignore # if leading and trailing hashes are present in variable name', function () {
+            it('should not truncate variables with leading and trailing # in their names', function () {
                 var url;
                 url = new Url('https://postman-echo.com/get?user={{#user1#}}&fo=ba&user2={{#user1}}&user3={{user3#}}');
 
@@ -980,13 +980,13 @@ describe('Url', function () {
                     user2: '{{#user1}}', user3: '{{user3#}}' });
             });
 
-            it('should ignore # if used for variable name at middle position', function () {
+            it('should not truncate variables with # at middle position in their names', function () {
                 var url = new Url('https://postman-echo.com/get?foo=bar&hello={{wor#ld}}');
 
                 expect(url.query.toObject()).to.eql({ foo: 'bar', hello: '{{wor#ld}}' });
             });
 
-            it('should split at # if not a variable', function () {
+            it('should truncate query if # is used for something other than naming variables', function () {
                 var url = new Url('https://postman-echo.com/get?foo=bar#1&user={{user#1}}');
 
                 expect(url.query.toObject()).to.eql({ foo: 'bar' });


### PR DESCRIPTION
By default query is chopped at # but this shouldn't be the case for variables, atleast not until they are resolved thus # should be allowed in variable names. Fixes https://github.com/postmanlabs/postman-app-support/issues/5779