### PR TITLE
UrlMatchPattern: Add support for port match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Postman Collection SDK Changelog
 
+#### v3.4.3 (Unreleased)
+* #800 Added support for port match in `UrlMatchPattern`
+
 #### v3.4.2 (February 1, 2019)
 * #783 Added support for Array and Object variable type
   * Deprecated JSON variable type

--- a/lib/url-pattern/url-match-pattern-list.js
+++ b/lib/url-pattern/url-match-pattern-list.js
@@ -77,8 +77,9 @@ _.assign(UrlMatchPatternList.prototype, /** @lends UrlMatchPatternList.prototype
             }
 
             return (urlMatchPattern.testProtocol(url.protocol) &&
-              urlMatchPattern.testHost(url.getRemote()) &&
-              urlMatchPattern.testPath(url.getPath()));
+                urlMatchPattern.testHost(url.getHost()) &&
+                urlMatchPattern.testPort(url.port, url.protocol) &&
+                urlMatchPattern.testPath(url.getPath()));
         });
 
         return Boolean(matchedSpecificPattern);

--- a/lib/url-pattern/url-match-pattern.js
+++ b/lib/url-pattern/url-match-pattern.js
@@ -222,8 +222,8 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
         (port && typeof port !== STRING) && (port = String(port));
 
         // assign default port or portRegex
-        port = port || defaultPort;
-        portRegex = portRegex || defaultPort;
+        !port && (port = defaultPort);
+        !portRegex && (portRegex = defaultPort);
 
         // matches * or specific port
         return (

--- a/lib/url-pattern/url-match-pattern.js
+++ b/lib/url-pattern/url-match-pattern.js
@@ -3,6 +3,9 @@ var _ = require('../util').lodash,
     Url = require('../collection/url').Url,
 
     E = '',
+    STRING = 'string',
+    UNDEFINED = 'undefined',
+
     MATCH_ALL = '*',
     PREFIX_DELIMITER = '^',
     PROTOCOL_DELIMITER = '+',
@@ -11,6 +14,12 @@ var _ = require('../util').lodash,
     ALLOWED_PROTOCOLS = ['http', 'https', 'file', 'ftp'],
     ALLOWED_PROTOCOLS_REGEX = ALLOWED_PROTOCOLS.join('|'),
 
+    DEFAULT_PROTOCOL_PORT = {
+        ftp: '21',
+        http: '80',
+        https: '443'
+    },
+
     regexes = {
         escapeMatcher: /[.+^${}()|[\]\\]/g,
         escapeMatchReplacement: '\\$&',
@@ -18,8 +27,11 @@ var _ = require('../util').lodash,
         questionmarkReplacment: '.',
         starMatcher: '*',
         starReplacement: '.*',
+        // @note this matches empty HOST as well as LF/CRLF
+        // @todo match valid HOST name
+        // @note PATH is required(can be empty '/') i.e, {PROTOCOL}://{HOST}/
         patternSplit: '^((' + ALLOWED_PROTOCOLS_REGEX + '|\\*)(\\+(' + ALLOWED_PROTOCOLS_REGEX +
-            '))*)://(\\*|\\*\\.[^*/]+|[^*/]+|)(/.*)$'
+            '))*)://(\\*|\\*\\.[^*/:]+|[^*/:]+)(:\\*|:\\d+)?(/.*)$'
     },
 
     UrlMatchPattern;
@@ -87,7 +99,8 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
         return {
             protocols: _.uniq(match[1].split(PROTOCOL_DELIMITER)),
             host: match[5],
-            path: this.globPatternToRegexp(match[6])
+            port: match[6] && match[6].substr(1), // remove leading `:`
+            path: this.globPatternToRegexp(match[7])
         };
     },
 
@@ -139,7 +152,7 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
         * For Host match, we are considering the port with the host, hence we are using getRemote() instead of getHost()
         * We need to address three cases for the host urlStr
         * 1. * It matches all the host + protocol,  hence we are not having any parsing logic for it.
-        * 2. .*foo.bar.com Here the prefix could be anything but it should end with foo.bar.com
+        * 2. *.foo.bar.com Here the prefix could be anything but it should end with foo.bar.com
         * 3. foo.bar.com This is the absolute matching needs to done.
         */
         var matchRegexObject = this._matchPatternObject;
@@ -185,6 +198,38 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
      */
     matchAbsoluteHostPattern: function (matchRegexObject, remote) {
         return matchRegexObject.host === remote;
+    },
+
+    /**
+     * Tests if the current pattern allows the given port.
+     *
+     * @param {String} port The port to be checked if the pattern allows.
+     * @param {String} protocol Protocol to refer default port.
+     * @return {Boolean}
+     */
+    testPort: function (port, protocol) {
+        var portRegex = this._matchPatternObject.port,
+
+            // default port for given protocol
+            defaultPort = protocol && DEFAULT_PROTOCOL_PORT[protocol];
+
+        // return true if both given port and match pattern are absent
+        if (typeof port === UNDEFINED && typeof portRegex === UNDEFINED) {
+            return true;
+        }
+
+        // convert integer port to string
+        (port && typeof port !== STRING) && (port = String(port));
+
+        // assign default port or portRegex
+        port = port || defaultPort;
+        portRegex = portRegex || defaultPort;
+
+        // matches * or specific port
+        return (
+            portRegex === MATCH_ALL ||
+            portRegex === port
+        );
     },
 
     /**
@@ -238,7 +283,8 @@ _.assign(UrlMatchPattern.prototype, /** @lends UrlMatchPattern.prototype */ {
         }
 
         return (this.testProtocol(url.protocol) &&
-            this.testHost(url.getRemote()) &&
+            this.testHost(url.getHost()) &&
+            this.testPort(url.port, url.protocol) &&
             this.testPath(url.getPath()));
     },
 

--- a/lib/url-pattern/url-match-pattern.js
+++ b/lib/url-pattern/url-match-pattern.js
@@ -14,6 +14,7 @@ var _ = require('../util').lodash,
     ALLOWED_PROTOCOLS = ['http', 'https', 'file', 'ftp'],
     ALLOWED_PROTOCOLS_REGEX = ALLOWED_PROTOCOLS.join('|'),
 
+    // @todo initialize this and ALLOWED_PROTOCOLS via UrlMatchPattern options
     DEFAULT_PROTOCOL_PORT = {
         ftp: '21',
         http: '80',
@@ -27,9 +28,8 @@ var _ = require('../util').lodash,
         questionmarkReplacment: '.',
         starMatcher: '*',
         starReplacement: '.*',
-        // @note this matches empty HOST as well as LF/CRLF
         // @todo match valid HOST name
-        // @note PATH is required(can be empty '/') i.e, {PROTOCOL}://{HOST}/
+        // @note PATH is required(can be empty '/' or '/*') i.e, {PROTOCOL}://{HOST}/
         patternSplit: '^((' + ALLOWED_PROTOCOLS_REGEX + '|\\*)(\\+(' + ALLOWED_PROTOCOLS_REGEX +
             '))*)://(\\*|\\*\\.[^*/:]+|[^*/:]+)(:\\*|:\\d+)?(/.*)$'
     },

--- a/test/unit/certificate-list.test.js
+++ b/test/unit/certificate-list.test.js
@@ -18,6 +18,9 @@ describe('CertificateList', function () {
             var matchedCertificate = certificateList.resolveOne('https://www.google.com');
             expect(matchedCertificate).to.be.an.instanceof(Certificate);
 
+            matchedCertificate = certificateList.resolveOne('https://www.google.com:443');
+            expect(matchedCertificate).to.be.an.instanceof(Certificate);
+
             matchedCertificate = certificateList.resolveOne('https://www.bla.com');
             expect(matchedCertificate).to.be.undefined;
         });

--- a/test/unit/certificate.test.js
+++ b/test/unit/certificate.test.js
@@ -53,6 +53,38 @@ describe('Certificate', function () {
             expect(certificate.canApplyTo('http://www.google.com')).to.be.false;
             expect(certificate.canApplyTo('https://www.google.com')).to.be.false;
         });
+
+        it('should match given port correctly', function () {
+            var certificate = new Certificate({ matches: ['https://example.com:8080/*'] });
+            expect(certificate.canApplyTo('https://example.com:443')).to.be.false;
+            expect(certificate.canApplyTo('https://example.com:8080')).to.be.true;
+
+            certificate = new Certificate({ matches: ['https://example.com:*/*'] });
+            expect(certificate.canApplyTo('https://example.com')).to.be.true;
+            expect(certificate.canApplyTo('https://example.com:443')).to.be.true;
+            expect(certificate.canApplyTo('https://example.com:8080')).to.be.true;
+        });
+
+        it('should implicitly match port 443 if given in Url', function () {
+            var certificate = new Certificate({ matches: ['https://example.com/*'] });
+            expect(certificate.canApplyTo('https://example.com')).to.be.true;
+            expect(certificate.canApplyTo('https://example.com:443')).to.be.true;
+            expect(certificate.canApplyTo('https://example.com:8080')).to.be.false;
+        });
+
+        it('should implicitly match port 443 if given in matches', function () {
+            var certificate = new Certificate({ matches: ['https://example.com:443/*'] });
+            expect(certificate.canApplyTo('https://example.com')).to.be.true;
+            expect(certificate.canApplyTo('https://example.com:443')).to.be.true;
+            expect(certificate.canApplyTo('https://example.com:8080')).to.be.false;
+        });
+
+        it('should match non 443 port correctly', function () {
+            var certificate = new Certificate({ matches: ['https://example.com:8080/*'] });
+            expect(certificate.canApplyTo('https://example.com')).to.be.false;
+            expect(certificate.canApplyTo('https://example.com:443')).to.be.false;
+            expect(certificate.canApplyTo('https://example.com:8080')).to.be.true;
+        });
     });
 
     describe('toJSON', function () {

--- a/test/unit/certificate.test.js
+++ b/test/unit/certificate.test.js
@@ -22,12 +22,14 @@ describe('Certificate', function () {
     describe('canApplyTo', function () {
         it('should return false for empty target URLs', function () {
             var certificate = new Certificate({ matches: ['https://google.com/*'] });
+
             expect(certificate.canApplyTo('')).to.be.false;
             expect(certificate.canApplyTo(new sdk.Url())).to.be.false;
         });
 
         it('should return true only when tested with a match', function () {
             var certificate = new Certificate({ matches: ['https://google.com/*'] });
+
             expect(certificate.canApplyTo('https://www.google.com')).to.be.false;
             expect(certificate.canApplyTo('https://example.com')).to.be.false;
             expect(certificate.canApplyTo('https://google.com')).to.be.true;
@@ -35,6 +37,7 @@ describe('Certificate', function () {
 
         it('should return true when tested with a match on any of the allowed matches', function () {
             var certificate = new Certificate({ matches: ['https://google.com/*', 'https://*.example.com/*'] });
+
             expect(certificate.canApplyTo('https://twitter.com')).to.be.false;
             expect(certificate.canApplyTo('https://foo.example.com')).to.be.true;
             expect(certificate.canApplyTo('https://google.com')).to.be.true;
@@ -42,12 +45,14 @@ describe('Certificate', function () {
 
         it('should disallow test string with protocol not http or https', function () {
             var certificate = new Certificate({ matches: ['http://*'], server: 'https://proxy.com/' });
+
             expect(certificate.canApplyTo('foo://www.google.com')).to.be.false;
             expect(certificate.canApplyTo('file://www.google.com')).to.be.false;
         });
 
         it('should disallow any test string when match protocol is not http or https', function () {
             var certificate = new Certificate({ matches: ['ftp://*'], server: 'https://proxy.com/' });
+
             expect(certificate.canApplyTo('foo://www.google.com')).to.be.false;
             expect(certificate.canApplyTo('file://www.google.com')).to.be.false;
             expect(certificate.canApplyTo('http://www.google.com')).to.be.false;
@@ -56,10 +61,14 @@ describe('Certificate', function () {
 
         it('should match given port correctly', function () {
             var certificate = new Certificate({ matches: ['https://example.com:8080/*'] });
+
             expect(certificate.canApplyTo('https://example.com:443')).to.be.false;
             expect(certificate.canApplyTo('https://example.com:8080')).to.be.true;
+        });
 
-            certificate = new Certificate({ matches: ['https://example.com:*/*'] });
+        it('should match all the ports correctly', function () {
+            var certificate = new Certificate({ matches: ['https://example.com:*/*'] });
+
             expect(certificate.canApplyTo('https://example.com')).to.be.true;
             expect(certificate.canApplyTo('https://example.com:443')).to.be.true;
             expect(certificate.canApplyTo('https://example.com:8080')).to.be.true;
@@ -67,6 +76,7 @@ describe('Certificate', function () {
 
         it('should implicitly match port 443 if given in Url', function () {
             var certificate = new Certificate({ matches: ['https://example.com/*'] });
+
             expect(certificate.canApplyTo('https://example.com')).to.be.true;
             expect(certificate.canApplyTo('https://example.com:443')).to.be.true;
             expect(certificate.canApplyTo('https://example.com:8080')).to.be.false;
@@ -74,6 +84,7 @@ describe('Certificate', function () {
 
         it('should implicitly match port 443 if given in matches', function () {
             var certificate = new Certificate({ matches: ['https://example.com:443/*'] });
+
             expect(certificate.canApplyTo('https://example.com')).to.be.true;
             expect(certificate.canApplyTo('https://example.com:443')).to.be.true;
             expect(certificate.canApplyTo('https://example.com:8080')).to.be.false;
@@ -81,6 +92,7 @@ describe('Certificate', function () {
 
         it('should match non 443 port correctly', function () {
             var certificate = new Certificate({ matches: ['https://example.com:8080/*'] });
+
             expect(certificate.canApplyTo('https://example.com')).to.be.false;
             expect(certificate.canApplyTo('https://example.com:443')).to.be.false;
             expect(certificate.canApplyTo('https://example.com:8080')).to.be.true;

--- a/test/unit/url-match-pattern-list.test.js
+++ b/test/unit/url-match-pattern-list.test.js
@@ -21,6 +21,7 @@ describe('UrlMatchPatternList', function () {
             var matchPatternList = new UrlMatchPatternList({}, ['https://example.com/*']);
             expect(matchPatternList.test('https://example.com')).to.be.true;
             expect(matchPatternList.test('https://example.com/')).to.be.true;
+            expect(matchPatternList.test('https://example.com:443')).to.be.true;
             expect(matchPatternList.test('https://www.example.com/')).to.be.false;
             expect(matchPatternList.test('https://example.com/hello')).to.be.true;
             expect(matchPatternList.test('https://example.com/foo/bar')).to.be.true;

--- a/test/unit/url-match-pattern.test.js
+++ b/test/unit/url-match-pattern.test.js
@@ -354,6 +354,7 @@ describe('UrlMatchPattern', function () {
         it('should implicitly match with default http port if protocol is defined', function () {
             var matchPattern = new UrlMatchPattern('http://*/*');
             expect(matchPattern.testPort(undefined, 'http')).to.be.true;
+            expect(matchPattern.testPort(80, 'http')).to.be.true;
             expect(matchPattern.testPort('80', 'http')).to.be.true;
             expect(matchPattern.testPort('8080', 'http')).to.be.false;
         });
@@ -361,6 +362,7 @@ describe('UrlMatchPattern', function () {
         it('should implicitly match with default https port if protocol is defined', function () {
             var matchPattern = new UrlMatchPattern('https://*/*');
             expect(matchPattern.testPort(undefined, 'https')).to.be.true;
+            expect(matchPattern.testPort(443, 'https')).to.be.true;
             expect(matchPattern.testPort('443', 'https')).to.be.true;
             expect(matchPattern.testPort(8080, 'https')).to.be.false;
         });
@@ -369,6 +371,7 @@ describe('UrlMatchPattern', function () {
             var matchPattern = new UrlMatchPattern('ftp://*/*');
             expect(matchPattern.testPort(undefined, 'ftp')).to.be.true;
             expect(matchPattern.testPort(21, 'ftp')).to.be.true;
+            expect(matchPattern.testPort('21', 'ftp')).to.be.true;
             expect(matchPattern.testPort('8080', 'ftp')).to.be.false;
         });
     });


### PR DESCRIPTION
- Match HOST and PORT separately
- Implicitly match default PORTs for a given PROTOCOL
- Fixed a bug where empty HOST are valid