### PR TITLE
Removed connection header from request size calculation

### DIFF
--- a/lib/collection/request.js
+++ b/lib/collection/request.js
@@ -57,24 +57,6 @@ var util = require('../util'),
     HTTP_X_X = 'HTTP/X.X',
 
     /**
-     * Connection header
-     *
-     * @private
-     * @const
-     * @type {String}
-     */
-    CONNECTION_KEEP_ALIVE = 'Connection: keep-alive',
-
-    /**
-     * Connection header key name
-     *
-     * @private
-     * @const
-     * @type {String}
-     */
-    CONNECTION_HEADER_KEY = 'connection',
-
-    /**
      * @private
      * @type {Boolean}
      */
@@ -371,12 +353,6 @@ _.assign(Request.prototype, /** @lends Request.prototype */ {
         // request-line = method SP request-target SP HTTP-version CRLF
         sizeInfo.header = (this.method + SP + requestTarget + SP + HTTP_X_X + CRLF + CRLF).length +
             this.headers.contentSize();
-        // account for connection header which will be added by Node's HTTP Agent
-        // since its not added back via Request~upsertHeader.
-        // @note requester.keepAlive is true by default in postman-runtime
-        if (!this.headers.has(CONNECTION_HEADER_KEY)) {
-            sizeInfo.header += (CONNECTION_KEEP_ALIVE + CRLF).length;
-        }
 
         // compute the approximate total body size by adding size of header and body
         sizeInfo.total = (sizeInfo.body || 0) + (sizeInfo.header || 0);

--- a/test/unit/request.test.js
+++ b/test/unit/request.test.js
@@ -568,9 +568,9 @@ describe('Request', function () {
     describe('.size', function () {
         it('should handle blank request correctly', function () {
             var request = new Request();
-            // HTTP request-line + Keep-Alive header + CRLF
+            // GET / HTTP/1.1 + CRLF + CRLF
             expect(request.size()).to.eql({
-                body: 0, header: 42, total: 42, source: 'COMPUTED'
+                body: 0, header: 18, total: 18, source: 'COMPUTED'
             });
         });
 
@@ -582,7 +582,7 @@ describe('Request', function () {
                 }
             });
             expect(request.size()).to.eql({
-                body: 7, header: 42, total: 49, source: 'COMPUTED'
+                body: 7, header: 18, total: 25, source: 'COMPUTED'
             });
         });
 
@@ -597,7 +597,7 @@ describe('Request', function () {
                 }
             });
             expect(request.size()).to.eql({
-                body: 7, header: 42, total: 49, source: 'COMPUTED' // foo=bar
+                body: 7, header: 18, total: 25, source: 'COMPUTED' // foo=bar
             });
         });
 
@@ -625,7 +625,7 @@ describe('Request', function () {
                 }
             });
             expect(request.size()).to.eql({
-                body: 7, header: 61, total: 68, source: 'CONTENT-LENGTH'
+                body: 7, header: 37, total: 44, source: 'CONTENT-LENGTH'
             });
         });
     });


### PR DESCRIPTION
- Remove `connection` header hack to fix request size calculation.
- Now handled in https://github.com/postmanlabs/postman-runtime/pull/755