### PR TITLE
Fixed proxy matching for URL with ports

### DIFF
--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -1,6 +1,5 @@
 var _ = require('../util').lodash,
     Property = require('./property').Property,
-    nodeUrl = require('url'),
     Url = require('./url').Url,
     UrlMatchPattern = require('../url-pattern/url-match-pattern').UrlMatchPattern,
     ProxyConfig,
@@ -136,9 +135,9 @@ _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
             port = _.get(options, 'port') >> 0;
 
         if (_.isString(options.host)) {
-            parsedUrl = nodeUrl.parse(options.host);
-            // we want to strip the protocol, but if protocol is not present then parsedUrl.hostname will be null
-            this.host = parsedUrl.protocol ? parsedUrl.hostname : options.host;
+            // strip the protocol from given host
+            parsedUrl = new Url(options.host);
+            this.host = parsedUrl.getHost();
         }
 
         _.isString(options.match) && (this.match = new UrlMatchPattern(options.match));
@@ -184,7 +183,7 @@ _.assign(ProxyConfig.prototype, /** @lends ProxyConfig.prototype */ {
      * @param {String=} [urlStr] The url string for which the proxy match needs to be done.
      */
     test: function (urlStr) {
-        var protocol = Url.isUrl(urlStr) ? urlStr.protocol : _.trimEnd(nodeUrl.parse(urlStr || E).protocol || E, COLON);
+        var protocol = Url.isUrl(urlStr) ? urlStr.protocol : (Url.parse(urlStr || E).protocol || E);
 
         // to allow target URLs without any protocol. e.g.: 'foo.com/bar'
         if (_.isEmpty(protocol)) {

--- a/lib/collection/proxy-config.js
+++ b/lib/collection/proxy-config.js
@@ -8,11 +8,11 @@ var _ = require('../util').lodash,
     COLON = ':',
     DEFAULT_PORT = 8080,
     PROTOCOL_HOST_SEPARATOR = '://',
-    MATCH_ALL_HOST_AND_PATH = '*/*',
+    MATCH_ALL_HOST_AND_PATH = '*:*/*',
     AUTH_CREDENTIALS_SEPARATOR = '@',
     DEFAULT_PROTOCOL = 'http',
     ALLOWED_PROTOCOLS = ['http', 'https'],
-    // 'http+https://*/*'
+    // 'http+https://*:*/*'
     DEFAULT_PATTERN = ALLOWED_PROTOCOLS.join(PROTOCOL_DELIMITER) + PROTOCOL_HOST_SEPARATOR + MATCH_ALL_HOST_AND_PATH;
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1977,7 +1977,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {

--- a/test/unit/proxy-config.test.js
+++ b/test/unit/proxy-config.test.js
@@ -114,7 +114,7 @@ describe('Proxy Config', function () {
 
             p1.updateProtocols(newProtocols);
             expect(p1.getProtocols()).to.eql(newProtocolsAfterUpdate);
-            expect(p1.match.pattern).to.eql('http://*/*');
+            expect(p1.match.pattern).to.eql('http://*:*/*');
 
             p1 = new ProxyConfig({ match: 'https://google.com/*' });
             protocols = ['https'];
@@ -145,10 +145,10 @@ describe('Proxy Config', function () {
             var pc = new ProxyConfig({ host: 'proxy.com' });
 
             pc.updateProtocols(['http']);
-            expect(pc.match.pattern).to.equal('http://*/*');
+            expect(pc.match.pattern).to.equal('http://*:*/*');
 
             pc.updateProtocols();
-            expect(pc.match.pattern).to.equal('http://*/*');
+            expect(pc.match.pattern).to.equal('http://*:*/*');
         });
 
         it('should ignore falsy host-path combinations whilst updating', function () {
@@ -177,7 +177,14 @@ describe('Proxy Config', function () {
         it('should match all urls provided', function () {
             var pc = new ProxyConfig({ host: 'proxy.com', tunnel: true });
             expect(pc.test('http://www.google.com/')).to.be.true;
+            expect(pc.test('http://www.google.com:80/')).to.be.true;
+            expect(pc.test('http://www.google.com:3000/')).to.be.true;
+            expect(pc.test('https://www.google.com/')).to.be.true;
+            expect(pc.test('https://www.google.com:80/')).to.be.true;
+            expect(pc.test('https://www.google.com:3000/')).to.be.true;
             expect(pc.test('foo.bar.com/')).to.be.true;
+            expect(pc.test('foo.bar.com:80/')).to.be.true;
+            expect(pc.test('foo.bar.com:3000/')).to.be.true;
         });
 
         it('should match all sdk Url provided', function () {
@@ -187,15 +194,24 @@ describe('Proxy Config', function () {
         });
 
         it('should parse any URL that uses the http protocol', function () {
-            var pc = new ProxyConfig({ match: 'http://*/*', host: 'proxy.com' });
+            var pc = new ProxyConfig({ match: 'http://*:*/*', host: 'proxy.com' });
             expect(pc.test('http://www.google.com/')).to.be.true;
+            expect(pc.test('http://www.google.com:80/')).to.be.true;
+            expect(pc.test('http://www.google.com:3000/')).to.be.true;
             expect(pc.test('foo.bar.com/')).to.be.true;
+            expect(pc.test('foo.bar.com:80/')).to.be.true;
+            expect(pc.test('foo.bar.com:3000/')).to.be.true;
         });
 
         it('should parse any URL that uses the http protocol, on any host, with path starts with /foo', function () {
-            var pc = new ProxyConfig({ match: 'http://*/foo*', host: 'proxy.com' });
+            var pc = new ProxyConfig({ match: 'http://*:*/foo*', host: 'proxy.com' });
             expect(pc.test('http://example.com/foo/bar.html')).to.be.true;
             expect(pc.test('http://www.google.com/foo')).to.be.true;
+            expect(pc.test('http://www.google.com:80/foo')).to.be.true;
+            expect(pc.test('http://www.google.com:3000/foo')).to.be.true;
+            expect(pc.test('foo.bar.com/foo/bar.html')).to.be.true;
+            expect(pc.test('foo.bar.com:80/foo/bar.html')).to.be.true;
+            expect(pc.test('foo.bar.com:3000/foo/bar.html')).to.be.true;
         });
 
         it('should parse any URL that uses the https protocol, is on a google.com host', function () {


### PR DESCRIPTION
**Solves:**
https://github.com/postmanlabs/postman-app-support/issues/6364

**Why is this happening:**

- We pass URL as a string for proxy lookup to [ProxyConfigList.resolve()|https://github.com/postmanlabs/postman-collection/blob/develop/lib/collection/proxy-config-list.js#L37].
- Then ProxyConfigList.resolve() passes the same URL as a string to [ProxyConfig.test()|https://github.com/postmanlabs/postman-collection/blob/develop/lib/collection/proxy-config.js#L186].
- ProxyConfig.test() then does `url.parse(urlString)` and extract the protocol from parsed URL.
- But url.parse() parses wrong when a URL without protocol (but with port) is given.
```javascript
var parsedUrl = url.parse('www.google.com:80')
// parsedURL will be as below
// {
//   protocol: 'www.google.com:',
//   slashes: null,
//   auth: null,
//   host: '80',
//   port: null,
//   hostname: '80',
//   hash: null,
//   search: null,
//   query: null,
//   pathname: null,
//   path: null,
//   href: 'www.google.com:80'
// }
```
- So no proxy will be matched for URL 'www.google.com:80' because of this faulty URL parsing.

**Solution:**

- Removed use of nodeUrl.parse() from ProxyConfig because it parses wrong when given URL has port but doesn't have a protocol
- Instead, use Url.parse() provided by SDK itself