### PR TITLE
Handled duplicates while parsing path variables

### DIFF
--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -406,6 +406,7 @@ _.assign(Url, /** @lends Url */ {
     parse: function (url) {
         url = _.trimStart(url);
         var pathVariables,
+            pathVariableKeys = {},
             p = {
                 raw: url
             };
@@ -455,8 +456,13 @@ _.assign(Url, /** @lends Url */ {
 
         // extract path variables
         pathVariables = _.transform(p.path, function (res, segment) {
-            // check if the segment has path variable prefix followed by the variable name.
-            if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER) && segment !== PATH_VARIABLE_IDENTIFIER) {
+            // check if the segment has path variable prefix followed by the variable name and
+            // the variable is not already added in the list.
+            if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER) &&
+                segment !== PATH_VARIABLE_IDENTIFIER &&
+                !pathVariableKeys[segment]) {
+                    console.log(pathVariableKeys)
+                pathVariableKeys[segment] = true;
                 res.push({ key: segment.slice(1) }); // remove path variable prefix.
             }
         }, []);

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -461,7 +461,6 @@ _.assign(Url, /** @lends Url */ {
             if (_.startsWith(segment, PATH_VARIABLE_IDENTIFIER) &&
                 segment !== PATH_VARIABLE_IDENTIFIER &&
                 !pathVariableKeys[segment]) {
-                    console.log(pathVariableKeys)
                 pathVariableKeys[segment] = true;
                 res.push({ key: segment.slice(1) }); // remove path variable prefix.
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1977,7 +1977,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -517,6 +517,20 @@ describe('Url', function () {
             expect(subject.path).to.eql([':', ':', ':var']);
             expect(subject.variable).to.have.lengthOf(1).that.eql([{ key: 'var' }]);
         });
+
+        it('should parse a path variable only once if it is used multiple times', function () {
+            var subject = Url.parse('http://127.0.0.1/:foo/:bar/:foo');
+            expect(subject).to.have.property('variable').that.has.lengthOf(2).that.eql([
+                { key: 'foo' }, { key: 'bar' }
+            ]);
+        });
+
+        it('should parse path variables containing special characters properly', function () {
+            var subject = Url.parse('http://127.0.0.1/:郵差/:foo.json');
+            expect(subject).to.have.property('variable').that.has.lengthOf(2).that.eql([
+                { key: '郵差' }, { key: 'foo.json' }
+            ]);
+        });
     });
 
     describe('unparsing', function () {


### PR DESCRIPTION
**What is the problem:**
```javascript
var Url = require('postman-collection').Url;
var parsedUrl = Url.parse('google.com/:foo/:foo')
console.log(parsedUrl.variable);
// prints [{key: 'foo'}, {key: 'foo'}]
```

It should not add duplicate path variable in the variable list.

**Solution:**
check for duplicates before adding to list.