### PR TITLE
Updated variableScope.has() method to search in layers

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  new features:
+    - GH-882 Updated `variableScope.has()` method to search in layers
+
 3.4.9:
   date: 2019-06-07
   improvements:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,6 @@
 master:
   new features:
-    - GH-882 Updated `VariableScope~has` method to search in layers
+    - GH-882 Updated `VariableScope~has` method to search in all the scopes
 
 3.4.9:
   date: 2019-06-07

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,6 @@
 master:
   new features:
-    - GH-882 Updated `variableScope.has()` method to search in layers
+    - GH-882 Updated `VariableScope~has` method to search in layers
 
 3.4.9:
   date: 2019-06-07

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -194,7 +194,7 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      * Determines whether one particular variable is defined in this scope of variables.
      *
      * @param {String} key - The name of the variable to check
-     * @returns {Boolean}
+     * @returns {Boolean} - True if variable with given key is present and enabled in any layers, false otherwise
      */
     has: function (key) {
         var variable = this.values.oneNormalizedVariable(key),

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -193,7 +193,7 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
     /**
      * Determines whether one particular variable is defined in this scope of variables.
      *
-     * @param {String} key
+     * @param {String} key - The name of the variable to check
      * @returns {Boolean}
      */
     has: function (key) {
@@ -201,8 +201,9 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
             i,
             ii;
 
-        // if a variable does not exist in local scope, we search all the layers and return the first occurrence.
-        if (!(variable || !this._layers)) {
+        // if a variable is disabled or does not exist in local scope,
+        // we search all the layers and return the first occurrence.
+        if ((!variable || variable.disabled) && this._layers) {
             for (i = 0, ii = this._layers.length; i < ii; i++) {
                 variable = this._layers[i].oneNormalizedVariable(key);
                 if (variable && !variable.disabled) { break; }

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -193,15 +193,15 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
     /**
      * Determines whether one particular variable is defined in this scope of variables.
      *
-     * @param {String} variableName
+     * @param {String} key
      * @returns {Boolean}
      */
-    has: function (variableName) {
-        var variable = this.values.oneNormalizedVariable(variableName)
+    has: function (key) {
+        var variable = this.values.oneNormalizedVariable(key),
             i,
             ii;
 
-            // if a variable does not exist in local scope, we search all the layers and return the first occurrence.
+        // if a variable does not exist in local scope, we search all the layers and return the first occurrence.
         if (!(variable || !this._layers)) {
             for (i = 0, ii = this._layers.length; i < ii; i++) {
                 variable = this._layers[i].oneNormalizedVariable(key);

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -197,7 +197,17 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      * @returns {Boolean}
      */
     has: function (variableName) {
-        var variable = this.values.oneNormalizedVariable(variableName);
+        var variable = this.values.oneNormalizedVariable(variableName)
+            i,
+            ii;
+
+            // if a variable does not exist in local scope, we search all the layers and return the first occurrence.
+        if (!(variable || !this._layers)) {
+            for (i = 0, ii = this._layers.length; i < ii; i++) {
+                variable = this._layers[i].oneNormalizedVariable(key);
+                if (variable && !variable.disabled) { break; }
+            }
+        }
 
         return Boolean(variable && !variable.disabled);
     },

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -204,14 +204,14 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
 
         // if a variable is disabled or does not exist in local scope,
         // we search all the layers and return the first occurrence.
-        if ((!variable || variable.disabled) && this._layers) {
+        if ((!variable || variable.disabled === true) && this._layers) {
             for (i = 0, ii = this._layers.length; i < ii; i++) {
                 variable = this._layers[i].oneNormalizedVariable(key);
                 if (variable && !variable.disabled) { break; }
             }
         }
 
-        return Boolean(variable && !variable.disabled);
+        return Boolean(variable && variable.disabled !== true);
     },
 
     /**

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -194,7 +194,8 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      * Determines whether one particular variable is defined in this scope of variables.
      *
      * @param {String} key - The name of the variable to check
-     * @returns {Boolean} - True if variable with given key is present and enabled in any layers, false otherwise
+     * @returns {Boolean} - Returns true if an enabled variable with given key is present in current or parent scopes,
+     *                      false otherwise
      */
     has: function (key) {
         var variable = this.values.oneNormalizedVariable(key),

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -207,7 +207,7 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
         if ((!variable || variable.disabled === true) && this._layers) {
             for (i = 0, ii = this._layers.length; i < ii; i++) {
                 variable = this._layers[i].oneNormalizedVariable(key);
-                if (variable && !variable.disabled) { break; }
+                if (variable && variable.disabled !== true) { break; }
             }
         }
 

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -900,7 +900,7 @@ describe('VariableScope', function () {
     });
 
     describe('has', function () {
-        it('should correctly determine if the current scope contains a provided identifier', function () {
+        it('should find variable from current scope', function () {
             var scope = new VariableScope([
                 { key: 'alpha', value: 'foo' },
                 { key: 'gamma', value: 'baz', disabled: true }
@@ -911,45 +911,43 @@ describe('VariableScope', function () {
             expect(scope.has('random')).to.be.false;
         });
 
-        it('should correctly determine if the current or parent scope contains provided identifier when it is enabled',
-            function () {
-                var scope = new VariableScope([
-                    { key: 'alpha', value: 'foo' }
-                ]);
+        it('should find variables from all scopes', function () {
+            var scope = new VariableScope([
+                { key: 'alpha', value: 'foo' }
+            ]);
 
-                scope.addLayer(new VariableList(null, [
-                    { key: 'alpha_layer1', value: 'foo_layer1' }
-                ]));
+            scope.addLayer(new VariableList(null, [
+                { key: 'alpha_layer1', value: 'foo_layer1' }
+            ]));
 
-                scope.addLayer(new VariableList(null, [
-                    { key: 'alpha_layer2', value: 'foo_layer2' }
-                ]));
+            scope.addLayer(new VariableList(null, [
+                { key: 'alpha_layer2', value: 'foo_layer2' }
+            ]));
 
-                expect(scope.has('alpha')).to.be.true;
-                expect(scope.has('alpha_layer1')).to.be.true;
-                expect(scope.has('alpha_layer2')).to.be.true;
-            });
+            expect(scope.has('alpha')).to.be.true;
+            expect(scope.has('alpha_layer1')).to.be.true;
+            expect(scope.has('alpha_layer2')).to.be.true;
+        });
 
-        it('should correctly determine if the current or parent scope contains provided identifier when it is disabled',
-            function () {
-                var scope = new VariableScope([
-                    { key: 'alpha', value: 'foo', disabled: true }
-                ]);
+        it('should not consider disabled variables from any scopes', function () {
+            var scope = new VariableScope([
+                { key: 'alpha', value: 'foo', disabled: true }
+            ]);
 
-                scope.addLayer(new VariableList(null, [
-                    { key: 'alpha_layer1', value: 'foo_layer1', disabled: true }
-                ]));
+            scope.addLayer(new VariableList(null, [
+                { key: 'alpha_layer1', value: 'foo_layer1', disabled: true }
+            ]));
 
-                scope.addLayer(new VariableList(null, [
-                    { key: 'alpha_layer2', value: 'foo_layer2', disabled: true }
-                ]));
+            scope.addLayer(new VariableList(null, [
+                { key: 'alpha_layer2', value: 'foo_layer2', disabled: true }
+            ]));
 
-                expect(scope.has('alpha')).to.be.false;
-                expect(scope.has('alpha_layer1')).to.be.false;
-                expect(scope.has('alpha_layer2')).to.be.false;
-            });
+            expect(scope.has('alpha')).to.be.false;
+            expect(scope.has('alpha_layer1')).to.be.false;
+            expect(scope.has('alpha_layer2')).to.be.false;
+        });
 
-        it('should return true if variable with same name is present in all scopes', function () {
+        it('should return true incase of duplicates across the scopes', function () {
             var scope = new VariableScope([
                 { key: 'alpha', value: 'foo' }
             ]);
@@ -965,7 +963,7 @@ describe('VariableScope', function () {
             expect(scope.has('alpha')).to.be.true;
         });
 
-        it('should correctly find variable that exists in only one scope', function () {
+        it('should find variable that exists in only one scope', function () {
             var scope = new VariableScope([
                 { key: 'alpha', value: 'foo' }
             ]);
@@ -981,7 +979,7 @@ describe('VariableScope', function () {
             expect(scope.has('beta')).to.be.true;
         });
 
-        it('should correctly find only enabled variable from duplicate variables in current scope', function () {
+        it('should find enabled variable from duplicates in current scope', function () {
             var scope = new VariableScope([
                 { key: 'alpha', value: 'foo_disabled_1', disabled: true },
                 { key: 'alpha', value: 'foo' },
@@ -991,7 +989,7 @@ describe('VariableScope', function () {
             expect(scope.has('alpha')).to.be.true;
         });
 
-        it('should correctly find only enabled variable from duplicate variables in parent scopes', function () {
+        it('should find enabled variable from duplicates across the scopes', function () {
             var scope = new VariableScope([
                 { key: 'alpha', value: 'foo_disabled_1', disabled: true },
                 { key: 'alpha', value: 'foo_disabled_2', disabled: true }
@@ -1010,23 +1008,6 @@ describe('VariableScope', function () {
 
             expect(scope.has('alpha')).to.be.true;
         });
-
-        it('should correctly find only enabled variable from duplicate variables in all scopes with only one enabled',
-            function () {
-                var scope = new VariableScope([
-                    { key: 'alpha', value: 'foo', disabled: true }
-                ]);
-
-                scope.addLayer(new VariableList(null, [
-                    { key: 'alpha', value: 'foo_layer1' }
-                ]));
-
-                scope.addLayer(new VariableList(null, [
-                    { key: 'alpha', value: 'foo_layer2', disabled: true }
-                ]));
-
-                expect(scope.has('alpha')).to.be.true;
-            });
     });
 
     describe('disabled variable', function () {

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -981,6 +981,36 @@ describe('VariableScope', function () {
             expect(scope.has('beta')).to.be.true;
         });
 
+        it('should correctly find only enabled variable from duplicate variables in current scope', function () {
+            var scope = new VariableScope([
+                { key: 'alpha', value: 'foo_disabled_1', disabled: true },
+                { key: 'alpha', value: 'foo' },
+                { key: 'alpha', value: 'foo_disabled_2', disabled: true }
+            ]);
+
+            expect(scope.has('alpha')).to.be.true;
+        });
+
+        it('should correctly find only enabled variable from duplicate variables in parent scopes', function () {
+            var scope = new VariableScope([
+                { key: 'alpha', value: 'foo_disabled_1', disabled: true },
+                { key: 'alpha', value: 'foo_disabled_2', disabled: true }
+            ]);
+
+            scope.addLayer(new VariableList(null, [
+                { key: 'alpha', value: 'foo_disabled_1_layer_1', disabled: true },
+                { key: 'alpha', value: 'foo_layer_1' },
+                { key: 'alpha', value: 'foo_disabled_2_layer_1', disabled: true }
+            ]));
+
+            scope.addLayer(new VariableList(null, [
+                { key: 'alpha', value: 'foo_disabled_1_layer_2', disabled: true },
+                { key: 'alpha', value: 'foo_disabled_2_layer_2', disabled: true }
+            ]));
+
+            expect(scope.has('alpha')).to.be.true;
+        });
+
         it('should correctly find only enabled variable from duplicate variables in all scopes with only one enabled',
             function () {
                 var scope = new VariableScope([

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -903,22 +903,35 @@ describe('VariableScope', function () {
         var scope = new VariableScope([
             { key: 'alpha', value: 'foo' },
             { key: 'beta', value: 'bar' },
-            { key: 'gamma', value: 'baz', disabled: true }
+            { key: 'gamma', value: 'baz', disabled: true },
+            { key: 'alpha_disabled', value: 'foo_disabled', disabled: true },
+            { key: 'beta_duplicate', value: 'bar_duplicate' },
+            { key: 'gamma_single_enabled', value: 'baz_single_enabled', disabled: true }
         ]);
 
         scope.addLayer(new VariableList(null, [
             { key: 'alpha_layer1', value: 'foo_layer1' },
-            { key: 'beta_layer1', value: 'bar_layer1', disabled: true }
+            { key: 'beta_layer1', value: 'bar_layer1', disabled: true },
+            { key: 'alpha_disabled', value: 'foo_disabled', disabled: true },
+            { key: 'beta_duplicate', value: 'bar_duplicate' },
+            { key: 'gamma_single_enabled', value: 'baz_single_enabled', disabled: true },
+            { key: 'theta_single', value: 'only_in_one_layer' }
         ]));
 
         scope.addLayer(new VariableList(null, [
             { key: 'alpha_layer2', value: 'foo_layer2' },
-            { key: 'beta_layer2', value: 'bar_layer2', disabled: true }
+            { key: 'beta_layer2', value: 'bar_layer2', disabled: true },
+            { key: 'alpha_disabled', value: 'foo_disabled', disabled: true },
+            { key: 'beta_duplicate', value: 'bar_duplicate' },
+            { key: 'gamma_single_enabled', value: 'baz_single_enabled' }
         ]));
 
         scope.addLayer(new VariableList(null, [
             { key: 'alpha_layer3', value: 'foo_layer3' },
-            { key: 'beta_layer3', value: 'bar_layer3', disabled: true }
+            { key: 'beta_layer3', value: 'bar_layer3', disabled: true },
+            { key: 'alpha_disabled', value: 'foo_disabled', disabled: true },
+            { key: 'beta_duplicate', value: 'bar_duplicate' },
+            { key: 'gamma_single_enabled', value: 'baz_single_enabled', disabled: true }
         ]));
 
         it('should correctly determine if the current scope contains a provided identifier', function () {
@@ -935,6 +948,23 @@ describe('VariableScope', function () {
             expect(scope.has('beta_layer2')).to.be.false;
             expect(scope.has('beta_layer3')).to.be.false;
         });
+
+        it('should not consider disabled variables from any layer', function () {
+            expect(scope.has('alpha_disabled')).to.be.false;
+        });
+
+        it('should return true if variable with same name is present in all layers', function () {
+            expect(scope.has('beta_duplicate')).to.be.true;
+        });
+
+        it('should correctly find variable that exists in only one layer', function () {
+            expect(scope.has('theta_single')).to.be.true;
+        });
+
+        it('should correctly find only enabled variable from duplicate variables in all layers with only one enabled',
+            function () {
+                expect(scope.has('gamma_single_enabled')).to.be.true;
+            });
     });
 
     describe('disabled variable', function () {

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -906,10 +906,34 @@ describe('VariableScope', function () {
             { key: 'gamma', value: 'baz', disabled: true }
         ]);
 
+        scope.addLayer(new VariableList(null, [
+            { key: 'alpha_layer1', value: 'foo_layer1' },
+            { key: 'beta_layer1', value: 'bar_layer1', disabled: true }
+        ]));
+
+        scope.addLayer(new VariableList(null, [
+            { key: 'alpha_layer2', value: 'foo_layer2' },
+            { key: 'beta_layer2', value: 'bar_layer2', disabled: true }
+        ]));
+
+        scope.addLayer(new VariableList(null, [
+            { key: 'alpha_layer3', value: 'foo_layer3' },
+            { key: 'beta_layer3', value: 'bar_layer3', disabled: true }
+        ]));
+
         it('should correctly determine if the current scope contains a provided identifier', function () {
             expect(scope.has('alpha')).to.be.true;
             expect(scope.has('gamma')).to.be.false;
             expect(scope.has('random')).to.be.false;
+        });
+
+        it('should correctly determine if the current scope contains a provided identifier in layers', function () {
+            expect(scope.has('alpha_layer1')).to.be.true;
+            expect(scope.has('alpha_layer2')).to.be.true;
+            expect(scope.has('alpha_layer3')).to.be.true;
+            expect(scope.has('beta_layer1')).to.be.false;
+            expect(scope.has('beta_layer2')).to.be.false;
+            expect(scope.has('beta_layer3')).to.be.false;
         });
     });
 


### PR DESCRIPTION
Updated variableScope.has() method to search given variable in layers of the scope.

Solves: https://github.com/postmanlabs/postman-app-support/issues/6595

Benchmarks before update:
```
Search variable in first layer:
    5 layers of 10 variables: 14,699,406 ops/sec (±1.23%, ⨉1000000)
    5 layers of 100 variables: 9,606,022 ops/sec (±4.52%, ⨉1000000)
    5 layers of 1000 variables: 10,110,274 ops/sec (±0.58%, ⨉1000000)

Search variable in last layer:
    5 layers of 10 variables: not supported
    5 layers of 100 variables: not supported
    5 layers of 1000 variables: not supported
```

Benchmarks after update:
```
Search variable in first layer:
    5 layers of 10 variables: 14,180,963 ops/sec (±0.52%, ⨉1000000)
    5 layers of 100 variables: 10,084,397 ops/sec (±1.98%, ⨉1000000)
    5 layers of 1000 variables: 10,542,299 ops/sec (±1.02%, ⨉1000000)

Search variable in last layer:
    5 layers of 10 variables: 3,142,960 ops/sec (±0.97%, ⨉1000000)
    5 layers of 100 variables: 790,895 ops/sec (±0.31%, ⨉1000000)
    5 layers of 1000 variables: 86,119 ops/sec (±0.14%, ⨉430598)
```