### PR TITLE
Fixed a bug where VariableScope.get() method falsely returned undefined

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,11 +1,10 @@
 master:
-  fixed bugs:
-    - >-
-      GH-883 Fixed a bug where `VariableScope~get` method falsely returned `undefined` when variable
-      with same name is present in both, current and parent scopes, but it is disabled in current scope
-      and enabled in parent scope.
   new features:
     - GH-882 Updated `VariableScope~has` method to search in all the scopes
+  fixed bugs:
+    - >-
+      GH-883 Fixed a bug where `VariableScope~get` method doesn't search
+      all the scopes if the variable is disabled in local scope
 
 3.4.9:
   date: 2019-06-07

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,5 +1,5 @@
 master:
-  new features:
+  fixed bugs:
     - GH-883 Fixed a bug where `VariableScope~get` method falsely returned `undefined`
 
 3.4.9:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,9 @@
 master:
   fixed bugs:
-    - GH-883 Fixed a bug where `VariableScope~get` method falsely returned `undefined`
+    - >-
+      GH-883 Fixed a bug where `VariableScope~get` method falsely returned `undefined` when variable
+      with same name is present in both, current and parent scopes, but it is disabled in current scope
+      and enabled in parent scope.
 
 3.4.9:
   date: 2019-06-07

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  new features:
+    - GH-883 Fixed a bug where `VariableScope~get` method falsely returned `undefined`
+
 3.4.9:
   date: 2019-06-07
   improvements:

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -214,7 +214,7 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
             ii;
 
         // if a variable does not exist in local scope, we search all the layers and return the first occurrence.
-        if (!(variable || !this._layers)) {
+        if ((!variable || variable.disabled) && this._layers) {
             for (i = 0, ii = this._layers.length; i < ii; i++) {
                 variable = this._layers[i].oneNormalizedVariable(key);
                 if (variable && !variable.disabled) { break; }

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -214,14 +214,14 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
             ii;
 
         // if a variable does not exist in local scope, we search all the layers and return the first occurrence.
-        if ((!variable || variable.disabled) && this._layers) {
+        if ((!variable || variable.disabled === true) && this._layers) {
             for (i = 0, ii = this._layers.length; i < ii; i++) {
                 variable = this._layers[i].oneNormalizedVariable(key);
-                if (variable && !variable.disabled) { break; }
+                if (variable && variable.disabled !== true) { break; }
             }
         }
 
-        return (variable && !variable.disabled) ? variable.valueOf() : undefined;
+        return (variable && variable.disabled !== true) ? variable.valueOf() : undefined;
     },
 
     /**

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -290,7 +290,7 @@ describe('VariableScope', function () {
 
     describe('PM API helpers', function () {
         describe('get', function () {
-            it('should correctly return the specified value', function () {
+            it('should get the specified variable', function () {
                 var scope = new VariableScope([
                     { key: 'var-1', value: 'var-1-value' },
                     { key: 'var-2', value: 'var-2-value' }
@@ -299,7 +299,7 @@ describe('VariableScope', function () {
                 expect(scope.get('var-2')).to.equal('var-2-value');
             });
 
-            it('should return last enabled value from multi value list', function () {
+            it('should get last enabled from multi value list', function () {
                 var scope = new VariableScope([
                     { key: 'var-2', value: 'var-2-value' },
                     { key: 'var-2', value: 'var-2-value2' },
@@ -309,7 +309,7 @@ describe('VariableScope', function () {
                 expect(scope.get('var-2')).to.equal('var-2-value2');
             });
 
-            it('should return undefined for disabled variable', function () {
+            it('should bail out if variable is disabled', function () {
                 var scope = new VariableScope([
                     { key: 'var-3', value: 'var-3-value3', disabled: true }
                 ]);
@@ -317,7 +317,7 @@ describe('VariableScope', function () {
                 expect(scope.get('var-3')).to.be.undefined;
             });
 
-            it('should return undefined for unknown key', function () {
+            it('should bail out if no matches are found', function () {
                 var scope = new VariableScope([
                     { key: 'var-2', value: 'var-3-value3', disabled: true }
                 ]);
@@ -326,7 +326,7 @@ describe('VariableScope', function () {
             });
 
             describe('multi layer search', function () {
-                it('should get variable from parent layers', function () {
+                it('should get from parent scope', function () {
                     var scope = new VariableScope([
                         { key: 'alpha', value: 'foo' }
                     ]);
@@ -362,7 +362,7 @@ describe('VariableScope', function () {
                     expect(scope.get('random')).to.be.undefined;
                 });
 
-                it('should pick last enabled from multi value list', function () {
+                it('should get last enabled from multi value list', function () {
                     var scope = new VariableScope([
                         { key: 'alpha', value: 'foo' }
                     ]);
@@ -376,7 +376,7 @@ describe('VariableScope', function () {
                     expect(scope.get('gamma')).to.equal('foo_2');
                 });
 
-                it('should pick from current scope in case of duplicates', function () {
+                it('should get from current scope in case of duplicates', function () {
                     var scope = new VariableScope([
                         { key: 'alpha', value: 'foo' }
                     ]);
@@ -388,7 +388,7 @@ describe('VariableScope', function () {
                     expect(scope.get('alpha')).to.equal('foo');
                 });
 
-                it('should pick from first layer with enabled value in case of duplicates', function () {
+                it('should get first enabled in case of duplicates', function () {
                     var scope = new VariableScope([
                         { key: 'alpha', value: 'foo', disabled: true }
                     ]);

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -290,67 +290,118 @@ describe('VariableScope', function () {
 
     describe('PM API helpers', function () {
         describe('get', function () {
-            var scope = new VariableScope({
-                values: [{
-                    key: 'var-1',
-                    value: 'var-1-value'
-                }, {
-                    key: 'var-2',
-                    value: 'var-2-value'
-                }, {
-                    key: 'var-2',
-                    value: 'var-2-value2'
-                }, {
-                    key: 'var-2',
-                    value: 'var-2-value3',
-                    disabled: true
-                }, {
-                    key: 'var-3',
-                    value: 'var-3-value',
-                    disabled: true
-                }]
-            });
-
             it('should correctly return the specified value', function () {
-                expect(scope.get('var-1')).to.equal('var-1-value');
+                var scope = new VariableScope([
+                    { key: 'var-1', value: 'var-1-value' },
+                    { key: 'var-2', value: 'var-2-value' }
+                ]);
+
+                expect(scope.get('var-2')).to.equal('var-2-value');
             });
 
             it('should return last enabled value from multi value list', function () {
+                var scope = new VariableScope([
+                    { key: 'var-2', value: 'var-2-value' },
+                    { key: 'var-2', value: 'var-2-value2' },
+                    { key: 'var-2', value: 'var-2-value3', disabled: true }
+                ]);
+
                 expect(scope.get('var-2')).to.equal('var-2-value2');
             });
 
             it('should return undefined for disabled variable', function () {
+                var scope = new VariableScope([
+                    { key: 'var-3', value: 'var-3-value3', disabled: true }
+                ]);
+
                 expect(scope.get('var-3')).to.be.undefined;
             });
 
-            it('should return undefined for ', function () {
+            it('should return undefined for unknown key', function () {
+                var scope = new VariableScope([
+                    { key: 'var-2', value: 'var-3-value3', disabled: true }
+                ]);
+
                 expect(scope.get('random')).to.be.undefined;
             });
 
             describe('multi layer search', function () {
-                var newScope = new VariableScope();
+                it('should get variable from parent layers', function () {
+                    var scope = new VariableScope([
+                        { key: 'alpha', value: 'foo' }
+                    ]);
 
-                newScope.addLayer(new VariableList({}, [
-                    { key: 'alpha', value: 'foo' },
-                    { key: 'beta', value: 'bar', disabled: true },
-                    { key: 'gamma', value: 'foo' },
-                    { key: 'gamma', value: 'bar', disabled: true }
-                ]));
+                    scope.addLayer(new VariableList({}, [
+                        { key: 'alpha_layer_1', value: 'foo_layer_1' }
+                    ]));
 
-                it('should work correctly', function () {
-                    expect(newScope.get('alpha')).to.equal('foo');
+                    expect(scope.get('alpha_layer_1')).to.equal('foo_layer_1');
                 });
 
-                it('should bail out if variable is undefined', function () {
-                    expect(newScope.get('beta')).to.be.undefined;
+                it('should bail out if variable is disabled', function () {
+                    var scope = new VariableScope([
+                        { key: 'alpha', value: 'foo' }
+                    ]);
+
+                    scope.addLayer(new VariableList({}, [
+                        { key: 'beta', value: 'bar', disabled: true }
+                    ]));
+
+                    expect(scope.get('beta')).to.be.undefined;
                 });
 
                 it('should bail out if no matches are found', function () {
-                    expect(newScope.get('random')).to.be.undefined;
+                    var scope = new VariableScope([
+                        { key: 'alpha', value: 'foo' }
+                    ]);
+
+                    scope.addLayer(new VariableList({}, [
+                        { key: 'alpha_layer_1', value: 'foo_layer_1' }
+                    ]));
+
+                    expect(scope.get('random')).to.be.undefined;
                 });
 
                 it('should pick last enabled from multi value list', function () {
-                    expect(newScope.get('gamma')).to.equal('foo');
+                    var scope = new VariableScope([
+                        { key: 'alpha', value: 'foo' }
+                    ]);
+
+                    scope.addLayer(new VariableList({}, [
+                        { key: 'gamma', value: 'foo' },
+                        { key: 'gamma', value: 'foo_2' },
+                        { key: 'gamma', value: 'foo_3', disabled: true }
+                    ]));
+
+                    expect(scope.get('gamma')).to.equal('foo_2');
+                });
+
+                it('should pick from current scope in case of duplicates', function () {
+                    var scope = new VariableScope([
+                        { key: 'alpha', value: 'foo' }
+                    ]);
+
+                    scope.addLayer(new VariableList({}, [
+                        { key: 'alpha', value: 'foo_layer_1' }
+                    ]));
+
+                    expect(scope.get('alpha')).to.equal('foo');
+                });
+
+                it('should pick from first layer with enabled value in case of duplicates', function () {
+                    var scope = new VariableScope([
+                        { key: 'alpha', value: 'foo', disabled: true }
+                    ]);
+
+                    scope.addLayer(new VariableList({}, [
+                        { key: 'alpha', value: 'foo_layer_1' }
+                    ]));
+
+                    scope.addLayer(new VariableList({}, [
+                        { key: 'alpha', value: 'foo_layer_2', disabled: true }
+                    ]));
+
+                    expect(scope.get('alpha')).to.equal('foo_layer_1');
                 });
             });
         });


### PR DESCRIPTION
- Fixed a bug where `VariableScope.get()` method returned `undefined` if a variable with a duplicate key is present in both, current scope and any parent scopes, but it is disabled in current scope and enabled in parent scope.
- Corrected behavior: It should ignore disabled variable of current scope and return enabled variable from parent scope.

Example:
```javascript
var scope = new VariableScope([
    { key: 'alpha', value: 'foo', disabled: true }
]);

scope.addLayer(new VariableList({}, [
    { key: 'alpha', value: 'foo_layer_1' }
]));

console.log(scope.get('alpha'));
/* Output:
* => undefined // before this fix
* => foo_layer_1 // after this fix
*/
```