### PR TITLE
Fixed Request~authorizeUsing arguments assignment

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -5,6 +5,9 @@ master:
     - >-
       GH-883 Fixed a bug where `VariableScope~get` method doesn't search
       all the scopes if the variable is disabled in local scope
+    - >-
+      GH-884 Fixed a bug where `Request~authorizeUsing` was not handling
+      arguments passed as object correctly
 
 3.4.9:
   date: 2019-06-07

--- a/lib/collection/request.js
+++ b/lib/collection/request.js
@@ -188,8 +188,8 @@ _.assign(Request.prototype, /** @lends Request.prototype */ {
      */
     authorizeUsing: function (type, options) {
         if (_.isObject(type) && _.isNil(options)) {
-            type = options.type;
-            options = _.omit(options, 'type');
+            options = _.omit(type, 'type');
+            type = type.type;
         }
 
         // null = delete request

--- a/test/unit/request.test.js
+++ b/test/unit/request.test.js
@@ -563,6 +563,24 @@ describe('Request', function () {
                 ]
             });
         });
+
+        it('should handle all the arguments passed as object', function () {
+            var request = new Request();
+
+            request.authorizeUsing({
+                type: 'basic',
+                username: 'foo',
+                password: 'bar'
+            });
+
+            expect(request.auth.toJSON()).to.eql({
+                type: 'basic',
+                basic: [
+                    { type: 'any', value: 'foo', key: 'username' },
+                    { type: 'any', value: 'bar', key: 'password' }
+                ]
+            });
+        });
     });
 
     describe('.size', function () {


### PR DESCRIPTION
Fixed a bug where `Request~authorizeUsing` was not handling arguments passed as an object correctly.