### PR TITLE
Handle disabled query params in Url~toString

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -8,6 +8,9 @@ master:
     - >-
       GH-884 Fixed a bug where `Request~authorizeUsing` was not handling
       arguments passed as object correctly
+    - >-
+      GH-885 Fixed a bug where `Url~toString` adds query separator `?` even if
+      all query params are disabled
 
 3.4.9:
   date: 2019-06-07

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -199,7 +199,8 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
      */
     toString: function (forceProtocol) {
         var rawUrl = E,
-            protocol = this.protocol;
+            protocol = this.protocol,
+            queryString;
 
         forceProtocol && !protocol && (protocol = DEFAULT_PROTOCOL);
 
@@ -226,7 +227,8 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
         }
 
         if (this.query && this.query.count()) {
-            rawUrl += QUERY_SEPARATOR + this.getQueryString({ ignoreDisabled: true });
+            queryString = this.getQueryString({ ignoreDisabled: true });
+            queryString && (rawUrl += QUERY_SEPARATOR + queryString);
         }
 
         if (this.hash) {

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -794,6 +794,18 @@ describe('Url', function () {
             var url = new Url('https://postman-echo.com///get');
             expect(url.toString()).to.eql('https://postman-echo.com///get');
         });
+
+        it('should handle disabled query parameters', function () {
+            var url = new Url({
+                host: 'https://postman-echo.com',
+                query: [{
+                    key: 'foo',
+                    value: 'bar',
+                    disabled: true
+                }]
+            });
+            expect(url.toString()).to.eql('https://postman-echo.com');
+        });
     });
 
     describe('getHost', function () {


### PR DESCRIPTION
Fixed a bug where `Url~toString` adds query separator `?` even if all query params are disabled.

Refer: https://github.com/postmanlabs/newman/issues/2012