### PR TITLE
Modify `$randomPhone*` to send extension separately

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,10 @@
+master:
+  fixed bugs:
+    - >-
+      GH-891 Modified behavior of `$randomPhoneNumber` to not include phone
+      extension and added `$randomPhoneNumberExt` and
+      `$randomPhoneNumberWithExt`
+
 3.5.0:
   date: 2019-06-17
   new features:
@@ -13,10 +20,6 @@
     - >-
       GH-885 Fixed a bug where `Url~toString` adds query separator `?` even if
       all query params are disabled
-    - >-
-      GH-891 Modified behavior of `$randomPhoneNumber` to not include phone
-      extension and added `$randomPhoneNumberExt` and
-      `$randomPhoneNumberWithExt`
 
 3.4.9:
   date: 2019-06-07

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -13,6 +13,10 @@
     - >-
       GH-885 Fixed a bug where `Url~toString` adds query separator `?` even if
       all query params are disabled
+    - >-
+      GH-891 Modified behavior of `$randomPhoneNumber` to not include phone
+      extension and added `$randomPhoneNumberExt` and
+      `$randomPhoneNumberWithExt`
 
 3.4.9:
   date: 2019-06-07

--- a/lib/superstring/faker-map.js
+++ b/lib/superstring/faker-map.js
@@ -121,6 +121,8 @@ module.exports = {
     JobType: 'name.jobType',
 
     PhoneNumber: 'phone.phoneNumber',
+    PhoneNumberExt: 'phone.phoneNumberExt',
+    PhoneNumberWithExt: 'phone.phoneNumberWithExt',
     PhoneNumberFormat: 'phone.phoneNumberFormat',
     PhoneFormats: 'phone.phoneFormats',
 

--- a/lib/superstring/faker-map.js
+++ b/lib/superstring/faker-map.js
@@ -121,7 +121,6 @@ module.exports = {
     JobType: 'name.jobType',
 
     PhoneNumber: 'phone.phoneNumber',
-    PhoneNumberExt: 'phone.phoneNumberExt',
     PhoneNumberWithExt: 'phone.phoneNumberWithExt',
     PhoneNumberFormat: 'phone.phoneNumberFormat',
     PhoneFormats: 'phone.phoneFormats',

--- a/lib/superstring/index.js
+++ b/lib/superstring/index.js
@@ -232,6 +232,23 @@ _.assign(Substitutor, /** @lends Substitutor */ {
     }
 });
 
+// override the functions from the faker library with custom functions. later when fakermap is
+// iterated to pick up functions from the faker library, these functions are used instead.
+// new functions which don't exist in faker library can also be added here.
+_.assign(faker.phone, {
+    phoneNumber: function () {
+        return faker.phone.phoneNumberFormat(0);
+    },
+
+    phoneNumberExt: function () {
+        return faker.helpers.replaceSymbolWithNumber('###');
+    },
+
+    phoneNumberWithExt: function () {
+        return faker.phone.phoneNumberFormat(1);
+    }
+});
+
 // picks faker functions from the faker library
 // @todo make the default variales of SuperString extensible and do this anywhere else but here
 _.forOwn(fakermap, function (extension, name) {

--- a/lib/superstring/index.js
+++ b/lib/superstring/index.js
@@ -240,12 +240,8 @@ _.assign(faker.phone, {
         return faker.phone.phoneNumberFormat(0);
     },
 
-    phoneNumberExt: function () {
-        return faker.helpers.replaceSymbolWithNumber('###');
-    },
-
     phoneNumberWithExt: function () {
-        return faker.phone.phoneNumberFormat(1);
+        return faker.phone.phoneNumberFormat(2);
     }
 });
 


### PR DESCRIPTION
Modify `$randomPhoneNumber` to send a phone number without an extension and add `$randomPhoneNumberExt` and `$randomPhoneNumberWithExt`.

This is done by overriding the _faker.js_ library functions with our own custom functions before `faker-map` is iterated in superstring module.

Ref:
- https://github.com/postmanlabs/postman-app-support/issues/6765
- https://github.com/postmanlabs/postman-app-support/issues/971