### PR TITLE
Add a new method `getAll` to PropertyList

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,8 @@
+master:
+  new features:
+    - GH-893 Added a new method `getAll(key)` to `PropertyList` which returns an
+      array of all values of the list.
+
 3.5.0:
   date: 2019-06-17
   new features:

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -389,6 +389,30 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
     },
 
     /**
+     * Get all the values of an item in the list. If multiple values are not allowed, only the last item is returned.
+     *
+     * @param {String|Function} key
+     * @returns {Array<PropertyList.Type|*>}
+     */
+    getAll: function (key) {
+        var member,
+            val = [];
+
+        member = this.reference[this._postman_listIndexCaseInsensitive ? String(key).toLowerCase() : key];
+        if (!member) { return; } // eslint-disable-line getter-return
+
+        if (this._postman_listAllowsMultipleValues && Array.isArray(member)) {
+            _.forEach(member, function (obj) {
+                val.push(obj.valueOf());
+            });
+            return val;
+        }
+
+        val.push(member.valueOf());
+        return val;
+    },
+
+    /**
      * Iterate on each item of this list.
      *
      * @param {Function} iterator

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -655,6 +655,54 @@ describe('PropertyList', function () {
         });
     });
 
+    describe('.getAll()', function () {
+        var FakeType = function (options) {
+            this.keyAttr = options.keyAttr;
+            this.value = options.value;
+            this.disabled = options.disabled;
+        };
+
+        FakeType._postman_propertyIndexKey = 'keyAttr';
+        FakeType._postman_propertyIndexCaseInsensitive = true;
+        FakeType._postman_propertyAllowsMultipleValues = true;
+        FakeType.prototype.valueOf = function () {
+            return this.value;
+        };
+
+        it('should return an array of all values', function () {
+            var list = new PropertyList(FakeType, {}, [{
+                keyAttr: 'key1',
+                value: 'val1'
+            }, {
+                keyAttr: 'key1',
+                value: 'val2'
+            }, {
+                keyAttr: 'key2',
+                value: 'val3'
+            }]);
+
+            expect(list.getAll('key1')).to.eql(['val1', 'val2']);
+            expect(list.getAll('key2')).to.eql(['val3']);
+        });
+
+        it('should return an array with the newest value', function () {
+            FakeType._postman_propertyAllowsMultipleValues = false;
+            var list = new PropertyList(FakeType, {}, [{
+                keyAttr: 'key1',
+                value: 'val1' // this value is ignored
+            }, {
+                keyAttr: 'key1',
+                value: 'val2'
+            }, {
+                keyAttr: 'key2',
+                value: 'val3'
+            }]);
+
+            expect(list.getAll('key1')).to.eql(['val2']);
+            expect(list.getAll('key2')).to.eql(['val3']);
+        });
+    });
+
     describe('.remove()', function () {
         var FakeType = function (options) {
             this.keyAttr = options.keyAttr;


### PR DESCRIPTION
This method gets all the values of an item in the list. If multiple values are not allowed, only the last item is returned. The return type is always an array.

Ref: https://github.com/postmanlabs/postman-app-support/issues/6143