### PR TITLE
Remove irrelevant and incomplete faker generators

### DIFF
--- a/lib/superstring/faker-map.js
+++ b/lib/superstring/faker-map.js
@@ -1,14 +1,8 @@
 module.exports = {
     ZipCode: 'address.zipCode',
     City: 'address.city',
-    CityPrefix: 'address.cityPrefix',
-    CitySuffix: 'address.citySuffix',
     StreetName: 'address.streetName',
     StreetAddress: 'address.streetAddress',
-    StreetSuffix: 'address.streetSuffix',
-    StreetPrefix: 'address.streetPrefix',
-    SecondaryAddress: 'address.secondaryAddress',
-    County: 'address.county',
     Country: 'address.country',
     CountryCode: 'address.countryCode',
     State: 'address.state',
@@ -19,7 +13,6 @@ module.exports = {
     Color: 'commerce.color',
     Department: 'commerce.department',
     ProductName: 'commerce.productName',
-    Price: 'commerce.price',
     ProductAdjective: 'commerce.productAdjective',
     ProductMaterial: 'commerce.productMaterial',
     Product: 'commerce.product',
@@ -42,7 +35,6 @@ module.exports = {
 
     DatePast: 'date.past',
     DateFuture: 'date.future',
-    DateBetween: 'date.between',
     DateRecent: 'date.recent',
     Month: 'date.month',
     Weekday: 'date.weekday',
@@ -115,17 +107,12 @@ module.exports = {
     JobTitle: 'name.jobTitle',
     NamePrefix: 'name.prefix',
     NameSuffix: 'name.suffix',
-    NameTitle: 'name.title',
     JobDescriptor: 'name.jobDescriptor',
     JobArea: 'name.jobArea',
     JobType: 'name.jobType',
 
     PhoneNumber: 'phone.phoneNumber',
-    PhoneNumberFormat: 'phone.phoneNumberFormat',
-    PhoneFormats: 'phone.phoneFormats',
 
-    ArrayElement: 'random.arrayElement',
-    ObjectElement: 'random.objectElement',
     UUID: 'random.uuid',
     Boolean: 'random.boolean',
     Word: 'random.word',
@@ -140,7 +127,5 @@ module.exports = {
     CommonFileExt: 'system.commonFileExt',
     FileType: 'system.fileType',
     FileExt: 'system.fileExt',
-    DirectoryPath: 'system.directoryPath',
-    FilePath: 'system.filePath',
     Semver: 'system.semver'
 };

--- a/test/unit/superstring.test.js
+++ b/test/unit/superstring.test.js
@@ -52,5 +52,12 @@ describe('String utilities', function () {
                 generatorSet[extension] = name;
             });
         });
+
+        it('should not include generators that are incomplete', function () {
+            _.forOwn(fakermap, function (extension) {
+                var generator = _.get(faker, extension);
+                expect(generator()).to.not.be.undefined;
+            });
+        });
     });
 });


### PR DESCRIPTION
Removed:
- `address.cityPrefix`
- `address.citySuffix`
- `address.streetPrefix`
- `address.streetSuffix`
- `address.secondaryAddress`
- `address.county`
- `commerce.price`
- `date.between`
- `name.title`
- `phone.phoneNumberFormat`
- `phone.phoneFormats`
- `random.arrayElement`
- `random.objectElement`
- `system.directoryPath` (return `undefined`)
- `system.filePath` (return `undefined`)