### PR TITLE
Add dynamic generators for superstring

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+master:
+  fixed bugs:
+    - >-
+      GH-900 Added dynamic generators for `superstring` module and removed
+      invalid/unsupported faker generators.
+
 3.5.0:
   date: 2019-06-17
   new features:

--- a/lib/superstring/dynamic-generators.js
+++ b/lib/superstring/dynamic-generators.js
@@ -12,11 +12,7 @@ module.exports = {
     // faker.phone.phoneNumber returns phone number with or without extension randomly. this only returns a phone
     // number with extension.
     PhoneNumberExt: function () {
-        var extensionOptions = ['#', '##', '###', '1-###'];
-
-        // @todo may return +0 or +08 as extension
-        return '+' + faker.helpers.replaceSymbolWithNumber(faker.random.arrayElement(extensionOptions)) + '-'
-            + faker.phone.phoneNumberFormat(0);
+        return '+' + faker.random.number({ min: 1, max: 99 }) + '-' + faker.phone.phoneNumberFormat(0);
     },
 
     // faker's random.locale only returns 'en'. this returns from a list of random locales

--- a/lib/superstring/dynamic-generators.js
+++ b/lib/superstring/dynamic-generators.js
@@ -1,4 +1,79 @@
-var faker = require('faker/locale/en');
+var faker = require('faker/locale/en'),
+
+    // locale list generated from: https://github.com/chromium/chromium/blob/master/ui/base/l10n/l10n_util.cc
+    locales = ['af', 'am', 'an', 'ar', 'ast', 'az', 'be', 'bg', 'bh', 'bn', 'br', 'bs', 'ca', 'ceb', 'ckb', 'co', 'cs',
+        'cy', 'da', 'de', 'el', 'en', 'eo', 'es', 'et', 'eu', 'fa', 'fi', 'fil', 'fo', 'fr', 'fy', 'ga', 'gd', 'gl',
+        'gn', 'gu', 'ha', 'haw', 'he', 'hi', 'hmn', 'hr', 'ht', 'hu', 'hy', 'ia', 'id', 'ig', 'is', 'it', 'ja', 'jv',
+        'ka', 'kk', 'km', 'kn', 'ko', 'ku', 'ky', 'la', 'lb', 'ln', 'lo', 'lt', 'lv', 'mg', 'mi', 'mk', 'ml', 'mn',
+        'mo', 'mr', 'ms', 'mt', 'my', 'nb', 'ne', 'nl', 'nn', 'no', 'ny', 'oc', 'om', 'or', 'pa', 'pl', 'ps', 'pt',
+        'qu', 'rm', 'ro', 'ru', 'sd', 'sh', 'si', 'sk', 'sl', 'sm', 'sn', 'so', 'sq', 'sr', 'st', 'su', 'sv', 'sw',
+        'ta', 'te', 'tg', 'th', 'ti', 'tk', 'to', 'tr', 'tt', 'tw', 'ug', 'uk', 'ur', 'uz', 'vi', 'wa', 'xh', 'yi',
+        'yo', 'zh', 'zu'],
+
+    // paths for directories
+    directoryPaths = [
+        '/Applications',
+        '/bin',
+        '/boot',
+        '/boot/defaults',
+        '/dev',
+        '/etc',
+        '/etc/defaults',
+        '/etc/mail',
+        '/etc/namedb',
+        '/etc/periodic',
+        '/etc/ppp',
+        '/home',
+        '/home/user',
+        '/home/user/dir',
+        '/lib',
+        '/Library',
+        '/lost+found',
+        '/media',
+        '/mnt',
+        '/net',
+        '/Network',
+        '/opt',
+        '/opt/bin',
+        '/opt/include',
+        '/opt/lib',
+        '/opt/sbin',
+        '/opt/share',
+        '/private',
+        '/private/tmp',
+        '/private/var',
+        '/proc',
+        '/rescue',
+        '/root',
+        '/sbin',
+        '/selinux',
+        '/srv',
+        '/sys',
+        '/System',
+        '/tmp',
+        '/Users',
+        '/usr',
+        '/usr/X11R6',
+        '/usr/bin',
+        '/usr/include',
+        '/usr/lib',
+        '/usr/libdata',
+        '/usr/libexec',
+        '/usr/local/bin',
+        '/usr/local/src',
+        '/usr/obj',
+        '/usr/ports',
+        '/usr/sbin',
+        '/usr/share',
+        '/usr/src',
+        '/var',
+        '/var/log',
+        '/var/mail',
+        '/var/spool',
+        '/var/tmp',
+        '/var/yp'
+    ];
+
 
 // generators for $random* variables
 module.exports = {
@@ -17,18 +92,6 @@ module.exports = {
 
     // faker's random.locale only returns 'en'. this returns from a list of random locales
     Locale: function () {
-        // locale list generated from: http://www.loc.gov/standards/iso639-2/php/code_list.php
-        var locales = ['aa', 'ab', 'af', 'ak', 'am', 'ar', 'an', 'as', 'av', 'ae', 'ay', 'az', 'ba', 'bm', 'be',
-            'bn', 'bh', 'bi', 'bs', 'br', 'bg', 'ca', 'ch', 'ce', 'cu', 'cv', 'kw', 'co', 'cr', 'da', 'dv', 'dz',
-            'en', 'eo', 'et', 'ee', 'fo', 'fj', 'fi', 'fy', 'ff', 'gd', 'ga', 'gl', 'gv', 'gn', 'gu', 'ht', 'ha',
-            'he', 'hz', 'hi', 'ho', 'hr', 'hu', 'ig', 'io', 'ii', 'iu', 'ie', 'ia', 'id', 'ik', 'it', 'jv', 'ja',
-            'kl', 'kn', 'ks', 'kr', 'kk', 'km', 'ki', 'rw', 'ky', 'kv', 'kg', 'ko', 'kj', 'ku', 'lo', 'la', 'lv',
-            'li', 'ln', 'lt', 'lb', 'lu', 'lg', 'mh', 'ml', 'mr', 'mg', 'mt', 'mn', 'na', 'nv', 'nr', 'nd', 'ng',
-            'ne', 'nn', 'nb', 'no', 'ny', 'oc', 'oj', 'or', 'om', 'os', 'pa', 'pi', 'pl', 'pt', 'ps', 'qt', 'qu',
-            'rm', 'rn', 'ru', 'sg', 'sa', 'si', 'sl', 'se', 'sm', 'sn', 'sd', 'so', 'st', 'es', 'sc', 'sr', 'ss',
-            'su', 'sw', 'sv', 'ty', 'ta', 'tt', 'te', 'tg', 'tl', 'th', 'ti', 'to', 'tn', 'ts', 'tk', 'tr', 'tw',
-            'ug', 'uk', 'ur', 'uz', 've', 'vi', 'vo', 'wa', 'wo', 'xh', 'yi', 'yo', 'za', 'zu'];
-
         return faker.random.arrayElement(locales);
     },
 
@@ -52,69 +115,6 @@ module.exports = {
 
     // faker's system.directoryPath retuns nothing. this returns a path for a directory.
     DirectoryPath: function () {
-        var paths = [
-            '/Applications',
-            '/bin',
-            '/boot',
-            '/boot/defaults',
-            '/dev',
-            '/etc',
-            '/etc/defaults',
-            '/etc/mail',
-            '/etc/namedb',
-            '/etc/periodic',
-            '/etc/ppp',
-            '/home',
-            '/home/user',
-            '/home/user/dir',
-            '/lib',
-            '/Library',
-            '/lost+found',
-            '/media',
-            '/mnt',
-            '/net',
-            '/Network',
-            '/opt',
-            '/opt/bin',
-            '/opt/include',
-            '/opt/lib',
-            '/opt/sbin',
-            '/opt/share',
-            '/private',
-            '/private/tmp',
-            '/private/var',
-            '/proc',
-            '/rescue',
-            '/root',
-            '/sbin',
-            '/selinux',
-            '/srv',
-            '/sys',
-            '/System',
-            '/tmp',
-            '/Users',
-            '/usr',
-            '/usr/X11R6',
-            '/usr/bin',
-            '/usr/include',
-            '/usr/lib',
-            '/usr/libdata',
-            '/usr/libexec',
-            '/usr/local/bin',
-            '/usr/local/src',
-            '/usr/obj',
-            '/usr/ports',
-            '/usr/sbin',
-            '/usr/share',
-            '/usr/src',
-            '/var',
-            '/var/log',
-            '/var/mail',
-            '/var/spool',
-            '/var/tmp',
-            '/var/yp'
-        ];
-
-        return faker.random.arrayElement(paths);
+        return faker.random.arrayElement(directoryPaths);
     }
 };

--- a/lib/superstring/dynamic-generators.js
+++ b/lib/superstring/dynamic-generators.js
@@ -1,7 +1,7 @@
 var faker = require('faker/locale/en'),
 
     // locale list generated from: https://github.com/chromium/chromium/blob/master/ui/base/l10n/l10n_util.cc
-    locales = ['af', 'am', 'an', 'ar', 'ast', 'az', 'be', 'bg', 'bh', 'bn', 'br', 'bs', 'ca', 'ceb', 'ckb', 'co', 'cs',
+    LOCALES = ['af', 'am', 'an', 'ar', 'ast', 'az', 'be', 'bg', 'bh', 'bn', 'br', 'bs', 'ca', 'ceb', 'ckb', 'co', 'cs',
         'cy', 'da', 'de', 'el', 'en', 'eo', 'es', 'et', 'eu', 'fa', 'fi', 'fil', 'fo', 'fr', 'fy', 'ga', 'gd', 'gl',
         'gn', 'gu', 'ha', 'haw', 'he', 'hi', 'hmn', 'hr', 'ht', 'hu', 'hy', 'ia', 'id', 'ig', 'is', 'it', 'ja', 'jv',
         'ka', 'kk', 'km', 'kn', 'ko', 'ku', 'ky', 'la', 'lb', 'ln', 'lo', 'lt', 'lv', 'mg', 'mi', 'mk', 'ml', 'mn',
@@ -11,7 +11,7 @@ var faker = require('faker/locale/en'),
         'yo', 'zh', 'zu'],
 
     // paths for directories
-    directoryPaths = [
+    DIRECTORY_PATHS = [
         '/Applications',
         '/bin',
         '/boot',
@@ -87,12 +87,12 @@ module.exports = {
     // faker.phone.phoneNumber returns phone number with or without extension randomly. this only returns a phone
     // number with extension.
     PhoneNumberExt: function () {
-        return '+' + faker.random.number({ min: 1, max: 99 }) + '-' + faker.phone.phoneNumberFormat(0);
+        return faker.random.number({ min: 1, max: 99 }) + '-' + faker.phone.phoneNumberFormat(0);
     },
 
     // faker's random.locale only returns 'en'. this returns from a list of random locales
     Locale: function () {
-        return faker.random.arrayElement(locales);
+        return faker.random.arrayElement(LOCALES);
     },
 
     // fakers' random.words returns random number of words between 1, 3. this returns number of words between 2, 5.
@@ -115,6 +115,6 @@ module.exports = {
 
     // faker's system.directoryPath retuns nothing. this returns a path for a directory.
     DirectoryPath: function () {
-        return faker.random.arrayElement(directoryPaths);
+        return faker.random.arrayElement(DIRECTORY_PATHS);
     }
 };

--- a/lib/superstring/dynamic-generators.js
+++ b/lib/superstring/dynamic-generators.js
@@ -1,0 +1,51 @@
+var faker = require('faker/locale/en');
+
+// generators for $random* variables
+module.exports = {
+
+    // faker.phone.phoneNumber returns phone number with or without extension randomly. this only returns a phone
+    // number without extension.
+    PhoneNumber: function () {
+        return faker.phone.phoneNumberFormat(0);
+    },
+
+    // faker.phone.phoneNumber returns phone number with or without extension randomly. this only returns a phone
+    // number with extension.
+    PhoneNumberExt: function () {
+        var extensionOptions = ['#', '##', '###', '1-###'];
+
+        // @todo may return +0 or +08 as extension
+        return '+' + faker.helpers.replaceSymbolWithNumber(faker.random.arrayElement(extensionOptions)) + '-'
+            + faker.phone.phoneNumberFormat(0);
+    },
+
+    // faker's random.locale only returns 'en'. this returns from a list of random locales
+    Locale: function () {
+        // locale list generated from: http://www.loc.gov/standards/iso639-2/php/code_list.php
+        var locales = ['aa', 'ab', 'af', 'ak', 'am', 'ar', 'an', 'as', 'av', 'ae', 'ay', 'az', 'ba', 'bm', 'be',
+            'bn', 'bh', 'bi', 'bs', 'br', 'bg', 'ca', 'ch', 'ce', 'cu', 'cv', 'kw', 'co', 'cr', 'da', 'dv', 'dz',
+            'en', 'eo', 'et', 'ee', 'fo', 'fj', 'fi', 'fy', 'ff', 'gd', 'ga', 'gl', 'gv', 'gn', 'gu', 'ht', 'ha',
+            'he', 'hz', 'hi', 'ho', 'hr', 'hu', 'ig', 'io', 'ii', 'iu', 'ie', 'ia', 'id', 'ik', 'it', 'jv', 'ja',
+            'kl', 'kn', 'ks', 'kr', 'kk', 'km', 'ki', 'rw', 'ky', 'kv', 'kg', 'ko', 'kj', 'ku', 'lo', 'la', 'lv',
+            'li', 'ln', 'lt', 'lb', 'lu', 'lg', 'mh', 'ml', 'mr', 'mg', 'mt', 'mn', 'na', 'nv', 'nr', 'nd', 'ng',
+            'ne', 'nn', 'nb', 'no', 'ny', 'oc', 'oj', 'or', 'om', 'os', 'pa', 'pi', 'pl', 'pt', 'ps', 'qt', 'qu',
+            'rm', 'rn', 'ru', 'sg', 'sa', 'si', 'sl', 'se', 'sm', 'sn', 'sd', 'so', 'st', 'es', 'sc', 'sr', 'ss',
+            'su', 'sw', 'sv', 'ty', 'ta', 'tt', 'te', 'tg', 'tl', 'th', 'ti', 'to', 'tn', 'ts', 'tk', 'tr', 'tw',
+            'ug', 'uk', 'ur', 'uz', 've', 'vi', 'vo', 'wa', 'wo', 'xh', 'yi', 'yo', 'za', 'zu'];
+
+        return faker.random.arrayElement(locales);
+    },
+
+    // fakers' random.words returns random number of words between 1, 3. this returns number of words between 2, 5.
+    Words: function () {
+        var words = [],
+            count = faker.random.number({ min: 2, max: 5 }),
+            i;
+
+        for (i = 0; i < count; i++) {
+            words.push(faker.random.word());
+        }
+
+        return words.join(' ');
+    }
+};

--- a/lib/superstring/dynamic-generators.js
+++ b/lib/superstring/dynamic-generators.js
@@ -43,5 +43,78 @@ module.exports = {
         }
 
         return words.join(' ');
+    },
+
+    // faker's system.filePath retuns nothing. this returns a path for a file.
+    FilePath: function () {
+        return this.DirectoryPath() + '/' + faker.system.fileName();
+    },
+
+    // faker's system.directoryPath retuns nothing. this returns a path for a directory.
+    DirectoryPath: function () {
+        var paths = [
+            '/Applications',
+            '/bin',
+            '/boot',
+            '/boot/defaults',
+            '/dev',
+            '/etc',
+            '/etc/defaults',
+            '/etc/mail',
+            '/etc/namedb',
+            '/etc/periodic',
+            '/etc/ppp',
+            '/home',
+            '/home/user',
+            '/home/user/dir',
+            '/lib',
+            '/Library',
+            '/lost+found',
+            '/media',
+            '/mnt',
+            '/net',
+            '/Network',
+            '/opt',
+            '/opt/bin',
+            '/opt/include',
+            '/opt/lib',
+            '/opt/sbin',
+            '/opt/share',
+            '/private',
+            '/private/tmp',
+            '/private/var',
+            '/proc',
+            '/rescue',
+            '/root',
+            '/sbin',
+            '/selinux',
+            '/srv',
+            '/sys',
+            '/System',
+            '/tmp',
+            '/Users',
+            '/usr',
+            '/usr/X11R6',
+            '/usr/bin',
+            '/usr/include',
+            '/usr/lib',
+            '/usr/libdata',
+            '/usr/libexec',
+            '/usr/local/bin',
+            '/usr/local/src',
+            '/usr/obj',
+            '/usr/ports',
+            '/usr/sbin',
+            '/usr/share',
+            '/usr/src',
+            '/var',
+            '/var/log',
+            '/var/mail',
+            '/var/spool',
+            '/var/tmp',
+            '/var/yp'
+        ];
+
+        return faker.random.arrayElement(paths);
     }
 };

--- a/lib/superstring/faker-map.js
+++ b/lib/superstring/faker-map.js
@@ -111,13 +111,9 @@ module.exports = {
     JobArea: 'name.jobArea',
     JobType: 'name.jobType',
 
-    PhoneNumber: 'phone.phoneNumber',
-
     UUID: 'random.uuid',
     Boolean: 'random.boolean',
     Word: 'random.word',
-    Words: 'random.words',
-    Locale: 'random.locale',
     AlphaNumeric: 'random.alphaNumeric',
 
     FileName: 'system.fileName',

--- a/lib/superstring/index.js
+++ b/lib/superstring/index.js
@@ -2,6 +2,7 @@ var _ = require('../util').lodash,
     uuid = require('uuid'),
     faker = require('faker/locale/en'),
     fakermap = require('./faker-map'),
+    dynamicGenerators = require('./dynamic-generators'),
     E = '',
     FAKER_DYN_VAR_BASE = '$random',
 
@@ -237,6 +238,12 @@ _.assign(Substitutor, /** @lends Substitutor */ {
 _.forOwn(fakermap, function (extension, name) {
     var generator = _.get(faker, extension);
 
+    if (_.isFunction(generator)) {
+        Substitutor.DEFAULT_VARS[FAKER_DYN_VAR_BASE + name] = generator;
+    }
+});
+
+_.forOwn(dynamicGenerators, function (generator, name) {
     if (_.isFunction(generator)) {
         Substitutor.DEFAULT_VARS[FAKER_DYN_VAR_BASE + name] = generator;
     }

--- a/test/unit/dynamic-generators.test.js
+++ b/test/unit/dynamic-generators.test.js
@@ -44,5 +44,23 @@ describe('Overridden generator', function () {
             expect(wordsArray.length).to.be.at.least(2);
         });
     });
+
+    describe('FilePath', function () {
+        it('returns a file path', function () {
+            var filePath = dynamicGenerators.FilePath();
+
+            expect(filePath).to.not.be.undefined;
+            expect(filePath).to.not.be.null;
+        });
+    });
+
+    describe('DirectoryPath', function () {
+        it('returns a directory path', function () {
+            var directoryPath = dynamicGenerators.DirectoryPath();
+
+            expect(directoryPath).to.not.be.undefined;
+            expect(directoryPath).to.not.be.null;
+        });
+    });
 });
 

--- a/test/unit/dynamic-generators.test.js
+++ b/test/unit/dynamic-generators.test.js
@@ -1,0 +1,48 @@
+var dynamicGenerators = require('../../lib/superstring/dynamic-generators'),
+    expect = require('chai').expect;
+
+describe('Overridden generator', function () {
+    describe('PhoneNumber', function () {
+        it('returns a random phone number without extension', function () {
+            var phone1 = dynamicGenerators.PhoneNumber(),
+                phone2 = dynamicGenerators.PhoneNumber();
+
+            expect(phone1.length).to.equal(12);
+            expect(phone2.length).to.equal(12);
+            expect(phone1).to.not.equal(phone2);
+        });
+    });
+
+    describe('Locale', function () {
+        it('returns a random locale', function () {
+            var locale1 = dynamicGenerators.Locale(),
+                locale2 = dynamicGenerators.Locale();
+
+            expect(locale1.length).to.equal(2);
+            expect(locale2.length).to.equal(2);
+            expect(locale1).to.not.equal(locale2);
+        });
+    });
+
+    describe('PhoneNumberExt', function () {
+        it('returns a random phone number with extension', function () {
+            var phone1 = dynamicGenerators.PhoneNumberExt(),
+                phone2 = dynamicGenerators.PhoneNumberExt();
+
+            expect(phone1.length).to.equal(14);
+            expect(phone1.length).to.equal(14);
+            expect(phone1).to.not.equal(phone2);
+        });
+    });
+
+    describe('Words', function () {
+        it('returns some random numbers', function () {
+            var words = dynamicGenerators.Words(),
+                wordsArray = words.split(' ');
+
+            expect(words).to.not.be.null;
+            expect(wordsArray.length).to.be.at.least(2);
+        });
+    });
+});
+

--- a/test/unit/dynamic-generators.test.js
+++ b/test/unit/dynamic-generators.test.js
@@ -1,7 +1,7 @@
 var dynamicGenerators = require('../../lib/superstring/dynamic-generators'),
     expect = require('chai').expect;
 
-describe('Overridden generator', function () {
+describe('Dynamic generator', function () {
     describe('PhoneNumber', function () {
         it('returns a random phone number without extension', function () {
             var phone1 = dynamicGenerators.PhoneNumber(),
@@ -18,8 +18,8 @@ describe('Overridden generator', function () {
             var locale1 = dynamicGenerators.Locale(),
                 locale2 = dynamicGenerators.Locale();
 
-            expect(locale1.length).to.equal(2);
-            expect(locale2.length).to.equal(2);
+            expect(locale1.length).to.be.at.least(2).and.at.most(3);
+            expect(locale2.length).to.be.at.least(2).and.at.most(3);
             expect(locale1).to.not.equal(locale2);
         });
     });

--- a/test/unit/dynamic-generators.test.js
+++ b/test/unit/dynamic-generators.test.js
@@ -29,8 +29,8 @@ describe('Dynamic generator', function () {
             var phone1 = dynamicGenerators.PhoneNumberExt(),
                 phone2 = dynamicGenerators.PhoneNumberExt();
 
-            expect(phone1.length).to.be.at.least(15);
-            expect(phone2.length).to.be.at.least(15);
+            expect(phone1.length).to.be.at.least(14);
+            expect(phone2.length).to.be.at.least(14);
             expect(phone1).to.not.equal(phone2);
         });
     });

--- a/test/unit/dynamic-generators.test.js
+++ b/test/unit/dynamic-generators.test.js
@@ -29,8 +29,8 @@ describe('Overridden generator', function () {
             var phone1 = dynamicGenerators.PhoneNumberExt(),
                 phone2 = dynamicGenerators.PhoneNumberExt();
 
-            expect(phone1.length).to.equal(14);
-            expect(phone1.length).to.equal(14);
+            expect(phone1.length).to.be.at.least(15);
+            expect(phone2.length).to.be.at.least(15);
             expect(phone1).to.not.equal(phone2);
         });
     });


### PR DESCRIPTION
Continues from #897 

Overridden faker generators:
- `phone.phoneNumber`
- `random.words`
- `random.locale`
- `system.directoryPath`
- `system.filePath`

New generators:
- `$randomPhoneNumberExt`

This PR makes #891 obsolete.