### PR TITLE
Add function `replaceIn` to replace variables in an object or string

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,4 +1,8 @@
 master:
+  new features:
+    - >-
+      GH-914 Added a new function `replaceIn` to resolve variables in a given
+      template to their values
   chores:
     - >-
       GH-897, GH-900, GH-901 Added dynamic generators for `superstring` module

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,8 +1,8 @@
 master:
   new features:
     - >-
-      GH-914 Added a new function `replaceIn` to resolve variables in a given
-      template to their values
+      GH-914 Added a new method `VariableScope~replaceIn` to resolve variables
+      to their values in a given template
   chores:
     - >-
       GH-897, GH-900, GH-901 Added dynamic generators for `superstring` module

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -316,7 +316,13 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
         this.values.clear();
     },
 
-    interpolate: function (obj) {
+    /**
+     * Replace all variable names with their values in the given string or object
+     *
+     * @param {string|object} obj A string or an object to replace variables in
+     * @returns {string|object} The string or object with variables (if any) substituted with their values
+     */
+    replaceIn: function (obj) {
         var transformed,
             result;
 

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -316,6 +316,20 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
         this.values.clear();
     },
 
+    interpolate: function (obj) {
+        var transformed,
+            result;
+
+        if (typeof obj !== 'object') {
+            obj = [obj];
+            transformed = true;
+        }
+
+        result = Property.replaceSubstitutionsIn(obj, _.concat(this.values, this._layers));
+
+        return transformed ? result[0] : result;
+    },
+
     /**
      * Enable mutation tracking.
      *

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -323,20 +323,17 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      * @returns {string|object} The string or object with variables (if any) substituted with their values
      */
     replaceIn: function (template) {
-        var isString = typeof template === 'string',
-            result;
-
-        if (isString) {
-            template = [template];
+        if (_.isString(template) || _.isArray(template)) {
+            // convert template to object because replaceSubstitutionsIn only accepts objects
+            var result = Property.replaceSubstitutionsIn({ template: template }, _.concat(this.values, this._layers));
+            return result.template;
         }
 
-        if (typeof template !== 'object') {
-            return template;
+        if (_.isObject(template)) {
+            return Property.replaceSubstitutionsIn(template, _.concat(this.values, this._layers));
         }
 
-        result = Property.replaceSubstitutionsIn(template, _.concat(this.values, this._layers));
-
-        return isString ? result[0] : result;
+        return template;
     },
 
     /**

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -319,8 +319,8 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
     /**
      * Replace all variable names with their values in the given template.
      *
-     * @param {string|object} template - A string or an object to replace variables in
-     * @returns {string|object} The string or object with variables (if any) substituted with their values
+     * @param {String|Object} template - A string or an object to replace variables in
+     * @returns {String|Object} The string or object with variables (if any) substituted with their values
      */
     replaceIn: function (template) {
         if (_.isString(template) || _.isArray(template)) {

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -317,23 +317,26 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
     },
 
     /**
-     * Replace all variable names with their values in the given string or object
+     * Replace all variable names with their values in the given template.
      *
-     * @param {string|object} obj A string or an object to replace variables in
+     * @param {string|object} template - A string or an object to replace variables in
      * @returns {string|object} The string or object with variables (if any) substituted with their values
      */
-    replaceIn: function (obj) {
-        var transformed,
+    replaceIn: function (template) {
+        var isString = typeof template === 'string',
             result;
 
-        if (typeof obj !== 'object') {
-            obj = [obj];
-            transformed = true;
+        if (isString) {
+            template = [template];
         }
 
-        result = Property.replaceSubstitutionsIn(obj, _.concat(this.values, this._layers));
+        if (typeof template !== 'object') {
+            return template;
+        }
 
-        return transformed ? result[0] : result;
+        result = Property.replaceSubstitutionsIn(template, _.concat(this.values, this._layers));
+
+        return isString ? result[0] : result;
     },
 
     /**

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -645,8 +645,6 @@ describe('VariableScope', function () {
                 expect(scope.replaceIn(undefined)).to.equal(undefined);
                 expect(scope.replaceIn(true)).to.equal(true);
                 expect(scope.replaceIn({})).to.eql({});
-                expect(scope.replaceIn('`console.error()`')).to.equal('`console.error()`');
-
             });
 
             it('should work with no variables ', function () {

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -747,32 +747,21 @@ describe('VariableScope', function () {
 
             it('should be able to resolve variables deeply', function () {
                 var scope = new VariableScope({
-                        values: [{
-                            key: 'var1',
-                            value: 'var2'
-                        }, {
-                            key: 'var2',
-                            value: 'var1'
-                        }, {
-                            key: 'var1var2',
-                            value: 'var3'
-                        }]
-                    }),
-                    tests = [
-                        ['{{var1}}', 'var2'],
-                        ['{var1}}', '{var1}}'],
-                        ['{{var1}', '{{var1}'],
-                        ['{{{{var1}}', '{{var2'],
-                        ['{{ {{var1}} }}', '{{ var2 }}'],
-                        ['{}{{var1}}}{{}{}}}{{var2}}}{}', '{}var2}{{}{}}}var1}{}'],
-                        ['{{{{var2}}{{var1}}}}', 'var3']
-                    ],
-                    i,
-                    len = tests.length;
+                    values: [{
+                        key: 'var1',
+                        value: 'var2'
+                    }, {
+                        key: 'var2',
+                        value: 'var3'
+                    }, {
+                        key: 'var3',
+                        value: 'value'
+                    }]
+                });
 
-                for (i = 0; i < len; i++) {
-                    expect(scope.replaceIn(tests[i][0])).to.equal(tests[i][1]);
-                }
+                expect(scope.replaceIn('{{var1}}')).to.equal('var2');
+                expect(scope.replaceIn('{{{{var1}}}}')).to.equal('var3');
+                expect(scope.replaceIn('{{{{{{var1}}}}}}')).to.equal('value');
             });
 
             it('should handle layers priority', function () {

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -633,25 +633,25 @@ describe('VariableScope', function () {
         });
 
         describe('replaceIn', function () {
-            var scope = new VariableScope({
-                values: [{
-                    key: 'name',
-                    value: 'Cooper'
-                }, {
-                    key: 'job',
-                    value: 'Postman'
-                }, {
-                    key: 'nothing',
-                    value: 'disabled value',
-                    disabled: true
-                }]
-            });
+            var layer1 = new VariableList({}, [{ key: 'name', value: 'Cooper' }]),
+                layer2 = new VariableList({}, [{ key: 'job', value: 'Postman' }]),
+                scope = new VariableScope({
+                    values: [{
+                        key: 'place',
+                        value: 'Bangalore'
+                    }, {
+                        key: 'nothing',
+                        value: 'disabled value',
+                        disabled: true
+                    }]
+                }, [layer1, layer2]);
 
             it('should resolve all variables in object', function () {
-                var obj = { name: '{{name}}', job: '{{job}}' };
+                var obj = { name: '{{name}}', job: '{{job}}', place: '{{place}}' };
                 expect(scope.replaceIn(obj)).to.eql({
                     name: 'Cooper',
-                    job: 'Postman'
+                    job: 'Postman',
+                    place: 'Bangalore'
                 });
             });
 

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -631,6 +631,40 @@ describe('VariableScope', function () {
                 expect(scope.values.count()).to.equal(0);
             });
         });
+
+        describe('replaceIn', function () {
+            var scope = new VariableScope({
+                values: [{
+                    key: 'name',
+                    value: 'Cooper'
+                }, {
+                    key: 'job',
+                    value: 'Postman'
+                }, {
+                    key: 'nothing',
+                    value: 'disabled value',
+                    disabled: true
+                }]
+            });
+
+            it('should resolve all variables in object', function () {
+                var obj = { name: '{{name}}', job: '{{job}}' };
+                expect(scope.replaceIn(obj)).to.eql({
+                    name: 'Cooper',
+                    job: 'Postman'
+                });
+            });
+
+            it('should resolve all variables in string', function () {
+                expect(scope.replaceIn('I am {{name}} and I work at {{job}}'))
+                    .to.equal('I am Cooper and I work at Postman');
+            });
+
+            it('should not resolve disabled variables', function () {
+                expect(scope.replaceIn('I am {{name}} and I work at {{nothing}}'))
+                    .to.equal('I am Cooper and I work at {{nothing}}');
+            });
+        });
     });
 
     describe('isVariableScope', function () {


### PR DESCRIPTION
Ref: https://github.com/postmanlabs/postman-app-support/issues/2922

TODO:
- [x] Fix `[]` converting to `{}` and `['{{var}}']` to `{ 0: 'value' }`.