### PR TITLE
Handle malformed cookie value

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  fixed bugs:
+    - GH-938 Fixed a bug where malformed cookie value throws URIError
+
 3.5.2:
   date: 2019-09-04
   new features:

--- a/lib/collection/cookie.js
+++ b/lib/collection/cookie.js
@@ -218,7 +218,16 @@ _.assign(Cookie.prototype, /** @lends Cookie.prototype */ {
      * @return {String}
      */
     valueOf: function () {
-        return decodeURIComponent(this.value);
+        // @todo: benchmark this (try-catch) v/s other decode-uri-component
+        // modules or maybe add helper in postman-url-encoder.
+        try {
+            return decodeURIComponent(this.value);
+        }
+        // handle malformed URI sequence
+        // refer: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Malformed_URI
+        catch (error) {
+            return this.value;
+        }
     },
 
     /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -58,8 +58,15 @@ _.mixin(/** @lends util */ {
      * @returns {string}
      */
     ensureEncoded: function (string) {
-        // Takes care of the case where the string is already encoded.
-        return encodeURIComponent(decodeURIComponent(string));
+        try {
+            // Takes care of the case where the string is already encoded.
+            return encodeURIComponent(decodeURIComponent(string));
+        }
+        // handle malformed URI sequence
+        // refer: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Malformed_URI
+        catch (error) {
+            return string;
+        }
     },
 
     /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -58,9 +58,16 @@ _.mixin(/** @lends util */ {
      * @returns {string}
      */
     ensureEncoded: function (string) {
+        // Takes care of the case where the string is already encoded.
         try {
-            // Takes care of the case where the string is already encoded.
-            return encodeURIComponent(decodeURIComponent(string));
+            string = decodeURIComponent(string);
+        }
+        catch (e) {} // eslint-disable-line no-empty
+
+        // @todo: avoid using try-catch and instead add encode-decode helper
+        // in postman-url-encoder.
+        try {
+            return encodeURIComponent(string);
         }
         // handle malformed URI sequence
         // refer: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Malformed_URI

--- a/test/unit/cookie.test.js
+++ b/test/unit/cookie.test.js
@@ -41,7 +41,7 @@ describe('Cookie', function () {
 
             expect(strCookie).to.deep.include({
                 name: 'foo',
-                value: '%E0%A4%A'
+                value: '%25E0%25A4%25A'
             });
             expect(strCookie.valueOf()).to.equal('%E0%A4%A');
         });

--- a/test/unit/cookie.test.js
+++ b/test/unit/cookie.test.js
@@ -36,6 +36,16 @@ describe('Cookie', function () {
             expect(strCookie.expires).to.be.ok;
         });
 
+        it('should handle malformed values', function () {
+            var strCookie = new Cookie('foo=%E0%A4%A');
+
+            expect(strCookie).to.deep.include({
+                name: 'foo',
+                value: '%E0%A4%A'
+            });
+            expect(strCookie.valueOf()).to.equal('%E0%A4%A');
+        });
+
         describe('has property', function () {
             it('domain', function () {
                 expect(cookie).to.have.property('domain', rawCookie.domain);

--- a/test/unit/util.test.js
+++ b/test/unit/util.test.js
@@ -43,6 +43,24 @@ describe('SDK Utils', function () {
                 expect(util.lodash.randomString()).to.match(/^[A-z0-9]{6}$/);
             });
         });
+
+        describe('.ensureEncoded', function () {
+            it('should encode correctly', function () {
+                expect(util.lodash.ensureEncoded('hello world')).to.equal('hello%20world');
+            });
+
+            it('should not double encode', function () {
+                expect(util.lodash.ensureEncoded('hello%20world')).to.equal('hello%20world');
+            });
+
+            it('should handle malformed URI sequence on decode', function () {
+                expect(util.lodash.ensureEncoded('%E0%A4%A')).to.equal('%25E0%25A4%25A');
+            });
+
+            it('should handle malformed URI sequence on encode', function () {
+                expect(util.lodash.ensureEncoded('\uD800')).to.equal('\uD800');
+            });
+        });
     });
 
     describe('.btoa', function () {


### PR DESCRIPTION
Handle [URIError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Malformed_URI) on decoding malformed cookie value.

Refer: https://github.com/postmanlabs/postman-app-support/issues/7268

**Discovered via** https://github.com/postmanlabs/postman-runtime/commit/e7c40eeaa37649a1cd8000b23548ed96435597e7.
Previously we used to emit POJO Cookie object instead of PostmanCookie instance in `response` callback of runtime.
Since https://github.com/postmanlabs/postman-runtime/pull/865, we construct a PostmanCookie List.