### PR TITLE
Handle protocol separated using `:\\` while parsing URL

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -4,6 +4,7 @@ master:
   fixed bugs:
     - GH-983 Handle query params with empty key or value on unparseSingle
     - GH-984 Fixed a bug where empty port, auth, etc. are dropped on url.toString
+    - GH-991 Handle protocol separated using `:\\` while parsing URL
   chores:
     - GH-961 Added `nyc` and `codecov` for code coverage checks
     - Updated dependencies

--- a/lib/url-parse.js
+++ b/lib/url-parse.js
@@ -9,6 +9,7 @@ const REGEX_EXTRACT_VARS = /{{[^{}]*[.:/?#@&\]][^{}]*}}/g,
     PROTOCOL_SEPARATOR = '://',
     AUTH_SEGMENTS_SEPARATOR = ':',
     QUERY_SEGMENTS_SEPARATOR = '&',
+    PROTOCOL_SEPARATOR_WITH_BACKSLASH = ':\\\\',
 
     STRING = 'string',
     SAFE_REPLACE_CHAR = '_',
@@ -311,6 +312,17 @@ function parse (urlString) {
 
     // 3. url.protocol
     if ((index = urlString.indexOf(PROTOCOL_SEPARATOR)) !== -1) {
+        // extract from the front
+        url.protocol.value = urlString.slice(0, index);
+        url.protocol.beginIndex = pointer;
+        url.protocol.endIndex = pointer + index;
+
+        urlString = urlString.slice(index + 3);
+        length -= index + 3;
+        pointer += index + 3;
+    }
+    // protocol can be separated using :\\ as well
+    else if ((index = urlString.indexOf(PROTOCOL_SEPARATOR_WITH_BACKSLASH)) !== -1) {
         // extract from the front
         url.protocol.value = urlString.slice(0, index);
         url.protocol.beginIndex = pointer;

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -720,6 +720,15 @@ describe('Url', function () {
                 }
             });
         });
+
+        it('should handle handle protocol with backslashes', function () {
+            var subject = Url.parse('http:\\\\localhost');
+            expect(subject).to.deep.include({
+                raw: 'http:\\\\localhost',
+                protocol: 'http',
+                host: ['localhost']
+            });
+        });
     });
 
     describe('unparsing', function () {
@@ -1051,6 +1060,11 @@ describe('Url', function () {
 
         it('should replace \\ in pathname with /', function () {
             var url = 'http://localhost\\foo\\bar';
+            expect((new Url(url)).toString()).to.equal('http://localhost/foo/bar');
+        });
+
+        it('should replace \\ in protocol with /', function () {
+            var url = 'http:\\\\localhost/foo\\bar';
             expect((new Url(url)).toString()).to.equal('http://localhost/foo/bar');
         });
 


### PR DESCRIPTION
Handle URLs where the protocol is separated using `:\\`. e.g, `http:\\localhost`.