### PR TITLE
Handle `&`, `=` and `#` in query params on unparseSingle

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -5,7 +5,7 @@ master:
     - GH-983 Handle query params with empty key or value on unparseSingle
     - GH-984 Fixed a bug where empty port, auth, etc. are dropped on url.toString
     - GH-991 Handle protocol separated using `:\\` while parsing URL
-    - GH-994 Handle `&` and `#` in query params on `QueryParam~unparseSingle`
+    - GH-994 Handle `&`, `=` and `#` in query params on `QueryParam~unparseSingle`
   chores:
     - GH-961 Added `nyc` and `codecov` for code coverage checks
     - Updated dependencies

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -5,6 +5,7 @@ master:
     - GH-983 Handle query params with empty key or value on unparseSingle
     - GH-984 Fixed a bug where empty port, auth, etc. are dropped on url.toString
     - GH-991 Handle protocol separated using `:\\` while parsing URL
+    - GH-994 Handle `&` and `#` in query params on `QueryParam~unparseSingle`
   chores:
     - GH-961 Added `nyc` and `codecov` for code coverage checks
     - Updated dependencies

--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -11,12 +11,83 @@ var _ = require('../util').lodash,
     STRING = 'string',
     EQUALS = '=',
     EMPTY = '',
+    HASH = '#',
     BRACE_START = '{{',
     BRACE_END = '}}',
+    REGEX_HASH = /#/g,
+    REGEX_AMPERSAND = /&/g,
     REGEX_BRACE_START = /%7B%7B/g,
     REGEX_BRACE_END = /%7D%7D/g,
+    REGEX_EXTRACT_VARS = /{{[^{}]*[&#][^{}]*}}/g,
 
-    QueryParam;
+    QueryParam,
+
+    /**
+     * Percent encode reserved chars (& and #) in the given string.
+     *
+     * @private
+     * @param {String} str
+     * @returns {String}
+     */
+    encodeReservedChars = function (str) {
+        if (!str) {
+            return str;
+        }
+
+        // eslint-disable-next-line lodash/prefer-includes
+        str.indexOf(AMPERSAND) !== -1 && (str = str.replace(REGEX_AMPERSAND, '%26'));
+
+        // eslint-disable-next-line lodash/prefer-includes
+        str.indexOf(HASH) !== -1 && (str = str.replace(REGEX_HASH, '%23'));
+
+        return str;
+    },
+
+    /**
+     * Normalize the given param string by percent-encoding the reserved chars
+     * such that it won't affect the re-parsing.
+     *
+     * @private
+     * @param {String} str
+     * @returns {String}
+     */
+    normalizeParam = function (str) {
+        // bail out if the given sting is null or empty
+        if (!(str && typeof str === STRING)) {
+            return str;
+        }
+
+        // bail out if the given string does not include reserved chars
+        // eslint-disable-next-line lodash/prefer-includes
+        if (str.indexOf(AMPERSAND) === -1 && str.indexOf(HASH) === -1) {
+            return str;
+        }
+
+        var normalizedString = '',
+            pointer = 0,
+            variable,
+            match,
+            index;
+
+        // find all the instances of {{<variable>}} which includes reserved chars
+        while ((match = REGEX_EXTRACT_VARS.exec(str)) !== null) {
+            variable = match[0];
+            index = match.index;
+
+            // [pointer, index) string is normalized + the matched variable
+            normalizedString += encodeReservedChars(str.slice(pointer, index)) + variable;
+
+            // update the pointer
+            pointer = index + variable.length;
+        }
+
+        // whatever left in the string is normalized as well
+        if (pointer < str.length) {
+            normalizedString += encodeReservedChars(str.slice(pointer));
+        }
+
+        return normalizedString;
+    };
 
 /**
  * @typedef QueryParam~definition
@@ -217,7 +288,9 @@ _.assign(QueryParam, /** @lends QueryParam */ {
             result += EQUALS + (encode ? encodeQueryParam(value) : value);
         }
 
-        return result;
+        // @note `&` and `#` needs to be percent-encoded otherwise re-parsing
+        // the same URL string will generate different output
+        return normalizeParam(result);
     }
 });
 

--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -15,21 +15,23 @@ var _ = require('../util').lodash,
     BRACE_START = '{{',
     BRACE_END = '}}',
     REGEX_HASH = /#/g,
+    REGEX_EQUALS = /=/g, // eslint-disable-line no-div-regex
     REGEX_AMPERSAND = /&/g,
     REGEX_BRACE_START = /%7B%7B/g,
     REGEX_BRACE_END = /%7D%7D/g,
-    REGEX_EXTRACT_VARS = /{{[^{}]*[&#][^{}]*}}/g,
+    REGEX_EXTRACT_VARS = /{{[^{}]*[&#=][^{}]*}}/g,
 
     QueryParam,
 
     /**
-     * Percent encode reserved chars (& and #) in the given string.
+     * Percent encode reserved chars (&, = and #) in the given string.
      *
      * @private
      * @param {String} str
+     * @param {Boolean} encodeEquals
      * @returns {String}
      */
-    encodeReservedChars = function (str) {
+    encodeReservedChars = function (str, encodeEquals) {
         if (!str) {
             return str;
         }
@@ -40,6 +42,9 @@ var _ = require('../util').lodash,
         // eslint-disable-next-line lodash/prefer-includes
         str.indexOf(HASH) !== -1 && (str = str.replace(REGEX_HASH, '%23'));
 
+        // eslint-disable-next-line lodash/prefer-includes
+        encodeEquals && str.indexOf(EQUALS) !== -1 && (str = str.replace(REGEX_EQUALS, '%3D'));
+
         return str;
     },
 
@@ -47,11 +52,15 @@ var _ = require('../util').lodash,
      * Normalize the given param string by percent-encoding the reserved chars
      * such that it won't affect the re-parsing.
      *
+     * @note `&`, `=` and `#` needs to be percent-encoded otherwise re-parsing
+     * the same URL string will generate different output
+     *
      * @private
      * @param {String} str
+     * @param {Boolean} encodeEquals
      * @returns {String}
      */
-    normalizeParam = function (str) {
+    normalizeParam = function (str, encodeEquals) {
         // bail out if the given sting is null or empty
         if (!(str && typeof str === STRING)) {
             return str;
@@ -60,7 +69,10 @@ var _ = require('../util').lodash,
         // bail out if the given string does not include reserved chars
         // eslint-disable-next-line lodash/prefer-includes
         if (str.indexOf(AMPERSAND) === -1 && str.indexOf(HASH) === -1) {
-            return str;
+            // eslint-disable-next-line lodash/prefer-includes
+            if (!(encodeEquals && str.indexOf(EQUALS) !== -1)) {
+                return str;
+            }
         }
 
         var normalizedString = '',
@@ -75,7 +87,7 @@ var _ = require('../util').lodash,
             index = match.index;
 
             // [pointer, index) string is normalized + the matched variable
-            normalizedString += encodeReservedChars(str.slice(pointer, index)) + variable;
+            normalizedString += encodeReservedChars(str.slice(pointer, index), encodeEquals) + variable;
 
             // update the pointer
             pointer = index + variable.length;
@@ -83,7 +95,7 @@ var _ = require('../util').lodash,
 
         // whatever left in the string is normalized as well
         if (pointer < str.length) {
-            normalizedString += encodeReservedChars(str.slice(pointer));
+            normalizedString += encodeReservedChars(str.slice(pointer), encodeEquals);
         }
 
         return normalizedString;
@@ -278,19 +290,17 @@ _.assign(QueryParam, /** @lends QueryParam */ {
             result;
 
         if (typeof key === STRING) {
-            result = encode ? encodeQueryParam(key) : key;
+            result = encode ? encodeQueryParam(key) : normalizeParam(key, true);
         }
         else {
             result = E;
         }
 
         if (typeof value === STRING) {
-            result += EQUALS + (encode ? encodeQueryParam(value) : value);
+            result += EQUALS + (encode ? encodeQueryParam(value) : normalizeParam(value));
         }
 
-        // @note `&` and `#` needs to be percent-encoded otherwise re-parsing
-        // the same URL string will generate different output
-        return normalizeParam(result);
+        return result;
     }
 });
 

--- a/test/unit/query-param.test.js
+++ b/test/unit/query-param.test.js
@@ -138,6 +138,19 @@ describe('QueryParam', function () {
                 expect(QueryParam.unparseSingle({ key: null, value: ' ' }, true)).to.equal('=%20');
                 expect(QueryParam.unparseSingle({ value: '("foo")' }, true)).to.equal('=(%22foo%22)');
             });
+
+            it('should always encode `&` and `#` present in key or value', function () {
+                expect(QueryParam.unparseSingle({ key: null, value: '& #' })).to.equal('=%26 %23');
+                expect(QueryParam.unparseSingle({ key: '"#&#"' })).to.equal('"%23%26%23"');
+            });
+
+            it('should not encode `&` and `#` present in variable names', function () {
+                expect(QueryParam.unparseSingle({ key: '#{{#&#}}#', value: '{{&}}' }))
+                    .to.equal('%23{{#&#}}%23={{&}}');
+
+                expect(QueryParam.unparseSingle({ key: '{{&}} {{#}}', value: ' {{&}} ' }))
+                    .to.equal('{{&}} {{#}}= {{&}} ');
+            });
         });
     });
 
@@ -157,17 +170,17 @@ describe('QueryParam', function () {
     });
 
     it('should not url encode by default', function () {
-        var rawQueryString = 'x=y#z',
+        var rawQueryString = 'x=foo bar',
             params = QueryParam.parse(rawQueryString),
             paramStr = QueryParam.unparse(params);
         expect(paramStr).to.eql(rawQueryString);
     });
 
     it('should url encode if explicitly asked to', function () {
-        var rawQueryString = 'x=y#z',
+        var rawQueryString = 'x=foo bar',
             params = QueryParam.parse(rawQueryString),
             paramStr = QueryParam.unparse(params, { encode: true });
-        expect(paramStr).to.eql('x=y%23z');
+        expect(paramStr).to.eql('x=foo%20bar');
     });
 
     it('should be able to unparse when values are given as an object', function () {

--- a/test/unit/query-param.test.js
+++ b/test/unit/query-param.test.js
@@ -151,6 +151,16 @@ describe('QueryParam', function () {
                 expect(QueryParam.unparseSingle({ key: '{{&}} {{#}}', value: ' {{&}} ' }))
                     .to.equal('{{&}} {{#}}= {{&}} ');
             });
+
+            it('should always encode `=` present in param key', function () {
+                expect(QueryParam.unparseSingle({ key: '={{=}}=', value: '{{===}}' })).to.equal('%3D{{=}}%3D={{===}}');
+                expect(QueryParam.unparseSingle({ key: '={{&=#}}' })).to.equal('%3D{{&=#}}');
+            });
+
+            it('should not encode `=` present in param value', function () {
+                expect(QueryParam.unparseSingle({ key: '{{===}}', value: '={{=}}=' })).to.equal('{{===}}=={{=}}=');
+                expect(QueryParam.unparseSingle({ value: '={{&=#}}=' })).to.equal('=={{&=#}}=');
+            });
         });
     });
 

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -1005,6 +1005,17 @@ describe('Url', function () {
             expect(url.toString()).to.eql('https://postman-echo.com');
         });
 
+        it('should encode & and # in query parameters', function () {
+            var url = new Url({
+                host: 'https://postman-echo.com',
+                query: [{
+                    key: '#foo#',
+                    value: 'bar & {{&baz&}}'
+                }]
+            });
+            expect(url.toString()).to.eql('https://postman-echo.com?%23foo%23=bar %26 {{&baz&}}');
+        });
+
         it('should handle bare ipv4 addresses with variables', function () {
             var url = '127.0.{{subnet}}.1';
             expect((new Url(url)).toString()).to.equal(url);

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -1005,15 +1005,15 @@ describe('Url', function () {
             expect(url.toString()).to.eql('https://postman-echo.com');
         });
 
-        it('should encode & and # in query parameters', function () {
+        it('should encode &, = and # in query parameters', function () {
             var url = new Url({
                 host: 'https://postman-echo.com',
                 query: [{
-                    key: '#foo#',
-                    value: 'bar & {{&baz&}}'
+                    key: '#foo=',
+                    value: 'bar =&= {{&baz=}}'
                 }]
             });
-            expect(url.toString()).to.eql('https://postman-echo.com?%23foo%23=bar %26 {{&baz&}}');
+            expect(url.toString()).to.eql('https://postman-echo.com?%23foo%3D=bar =%26= {{&baz=}}');
         });
 
         it('should handle bare ipv4 addresses with variables', function () {


### PR DESCRIPTION
`&`, `=` and `#` needs to be percent-encoded otherwise re-parsing the same URL string will generate different outputs.

Note:
- `&`, `=` and `#` present in variable names will not be encoded.
- `=` needs to be encoded only for param keys