### PR TITLE
Update variable description on upsert

### DIFF
--- a/lib/collection/variable.js
+++ b/lib/collection/variable.js
@@ -1,10 +1,12 @@
 var _ = require('../util').lodash,
     Property = require('./property').Property,
+    Description = require('./description').Description,
 
     E = '',
     ANY = 'any',
     NULL = 'null',
     STRING = 'string',
+    DESCRIPTION = 'description',
 
     Variable;
 
@@ -191,10 +193,11 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
         if (!_.isObject(options)) {
             return;
         }
-        // set type and value.
+        // set type, value and description.
         // @note that we cannot update the key, once created during construction
         options.hasOwnProperty('type') && this.valueType(options.type, options.hasOwnProperty('value'));
         options.hasOwnProperty('value') && this.set(options.value);
+        options.hasOwnProperty('description') && (this.description = _.createDefined(options, DESCRIPTION, Description, this.description));
         options.hasOwnProperty('system') && (this.system = options.system);
         options.hasOwnProperty('disabled') && (this.disabled = options.disabled);
     }


### PR DESCRIPTION
Fixes #740 
### Issue
Variable description is not updating on upsert.
```
const list = new VariableList(null, [{
    key: 'k1',
    value: 'initial',
    description: 'initial description'
}]);

list.upsert({
    key: 'k1',
    value: 'updated',
    description: 'updated description'
});

list.toJSON();
// [{
//     description: {
//         content: 'initial description',
//         type: 'text/plain'
//     },
//     type: 'any',
//     value: 'updated',
//     key: 'k1'
// }]
```
### Fix
Update description also on variable upsert. 

### Validation
Changes validated locally.