### PR TITLE
Avoid mutating parents `protocolProfileBehavior` on resolution

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+master:
+  fixed bugs:
+    - >-
+      GH-1025 Fixed a bug where `Item.getProtocolProfileBehavior()` mutates
+      the `protocolProfileBehavior` of all its parents
+
 3.6.0:
   date: 2020-03-02
   new features:

--- a/lib/collection/item.js
+++ b/lib/collection/item.js
@@ -223,7 +223,11 @@ _.assign(Item.prototype, /** @lends Item.prototype */ {
 
         // inherit protocolProfileBehavior from ItemGroup(s)
         this.forEachParent({ withRoot: true }, function (entity) {
-            protocolProfileBehavior = Object.assign(extractProtocolProfileBehavior(entity), protocolProfileBehavior);
+            protocolProfileBehavior = Object.assign(
+                {},
+                extractProtocolProfileBehavior(entity),
+                protocolProfileBehavior
+            );
         });
 
         return protocolProfileBehavior;

--- a/test/unit/item.test.js
+++ b/test/unit/item.test.js
@@ -523,5 +523,28 @@ describe('Item', function () {
                 key: 'new-value'
             });
         });
+
+        // Refer: https://github.com/postmanlabs/postman-app-support/issues/8293
+        it('should not mutate the parent scope', function () {
+            var itemGroup = new sdk.ItemGroup({
+                    protocolProfileBehavior: { k0: 'v0' },
+                    item: [{
+                        name: 'I1',
+                        protocolProfileBehavior: { k1: 'v1' }
+                    }, {
+                        name: 'I2',
+                        protocolProfileBehavior: { k2: 'v2' }
+                    }, {
+                        name: 'I3',
+                        protocolProfileBehavior: { k3: 'v3' }
+                    }]
+                }),
+                items = itemGroup.items.members;
+
+            expect(items[0].getProtocolProfileBehaviorResolved()).to.eql({ k0: 'v0', k1: 'v1' });
+            expect(items[1].getProtocolProfileBehaviorResolved()).to.eql({ k0: 'v0', k2: 'v2' });
+            expect(items[2].getProtocolProfileBehaviorResolved()).to.eql({ k0: 'v0', k3: 'v3' });
+            expect(itemGroup.getProtocolProfileBehaviorResolved()).to.eql({ k0: 'v0' });
+        });
     });
 });


### PR DESCRIPTION
Fixed a bug where `Item.getProtocolProfileBehavior()` mutates the `protocolProfileBehavior` of all its parents.

Refer: https://github.com/postmanlabs/postman-app-support/issues/8293