### PR TITLE
Add $isoTimestamp to dynamic variables

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+master:
+  new features:
+    - GH-1060 Added $isoTimestamp to the dynamic variable list
+
 3.6.2:
   date: 2020-06-04
   fixed bugs:

--- a/lib/superstring/dynamic-variables.js
+++ b/lib/superstring/dynamic-variables.js
@@ -91,6 +91,13 @@ var faker = require('faker/locale/en'),
             }
         },
 
+        $isoTimestamp: {
+            description: 'The current ISO timestamp at zero UTC',
+            generator: function () {
+                return new Date().toISOString();
+            }
+        },
+
         $randomInt: {
             description: 'A random integer between 1 and 1000',
             generator: function () {

--- a/test/unit/dynamic-variables.test.js
+++ b/test/unit/dynamic-variables.test.js
@@ -33,6 +33,17 @@ describe('Dynamic variable', function () {
             expect(dynamicVariables.$timestamp.generator()).to.be.a('number');
         });
 
+        it('$isoTimestamp returns a timestamp in ISO format', function () {
+            var isoTimestamp = dynamicVariables.$isoTimestamp.generator(),
+                // eslint-disable-next-line security/detect-non-literal-regexp
+                regex = new RegExp('^(-?(?:[1-9][0-9]*)?[0-9]{4})' + // match year
+                    '-(1[0-2]|0[1-9])-(3[01]|0[1-9]|[12][0-9])' + // match month and day
+                    'T(2[0-3]|[01][0-9]):([0-5][0-9]):([0-5][0-9])(\\.[0-9]+)?(Z)?$'); // match time
+
+            expect(isoTimestamp).to.be.a('string');
+            expect(isoTimestamp).to.match(regex);
+        });
+
         it('$guid should return a valid uuid', function () {
             expect(dynamicVariables.$guid.generator())
                 .to.match(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);


### PR DESCRIPTION
Many APIs need timestamps to be send with the request and using ISO format is common to use. Currently, the dynamic variable only has `$timestamp` variable which provides the number of milliseconds since epoch.
Adding `$isoTimestamp` will provide the timestamp in ISO format at zero UTC.

Name: $isoTimestamp
Description: _The current ISO timestamp at zero UTC_