### PR TITLE
Checking whether key is callable or not

### DIFF
--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -132,7 +132,7 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
             // if multiple values are allowed, the reference may contain an array of items, mapped to an index.
             if (this._postman_listAllowsMultipleValues && Object.hasOwnProperty.call(this.reference, index)) {
 
-                // if the value is not an array, convert it to an array.
+                // if the value is not an array, convert it to an array
                 !_.isArray(this.reference[index]) && (this.reference[index] = [this.reference[index]]);
 
                 // add the item to the array of items corresponding to this index

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -130,7 +130,9 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
             this._postman_listIndexCaseInsensitive && (index = index.toLowerCase());
 
             // if multiple values are allowed, the reference may contain an array of items, mapped to an index.
-            if (this._postman_listAllowsMultipleValues && this.reference.hasOwnProperty(index)) {
+            if (this._postman_listAllowsMultipleValues &&
+                _.isFunction(this.reference.hasOwnProperty) ?
+                this.reference.hasOwnProperty(index) : this.reference.index !== undefined) {
 
                 // if the value is not an array, convert it to an array.
                 !_.isArray(this.reference[index]) && (this.reference[index] = [this.reference[index]]);

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -132,7 +132,7 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
             // if multiple values are allowed, the reference may contain an array of items, mapped to an index.
             if (this._postman_listAllowsMultipleValues && Object.hasOwnProperty.call(this.reference, index)) {
 
-                // if the value is not an array, convert it to an array
+                // if the value is not an array, convert it to an array.
                 !_.isArray(this.reference[index]) && (this.reference[index] = [this.reference[index]]);
 
                 // add the item to the array of items corresponding to this index

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -130,7 +130,7 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
             this._postman_listIndexCaseInsensitive && (index = index.toLowerCase());
 
             // if multiple values are allowed, the reference may contain an array of items, mapped to an index.
-            if (this._postman_listAllowsMultipleValues && Object.hasOwnProperty.call(this.reference, index)) {
+            if (this._postman_listAllowsMultipleValues && this.reference.hasOwnProperty(index)) {
 
                 // if the value is not an array, convert it to an array
                 !_.isArray(this.reference[index]) && (this.reference[index] = [this.reference[index]]);

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -130,9 +130,7 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
             this._postman_listIndexCaseInsensitive && (index = index.toLowerCase());
 
             // if multiple values are allowed, the reference may contain an array of items, mapped to an index.
-            if (this._postman_listAllowsMultipleValues &&
-                _.isFunction(this.reference.hasOwnProperty) ?
-                this.reference.hasOwnProperty(index) : this.reference.index !== undefined) {
+            if (this._postman_listAllowsMultipleValues && this.reference.hasOwnProperty(index)) {
 
                 // if the value is not an array, convert it to an array.
                 !_.isArray(this.reference[index]) && (this.reference[index] = [this.reference[index]]);

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -130,7 +130,7 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
             this._postman_listIndexCaseInsensitive && (index = index.toLowerCase());
 
             // if multiple values are allowed, the reference may contain an array of items, mapped to an index.
-            if (this._postman_listAllowsMultipleValues && this.reference.hasOwnProperty(index)) {
+            if (this._postman_listAllowsMultipleValues && Object.hasOwnProperty.call(this.reference, index)) {
 
                 // if the value is not an array, convert it to an array.
                 !_.isArray(this.reference[index]) && (this.reference[index] = [this.reference[index]]);

--- a/lib/collection/property-list.js
+++ b/lib/collection/property-list.js
@@ -130,7 +130,7 @@ _.assign(PropertyList.prototype, /** @lends PropertyList.prototype */ {
             this._postman_listIndexCaseInsensitive && (index = index.toLowerCase());
 
             // if multiple values are allowed, the reference may contain an array of items, mapped to an index.
-            if (this._postman_listAllowsMultipleValues && this.reference.hasOwnProperty(index)) {
+            if (this._postman_listAllowsMultipleValues && Object.hasOwnProperty.call(this.reference, index)) {
 
                 // if the value is not an array, convert it to an array
                 !_.isArray(this.reference[index]) && (this.reference[index] = [this.reference[index]]);

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -876,7 +876,7 @@ describe('PropertyList', function () {
 
         // Refer: https://github.com/postmanlabs/postman-app-support/issues/8924
         it('should be able to insert hasOwnProperty as a key', function () {
-            var pList = new PropertyList(FakeType, {}, { key: 'hasOwnProperty', value: 'false' });
+            var pList = new PropertyList(FakeType, {}, { key: 'hasOwnProperty', value: '0' });
             pList.insert({ key: 'foo', value: 'bar' });
 
             expect(pList.members).to.eql([

--- a/test/unit/property-list.test.js
+++ b/test/unit/property-list.test.js
@@ -860,12 +860,31 @@ describe('PropertyList', function () {
     });
 
     describe('.insert', function () {
+        var FakeType = function (options) {
+            this.key = options.key;
+            this.value = options.value;
+        };
+        FakeType._postman_propertyIndexKey = 'key';
+        FakeType._postman_propertyAllowsMultipleValues = true;
+
         it('should bail out for non-object arguments', function () {
             var pList = new PropertyList();
 
             pList.insert();
             expect(pList.members).to.eql([]);
         });
+
+        // Refer: https://github.com/postmanlabs/postman-app-support/issues/8924
+        it('should be able to insert hasOwnProperty as a key', function () {
+            var pList = new PropertyList(FakeType, {}, { key: 'hasOwnProperty', value: 'false' });
+            pList.insert({ key: 'foo', value: 'bar' });
+
+            expect(pList.members).to.eql([
+                { key: 'hasOwnProperty', value: '0' },
+                { key: 'foo', value: 'bar' }
+            ]);
+        });
+
     });
 
     describe('.add', function () {

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -1327,6 +1327,16 @@ describe('Url', function () {
             ]);
         });
 
+        it('should correctly add hasOwnProperty query key to an existing Url instance', function () {
+            var url = new Url();
+            url.addQueryParams('hasOwnProperty=0&foo=bar');
+
+            expect(url.toJSON().query).to.eql([
+                { key: 'hasOwnProperty', value: '0' },
+                { key: 'foo', value: 'bar' }
+            ]);
+        });
+
         it('should correctly remove a list of query params from an existing Url instance', function () {
             var url = new Url('https://postman-echo.com/get?alpha=foo&beta=bar&gamma=baz');
 

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -1327,6 +1327,7 @@ describe('Url', function () {
             ]);
         });
 
+        // Refer: https://github.com/postmanlabs/postman-app-support/issues/8924
         it('should correctly add hasOwnProperty query key to an existing Url instance', function () {
             var url = new Url();
             url.addQueryParams('hasOwnProperty=0&foo=bar');


### PR DESCRIPTION
It is fix for this [issue](https://github.com/postmanlabs/postman-app-support/issues/8924) .

The issue was caused when we had query parameter key named "hasOwnProperty" which is already a defined key in any object whose value is a function that can be used to check whether a key exists or not.

When adding any query parameter, we also check whether multiple values are allowed for that query parameter key, if allowed than we look for that key using "hasOwnProperty" function and if found than push query parameter value, else we create query parameter key with value. 
But when we have "hasOwnProperty" as query parameter key and try to add that to PostmanPropertyList object, it overwrites that default function value, and then we can not further call "hasOwnProperty" to check for a key in an object.

Here, I have added a check to see if the key is callable, if it is callable, then return function call, else if key's value is not undefined then push value to existing key, else add new query parameter key.
![image](https://user-images.githubusercontent.com/44117648/90638206-aca25b00-e24a-11ea-8bfb-3adcfa0acde5.png)
