### PR TITLE
Fix "items" attribute in JSON Schema

### DIFF
--- a/lib/schema/certificate.json
+++ b/lib/schema/certificate.json
@@ -11,7 +11,7 @@
         "matches": {
             "description": "A list of Url match pattern strings, to identify Urls this certificate can be used for.",
             "type": "array",
-            "item": {
+            "items": {
               "type": "string",
               "description": "An Url match pattern string"
             }


### PR DESCRIPTION
In the [JSON Shema](https://json-schema.org/) specification, inside a schema with type `"array"`, the attribute is called `"items"` and not `"item"`.

See [array reference](https://json-schema.org/understanding-json-schema/reference/array.html) for JSON Schema draft 7.
I think postman is using the `draft-04` json schema, which reference documentation can be found here:
https://tools.ietf.org/html/draft-zyp-json-schema-04 (the `items` attribute did not change between the JSON Schema versions)

---

I hope this is the right place to propose the change. The wrong value can also be seen here:
http://schema.getpostman.com/collection/json/v2.1.0/draft-04/collection.json 