### PR TITLE
Fix for cookie extension issue.

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,5 +1,6 @@
 master:
   chores:
+    - GH-1104 Fixed cookie extensions not getting stringified properly. Fixed check for path and domain.
     - GH-1098 Added unit tests for cookie.js, header.js, request-auth.js, item.js, content-info.js.
 
 3.6.6:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,8 @@
 master:
   chores:
-    - GH-1104 Fixed cookie extensions not getting stringified properly. Fixed check for path and domain.
+    - >-
+      GH-1104 Fixed Cookie extensions not getting stringified properly.
+      Also added type checks for Cookie extensions, path and domain.
     - GH-1098 Added unit tests for cookie.js, header.js, request-auth.js, item.js, content-info.js.
 
 3.6.6:

--- a/lib/collection/cookie.js
+++ b/lib/collection/cookie.js
@@ -157,7 +157,7 @@ _.assign(Cookie.prototype, /** @lends Cookie.prototype */ {
              * host name that is sending the Set-Cookie header. The SDK does not perform this check, but the underlying
              * client that actually sends the request could do it automatically.
              */
-            domain: _.isString(options.domain) ? options.domain : undefined,
+            domain: options.domain,
 
             /**
              * @type {String}
@@ -165,7 +165,7 @@ _.assign(Cookie.prototype, /** @lends Cookie.prototype */ {
              * @note
              * On server, the default value for the path option is the path of the URL that sent the Set-Cookie header.
              */
-            path: _.isString(options.path) ? options.path : undefined,
+            path: options.path,
 
             /**
              * A secure cookie will only be sent to the server when a request is made using SSL and the HTTPS protocol.
@@ -208,7 +208,7 @@ _.assign(Cookie.prototype, /** @lends Cookie.prototype */ {
              * Any extra parameters that are not strictly a part of the Cookie spec go here.
              * @type {Array}
              */
-            extensions: _.isArray(options.extensions) ? options.extensions : undefined
+            extensions: options.extensions
         });
     },
 
@@ -269,9 +269,9 @@ _.assign(Cookie.prototype, /** @lends Cookie.prototype */ {
             str += '; HttpOnly';
         }
 
-        if (this.extensions) {
+        if (this.extensions && _.isArray(this.extensions)) {
             this.extensions.forEach(function (ext) {
-                if (!ext.key || !ext.value) {
+                if (_.isNil(ext.key) || _.isNil(ext.value)) {
                     return;
                 }
                 str += '; ' + ext.key + '=' + ext.value;

--- a/lib/collection/cookie.js
+++ b/lib/collection/cookie.js
@@ -157,7 +157,7 @@ _.assign(Cookie.prototype, /** @lends Cookie.prototype */ {
              * host name that is sending the Set-Cookie header. The SDK does not perform this check, but the underlying
              * client that actually sends the request could do it automatically.
              */
-            domain: options.domain,
+            domain: _.isString(options.domain) ? options.domain : undefined,
 
             /**
              * @type {String}
@@ -165,7 +165,7 @@ _.assign(Cookie.prototype, /** @lends Cookie.prototype */ {
              * @note
              * On server, the default value for the path option is the path of the URL that sent the Set-Cookie header.
              */
-            path: options.path,
+            path: _.isString(options.path) ? options.path : undefined,
 
             /**
              * A secure cookie will only be sent to the server when a request is made using SSL and the HTTPS protocol.
@@ -208,7 +208,7 @@ _.assign(Cookie.prototype, /** @lends Cookie.prototype */ {
              * Any extra parameters that are not strictly a part of the Cookie spec go here.
              * @type {Array}
              */
-            extensions: options.extensions || undefined
+            extensions: _.isArray(options.extensions) ? options.extensions : undefined
         });
     },
 
@@ -271,7 +271,10 @@ _.assign(Cookie.prototype, /** @lends Cookie.prototype */ {
 
         if (this.extensions) {
             this.extensions.forEach(function (ext) {
-                str += '; ' + ext;
+                if (!ext.key || !ext.value) {
+                    return;
+                }
+                str += '; ' + ext.key + '=' + ext.value;
             });
         }
 

--- a/lib/collection/cookie.js
+++ b/lib/collection/cookie.js
@@ -269,12 +269,14 @@ _.assign(Cookie.prototype, /** @lends Cookie.prototype */ {
             str += '; HttpOnly';
         }
 
-        if (this.extensions && _.isArray(this.extensions)) {
+        if (_.isArray(this.extensions)) {
             this.extensions.forEach(function (ext) {
-                if (_.isNil(ext.key) || _.isNil(ext.value)) {
+                if (_.isNil(ext.key)) {
                     return;
                 }
-                str += '; ' + ext.key + '=' + ext.value;
+
+                var value = (ext.value) ? ext.value : true;
+                str += '; ' + ext.key + '=' + value;
             });
         }
 

--- a/test/unit/cookie.test.js
+++ b/test/unit/cookie.test.js
@@ -85,17 +85,6 @@ describe('Cookie', function () {
             expect(cookie.toString()).to.equal('testCookie=testCookieVal');
         });
 
-        it('should not add path when path values set as json object', function () {
-            var cookie = new Cookie({
-                key: 'testCookie',
-                value: 'testCookieVal',
-                path: {}
-            });
-
-            expect(cookie.path).to.be.undefined;
-            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
-        });
-
         it('should not add path when path values set as null', function () {
             var cookie = new Cookie({
                 key: 'testCookie',
@@ -103,42 +92,18 @@ describe('Cookie', function () {
                 path: null
             });
 
-            expect(cookie.path).to.be.undefined;
+            expect(cookie.path).to.be.null;
             expect(cookie.toString()).to.equal('testCookie=testCookieVal');
         });
 
-        it('should not add path when path values set as array', function () {
-            var cookie = new Cookie({
-                key: 'testCookie',
-                value: 'testCookieVal',
-                path: []
-            });
-
-            expect(cookie.path).to.be.undefined;
-            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
-        });
-
-        it('should not add path when path values set as number', function () {
+        it('should add path when path values set as number', function () {
             var cookie = new Cookie({
                 key: 'testCookie',
                 value: 'testCookieVal',
                 path: 123
             });
 
-            expect(cookie.path).to.be.undefined;
-            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
-        });
-
-        it('should not add path when path values set as function', function () {
-            var cookie = new Cookie({
-                key: 'testCookie',
-                value: 'testCookieVal',
-                // eslint-disable-next-line no-empty-function
-                path: function () {}
-            });
-
-            expect(cookie.path).to.be.undefined;
-            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal; Path=123');
         });
 
         it('should set domain when domain values set as empty string', function () {
@@ -152,17 +117,6 @@ describe('Cookie', function () {
             expect(cookie.toString()).to.equal('testCookie=testCookieVal');
         });
 
-        it('should not add domain when domain values set as json object', function () {
-            var cookie = new Cookie({
-                key: 'testCookie',
-                value: 'testCookieVal',
-                domain: {}
-            });
-
-            expect(cookie.domain).to.be.undefined;
-            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
-        });
-
         it('should not add domain when domain values set as null', function () {
             var cookie = new Cookie({
                 key: 'testCookie',
@@ -170,42 +124,18 @@ describe('Cookie', function () {
                 domain: null
             });
 
-            expect(cookie.domain).to.be.undefined;
+            expect(cookie.domain).to.be.null;
             expect(cookie.toString()).to.equal('testCookie=testCookieVal');
         });
 
-        it('should not add domain when domain values set as array', function () {
-            var cookie = new Cookie({
-                key: 'testCookie',
-                value: 'testCookieVal',
-                domain: []
-            });
-
-            expect(cookie.domain).to.be.undefined;
-            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
-        });
-
-        it('should not add domain when domain values set as number', function () {
+        it('should add domain when domain values set as number', function () {
             var cookie = new Cookie({
                 key: 'testCookie',
                 value: 'testCookieVal',
                 domain: 123
             });
 
-            expect(cookie.domain).to.be.undefined;
-            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
-        });
-
-        it('should not add domain when domain values set as function', function () {
-            var cookie = new Cookie({
-                key: 'testCookie',
-                value: 'testCookieVal',
-                // eslint-disable-next-line no-empty-function
-                domain: function () {}
-            });
-
-            expect(cookie.domain).to.be.undefined;
-            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal; Domain=123');
         });
 
         describe('has property', function () {

--- a/test/unit/cookie.test.js
+++ b/test/unit/cookie.test.js
@@ -74,7 +74,7 @@ describe('Cookie', function () {
             expect(unparsedSingle).to.equal('testCookie=fooTest');
         });
 
-        it('should set path when path values set as empty string', function () {
+        it('should validate for set of invalid values for path param', function () {
             var cookie = new Cookie({
                 key: 'testCookie',
                 value: 'testCookieVal',
@@ -83,10 +83,8 @@ describe('Cookie', function () {
 
             expect(cookie.path).to.equal('');
             expect(cookie.toString()).to.equal('testCookie=testCookieVal');
-        });
 
-        it('should not add path when path values set as null', function () {
-            var cookie = new Cookie({
+            cookie = new Cookie({
                 key: 'testCookie',
                 value: 'testCookieVal',
                 path: null
@@ -94,10 +92,8 @@ describe('Cookie', function () {
 
             expect(cookie.path).to.be.null;
             expect(cookie.toString()).to.equal('testCookie=testCookieVal');
-        });
 
-        it('should add path when path values set as number', function () {
-            var cookie = new Cookie({
+            cookie = new Cookie({
                 key: 'testCookie',
                 value: 'testCookieVal',
                 path: 123
@@ -106,18 +102,7 @@ describe('Cookie', function () {
             expect(cookie.toString()).to.equal('testCookie=testCookieVal; Path=123');
         });
 
-        it('should set domain when domain values set as empty string', function () {
-            var cookie = new Cookie({
-                key: 'testCookie',
-                value: 'testCookieVal',
-                domain: ''
-            });
-
-            expect(cookie.domain).to.equal('');
-            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
-        });
-
-        it('should not add domain when domain values set as null', function () {
+        it('should validate for set of invalid values for domain param', function () {
             var cookie = new Cookie({
                 key: 'testCookie',
                 value: 'testCookieVal',
@@ -126,10 +111,17 @@ describe('Cookie', function () {
 
             expect(cookie.domain).to.be.null;
             expect(cookie.toString()).to.equal('testCookie=testCookieVal');
-        });
 
-        it('should add domain when domain values set as number', function () {
-            var cookie = new Cookie({
+            cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                domain: ''
+            });
+
+            expect(cookie.domain).to.equal('');
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+
+            cookie = new Cookie({
                 key: 'testCookie',
                 value: 'testCookieVal',
                 domain: 123
@@ -500,7 +492,7 @@ describe('Cookie', function () {
                 }]
             });
 
-            expect(cookie.toString()).to.equal('testCookie=testCookieVal; Max-Age=1502442248');
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal; Max-Age=1502442248; Priority=true');
         });
     });
 });

--- a/test/unit/cookie.test.js
+++ b/test/unit/cookie.test.js
@@ -74,6 +74,140 @@ describe('Cookie', function () {
             expect(unparsedSingle).to.equal('testCookie=fooTest');
         });
 
+        it('should set path when path values set as empty string', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                path: ''
+            });
+
+            expect(cookie.path).to.equal('');
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+        });
+
+        it('should not add path when path values set as json object', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                path: {}
+            });
+
+            expect(cookie.path).to.be.undefined;
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+        });
+
+        it('should not add path when path values set as null', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                path: null
+            });
+
+            expect(cookie.path).to.be.undefined;
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+        });
+
+        it('should not add path when path values set as array', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                path: []
+            });
+
+            expect(cookie.path).to.be.undefined;
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+        });
+
+        it('should not add path when path values set as number', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                path: 123
+            });
+
+            expect(cookie.path).to.be.undefined;
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+        });
+
+        it('should not add path when path values set as function', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                // eslint-disable-next-line no-empty-function
+                path: function () {}
+            });
+
+            expect(cookie.path).to.be.undefined;
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+        });
+
+        it('should set domain when domain values set as empty string', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                domain: ''
+            });
+
+            expect(cookie.domain).to.equal('');
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+        });
+
+        it('should not add domain when domain values set as json object', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                domain: {}
+            });
+
+            expect(cookie.domain).to.be.undefined;
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+        });
+
+        it('should not add domain when domain values set as null', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                domain: null
+            });
+
+            expect(cookie.domain).to.be.undefined;
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+        });
+
+        it('should not add domain when domain values set as array', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                domain: []
+            });
+
+            expect(cookie.domain).to.be.undefined;
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+        });
+
+        it('should not add domain when domain values set as number', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                domain: 123
+            });
+
+            expect(cookie.domain).to.be.undefined;
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+        });
+
+        it('should not add domain when domain values set as function', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                // eslint-disable-next-line no-empty-function
+                domain: function () {}
+            });
+
+            expect(cookie.domain).to.be.undefined;
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal');
+        });
+
         describe('has property', function () {
             it('domain', function () {
                 expect(cookie).to.have.property('domain', rawCookie.domain);
@@ -396,10 +530,24 @@ describe('Cookie', function () {
                 }]
             });
 
-            expect(cookie.toString()).equals('testCookie=testCookieVal; Max-Age=1502442248; Priority=HIGH');
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal; Max-Age=1502442248; Priority=HIGH');
         });
 
-        it('should return single Set-Cookie header string with invalid key extensions', function () {
+        it('should not add extension when extensions is not an array', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                maxAge: 1502442248,
+                extensions: {
+                    key: 'Priority',
+                    value: 'HIGH'
+                }
+            });
+
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal; Max-Age=1502442248');
+        });
+
+        it('should not add extension when extension key is not specified', function () {
             var cookie = new Cookie({
                 key: 'testCookie',
                 value: 'testCookieVal',
@@ -409,10 +557,10 @@ describe('Cookie', function () {
                 }]
             });
 
-            expect(cookie.toString()).equals('testCookie=testCookieVal; Max-Age=1502442248');
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal; Max-Age=1502442248');
         });
 
-        it('should return single Set-Cookie header string with invalid value extensions', function () {
+        it('should not add extension when extension value is not specified', function () {
             var cookie = new Cookie({
                 key: 'testCookie',
                 value: 'testCookieVal',
@@ -422,7 +570,7 @@ describe('Cookie', function () {
                 }]
             });
 
-            expect(cookie.toString()).equals('testCookie=testCookieVal; Max-Age=1502442248');
+            expect(cookie.toString()).to.equal('testCookie=testCookieVal; Max-Age=1502442248');
         });
     });
 });

--- a/test/unit/cookie.test.js
+++ b/test/unit/cookie.test.js
@@ -384,5 +384,45 @@ describe('Cookie', function () {
 
             expect(cookie.toString()).to.equals('foo=fooTest; Max-Age=1502442248');
         });
+
+        it('should return single Set-Cookie header string with extensions', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                maxAge: 1502442248,
+                extensions: [{
+                    key: 'Priority',
+                    value: 'HIGH'
+                }]
+            });
+
+            expect(cookie.toString()).equals('testCookie=testCookieVal; Max-Age=1502442248; Priority=HIGH');
+        });
+
+        it('should return single Set-Cookie header string with invalid key extensions', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                maxAge: 1502442248,
+                extensions: [{
+                    value: 'HIGH'
+                }]
+            });
+
+            expect(cookie.toString()).equals('testCookie=testCookieVal; Max-Age=1502442248');
+        });
+
+        it('should return single Set-Cookie header string with invalid value extensions', function () {
+            var cookie = new Cookie({
+                key: 'testCookie',
+                value: 'testCookieVal',
+                maxAge: 1502442248,
+                extensions: [{
+                    key: 'Priority'
+                }]
+            });
+
+            expect(cookie.toString()).equals('testCookie=testCookieVal; Max-Age=1502442248');
+        });
     });
 });


### PR DESCRIPTION
Issue: cookie extensions not getting stringified properly. Fixed check for `path` and `domain`.