### PR TITLE
Fix `toJSON()` of RequestBody

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -3,6 +3,9 @@ master:
     - >-
       GH-1097 Fixed an issue in cookie where, PropertyList should've been
       added as required module for cookie.js file.
+    - >-
+      GH-1105 Fixed a bug where `toJSON()` on RequestBody returns non-serializable
+      object having streams for bodies containing file
   chores:
     - GH-1098 Added unit tests for cookie.js, header.js, request-auth.js, item.js, content-info.js.
 

--- a/lib/collection/form-param.js
+++ b/lib/collection/form-param.js
@@ -1,5 +1,6 @@
 var _ = require('../util').lodash,
     Property = require('./property').Property,
+    PropertyBase = require('./property-base').PropertyBase,
 
     FormParam;
 
@@ -52,7 +53,7 @@ _.assign(FormParam.prototype, /** @lends FormParam.prototype */ {
      * @returns {Object}
      */
     toJSON: function () {
-        var obj = Property.prototype.toJSON.apply(this);
+        var obj = PropertyBase.toJSON(this);
 
         // remove value from file param because it is non-serializable ReadStream
         if (obj.type === 'file') {

--- a/lib/collection/form-param.js
+++ b/lib/collection/form-param.js
@@ -44,6 +44,22 @@ _.assign(FormParam.prototype, /** @lends FormParam.prototype */ {
      */
     valueOf: function () {
         return this.value; // can be multiple types, so just return whatever we have instead of being too clever
+    },
+
+    /**
+     * Convert the form-param to JSON compatible plain object.
+     *
+     * @returns {Object}
+     */
+    toJSON: function () {
+        var obj = Property.prototype.toJSON.apply(this);
+
+        // remove value from file param because it is non-serializable ReadStream
+        if (obj.type === 'file') {
+            _.unset(obj, 'value');
+        }
+
+        return obj;
     }
 });
 

--- a/lib/collection/request-body.js
+++ b/lib/collection/request-body.js
@@ -210,6 +210,20 @@ _.assign(RequestBody.prototype, /** @lends RequestBody.prototype */ {
         }
 
         return _.isEmpty(data); // catch all for remaining data modes
+    },
+
+    /**
+     * Convert the request body to JSON compatible plain object
+     *
+     * @returns {Object}
+     */
+    toJSON: function () {
+        var obj = PropertyBase.toJSON(this);
+
+        // make sure that file content is removed because it is non-serializable ReadStream
+        _.unset(obj, 'file.content');
+
+        return obj;
     }
 });
 

--- a/test/unit/form-param.test.js
+++ b/test/unit/form-param.test.js
@@ -54,4 +54,42 @@ describe('FormParam', function () {
             expect(fp).to.have.property('contentType', undefined);
         });
     });
+
+    describe('.toJSON', function () {
+        it('should correctly handle param with type `text`', function () {
+            var definition = {
+                    key: 'foo',
+                    value: 'bar',
+                    type: 'text',
+                    contentType: 'application/json'
+                },
+                fp = new FormParam(definition);
+
+            expect(fp.toJSON()).to.eql(definition);
+        });
+
+        it('should correctly handle param with type `file`', function () {
+            var definition = {
+                    key: 'foo',
+                    src: 'fileSrc',
+                    type: 'file',
+                    contentType: 'application/json'
+                },
+                fp = new FormParam(definition);
+
+            expect(fp.toJSON()).to.eql(definition);
+        });
+
+        it('should not have value for param with type `file`', function () {
+            var fp = new FormParam({
+                key: 'foo',
+                value: 'this will be removed for file param',
+                type: 'file',
+                contentType: 'application/json',
+                src: 'fileSrc'
+            });
+
+            expect(fp.toJSON()).to.not.have.property('value');
+        });
+    });
 });

--- a/test/unit/request-body.test.js
+++ b/test/unit/request-body.test.js
@@ -441,4 +441,73 @@ describe('RequestBody', function () {
             expect(body.isEmpty()).to.be.false;
         });
     });
+
+    describe('.toJSON', function () {
+        it('should correctly handle raw body', function () {
+            var definition = {
+                    mode: 'raw',
+                    raw: 'Arbitrary raw request body'
+                },
+                rBody = new RequestBody(definition);
+
+            expect(rBody.toJSON()).to.eql(definition);
+        });
+
+        it('should correctly handle urlencoded body', function () {
+            var definition = {
+                    mode: 'urlencoded',
+                    urlencoded: [{ key: 'foo', value: 'bar' }]
+                },
+                rBody = new RequestBody(definition);
+
+            expect(rBody.toJSON()).to.eql(definition);
+        });
+
+        it('should correctly handle formdata body', function () {
+            var definition = {
+                    mode: 'formdata',
+                    formdata: [
+                        { key: 'foo', value: 'bar' },
+                        { key: 'foo', src: 'bar', type: 'file' }
+                    ]
+                },
+                rBody = new RequestBody(definition);
+
+            expect(rBody.toJSON()).to.eql(definition);
+        });
+
+        it('should correctly handle graphql body', function () {
+            var definition = {
+                    mode: 'graphql',
+                    graphql: {
+                        query: 'query Test { hello }',
+                        operationName: 'Test',
+                        variables: '{"foo":"bar"}'
+                    }
+                },
+                rBody = new RequestBody(definition);
+
+            expect(rBody.toJSON()).to.eql(definition);
+        });
+
+        it('should correctly handle file body', function () {
+            var definition = {
+                    mode: 'file',
+                    file: { src: 'fileSrc' }
+                },
+                rBody = new RequestBody(definition);
+
+            expect(rBody.toJSON()).to.eql(definition);
+        });
+
+        it('should not have content in file body', function () {
+            var definition = {
+                    mode: 'file',
+                    file: { src: 'fileSrc', content: 'this should be removed' }
+                },
+                rBody = new RequestBody(definition);
+
+            expect(rBody.toJSON().file).to.not.have.property('content');
+        });
+    });
 });


### PR DESCRIPTION
- Override `toJSON()` in FormParam to not return value for param with `type: 'file'`
- Override `toJSON()` in RequestBody to not return content for file body type