### PR TITLE
Add check for existing info object before migrating data from root level

### DIFF
--- a/lib/collection/collection.js
+++ b/lib/collection/collection.js
@@ -193,23 +193,24 @@ _.assign(Collection.prototype, /** @lends Collection.prototype */ {
     toJSON: function () {
         var json = ItemGroup.prototype.toJSON.apply(this);
 
-        // move ids and stuff from root level to `info` object
-        json.info = {
-            _postman_id: this.id,
-            name: this.name,
-            version: this.version,
-            schema: SCHEMA_URL
-        };
+        if (!json.hasOwnProperty('info')){
+            // move ids and stuff from root level to `info` object
+            json.info = {
+                _postman_id: this.id,
+                name: this.name,
+                version: this.version,
+                schema: SCHEMA_URL
+            };
 
-        delete json.id;
-        delete json.name;
-        delete json.version;
+            delete json.id;
+            delete json.name;
+            delete json.version;
 
-        if (json.hasOwnProperty('description')) {
-            json.info.description = this.description;
-            delete json.description;
+            if (json.hasOwnProperty('description')) {
+                json.info.description = this.description;
+                delete json.description;
+            }
         }
-
         return json;
     }
 });

--- a/lib/collection/collection.js
+++ b/lib/collection/collection.js
@@ -193,7 +193,7 @@ _.assign(Collection.prototype, /** @lends Collection.prototype */ {
     toJSON: function () {
         var json = ItemGroup.prototype.toJSON.apply(this);
 
-        if (!json.hasOwnProperty('info')){
+        if (!json.hasOwnProperty('info')) {
             // move ids and stuff from root level to `info` object
             json.info = {
                 _postman_id: this.id,


### PR DESCRIPTION
This closes issue #1127 by wrapping the root data migration to the 'info' object, with a hasOwnProperty('info') check on the root. 