### PR TITLE
Add 'types' declaration back to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "license": "Apache-2.0",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/postmanlabs/postman-collection.git"


### PR DESCRIPTION
94a74ac5b53605ada9cd3e27983b7157e012e987 removed the `types` declaration from `package.json` which breaks TypeScript projects importing `postman-collection` starting with version `3.6.9`.  Example build error:

```
error TS7016: Could not find a declaration file for module 'postman-collection'. 'node_modules/postman-collection/index.js' implicitly has an 'any' type.
  Try `npm install @types/postman-collection` if it exists or add a new declaration (.d.ts) file containing `declare module 'postman-collection';`

12 } from 'postman-collection';
          ~~~~~~~~~~~~~~~~~~~~
```
