### PR TITLE
WIP Contextual JSON variable interpolation

### DIFF
--- a/test/unit/variable-list.test.js
+++ b/test/unit/variable-list.test.js
@@ -61,6 +61,29 @@ describe('VariableList', function () {
         expect(resolved.xyz).to.equal('foo-bar');
     });
 
+    it('should handle nested interpolation in JSON documents', function () {
+        var template = {
+            xyz: JSON.stringify({
+                value: '{{alpha}}'
+            })
+        }
+
+        var variables = new VariableList(null, [
+            {
+                key: 'alpha',
+                value: JSON.stringify({
+                    foo: 'bar'
+                })
+            }
+        ])
+
+        var result = variables.substitute(template)
+        var json = JSON.parse(result.xyz)
+        expect(json).to.deep.equal({
+            value: '{"foo":"bar"}'
+        })
+    });
+
     it('should correctly resolve variables with a forward slash in their name', function () {
         var unresolved = {
                 xyz: '{{alp/ha}}'


### PR DESCRIPTION
This is more of a conversation starter than a solution. I encountered
this case when working with the Postman app: A stringified JSON document
including other JSON stringified interpolations is recursively evaluated
and results in an invalid JSON document (as nested quotes are not
properly escaped).

To illustrate the problem, the test case in this PR currently fails as
`JSON.parse()` would throw the following error:

```
SyntaxError: Unexpected token f in JSON at position 12
```

Some ideas:

- There could be a way to instruct collections to only perform one level
  of interpolation. Maybe triple curly braces?

- Given how much JSON is relevant in Postman, there could be a way to
  interpolate variables in a JSON-aware manner. For example, other
  systems support a pipe operator where you can transform the content.
  In this case, we could do something like `{{alpha | escape_json}}`

Signed-off-by: Juan Cruz Viotti <jv@jviotti.com>