### PR TITLE
Upgrade to "sanitize-html": "2.3.3". 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ node_js:
   - 10
   - 12
   - 14
-  - 15
+  - 16
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ node_js:
   - 10
   - 12
   - 14
-  - 16
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ os:
   - linux
   - windows
 node_js:
-  - 6
   - 8
   - 10
+  - 12
+  - 14
+  - 15
 
 jobs:
   include:

--- a/package-lock.json
+++ b/package-lock.json
@@ -445,6 +445,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -619,7 +620,8 @@
     "array-uniq": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+      "dev": true
     },
     "array-unique": {
       "version": "0.3.2",
@@ -1397,6 +1399,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1592,6 +1595,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -1599,7 +1603,13 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "colorette": {
+      "version": "1.2.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha1-y8x51emcrqLb8Q6zom/Ys+as+pQ="
     },
     "colors": {
       "version": "1.0.3",
@@ -2066,6 +2076,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha1-RNLqNnm49NT/ujPwPYZfwee/SVU="
+    },
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
@@ -2422,11 +2437,12 @@
       }
     },
     "dom-serializer": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "version": "1.3.1",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/dom-serializer/-/dom-serializer-1.3.1.tgz",
+      "integrity": "sha1-2EWhVl18BBqV5dq2IYSrQeOlGb4=",
       "requires": {
         "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
         "entities": "^2.0.0"
       }
     },
@@ -2437,39 +2453,26 @@
       "dev": true
     },
     "domelementtype": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-      "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+      "version": "2.2.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/domelementtype/-/domelementtype-2.2.0.tgz",
+      "integrity": "sha1-mgtsJ4LtahxzI9QiZxg9+b2LHVc="
     },
     "domhandler": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "version": "4.2.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/domhandler/-/domhandler-4.2.0.tgz",
+      "integrity": "sha1-+XaKXwNL5gqJonwuTQ9066DYsFk=",
       "requires": {
-        "domelementtype": "1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-        }
+        "domelementtype": "^2.2.0"
       }
     },
     "domutils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "version": "2.6.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/domutils/-/domutils-2.6.0.tgz",
+      "integrity": "sha1-LhXAQYXUP7Fq5wV8t2Qzxu25OLc=",
       "requires": {
-        "dom-serializer": "0",
-        "domelementtype": "1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-        }
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
       }
     },
     "duplexer2": {
@@ -2761,7 +2764,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "eslint": {
       "version": "5.16.0",
@@ -4385,7 +4389,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -4505,28 +4510,14 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "version": "6.1.0",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha1-xNditsM3GgXb5l6UrkOp+EX7j7c=",
       "requires": {
-        "domelementtype": "^1.3.1",
-        "domhandler": "^2.3.0",
-        "domutils": "^1.5.1",
-        "entities": "^1.1.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^3.1.1"
-      },
-      "dependencies": {
-        "domelementtype": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-        },
-        "entities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
-        }
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
       }
     },
     "http-errors": {
@@ -4657,7 +4648,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "inline-source-map": {
       "version": "0.6.2",
@@ -5499,6 +5491,11 @@
         "graceful-fs": "^4.1.9"
       }
     },
+    "klona": {
+      "version": "2.0.4",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/klona/-/klona-2.0.4.tgz",
+      "integrity": "sha1-e7Hjr/sMuGJFR+9+j2cI6i4538A="
+    },
     "labeled-stream-splicer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.2.tgz",
@@ -5566,42 +5563,17 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
-    "lodash.clonedeep": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
-    },
-    "lodash.escaperegexp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
-      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
-    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
     },
-    "lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-    },
-    "lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-    },
     "lodash.memoize": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
       "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
       "dev": true
-    },
-    "lodash.mergewith": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
-      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "lodash.omit": {
       "version": "4.5.0",
@@ -6280,6 +6252,11 @@
       "dev": true,
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.23",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/nanoid/-/nanoid-3.1.23.tgz",
+      "integrity": "sha1-90QIbOfCvEfuCoRyV01ceOQYOoE="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -6378,11 +6355,6 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
-    },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
       "version": "14.1.1",
@@ -6761,6 +6733,11 @@
       "integrity": "sha1-VjRtR0nXjyNDDKDHE4UK75GqNh0=",
       "dev": true
     },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
+    },
     "parseqs": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
@@ -6916,23 +6893,13 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-      "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+      "version": "8.2.15",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/postcss/-/postcss-8.2.15.tgz",
+      "integrity": "sha1-nmbM8HKSgX0ib8MVy7+bwUj7ymU=",
       "requires": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "colorette": "^1.2.2",
+        "nanoid": "^3.1.23",
+        "source-map": "^0.6.1"
       }
     },
     "postman-jsdoc-theme": {
@@ -7266,6 +7233,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
       "requires": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -7570,7 +7538,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -7587,20 +7556,29 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sanitize-html": {
-      "version": "1.20.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.1.tgz",
-      "integrity": "sha512-txnH8TQjaQvg2Q0HY06G6CDJLVYCpbnxrdO0WN8gjCKaU5J0KbyGYhZxx5QJg3WLZ1lB7XU9kDkfrCXUozqptA==",
+      "version": "2.3.3",
+      "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/sanitize-html/-/sanitize-html-2.3.3.tgz",
+      "integrity": "sha1-PbOCyaYhzOTEbZDxDGTx6dqeg1M=",
       "requires": {
-        "chalk": "^2.4.1",
-        "htmlparser2": "^3.10.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.escaperegexp": "^4.1.2",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.mergewith": "^4.6.1",
-        "postcss": "^7.0.5",
-        "srcset": "^1.0.0",
-        "xtend": "^4.0.1"
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "klona": "^2.0.3",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.0.2"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha1-FLqDpdNz49MR5a/KKc9b+tllvzQ="
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://longreen.jfrog.io/longreen/api/npm/npm/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha1-RCf1CrNCnpAl6n1S6QQ6nvQVk0Q="
+        }
       }
     },
     "schema-compiler": {
@@ -8081,15 +8059,6 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
-    "srcset": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
-      "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
-      "requires": {
-        "array-uniq": "^1.0.2",
-        "number-is-nan": "^1.0.0"
-      }
-    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -8402,6 +8371,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.2.0.tgz",
       "integrity": "sha512-6YqyX6ZWEYguAxgZzHGL7SsCeGx3V2TtOTqZz1xSTSWnqsbWwbptafNyvf/ACquZUXV3DANr5BDIwNYe1mN42w==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -8448,6 +8418,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -9028,7 +8999,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
@@ -9275,7 +9247,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mime-format": "2.0.1",
     "mime-types": "2.1.30",
     "postman-url-encoder": "3.0.1",
-    "sanitize-html": "1.20.1",
+    "sanitize-html": "2.3.3",
     "semver": "7.3.5",
     "uuid": "3.4.0"
   },

--- a/test/system/travis-yml.test.js
+++ b/test/system/travis-yml.test.js
@@ -23,7 +23,7 @@ describe('travis.yml', function () {
     describe('strucure', function () {
         it('should have the language set to node', function () {
             expect(travisYAML).to.have.property('language').that.equal('node_js');
-            expect(travisYAML).to.have.property('node_js').that.eql([6, 8, 10]);
+            expect(travisYAML).to.have.property('node_js').that.eql([8, 10, 12, 14, 15]);
         });
     });
 });

--- a/test/system/travis-yml.test.js
+++ b/test/system/travis-yml.test.js
@@ -23,7 +23,7 @@ describe('travis.yml', function () {
     describe('strucure', function () {
         it('should have the language set to node', function () {
             expect(travisYAML).to.have.property('language').that.equal('node_js');
-            expect(travisYAML).to.have.property('node_js').that.eql([8, 10, 12, 14, 15]);
+            expect(travisYAML).to.have.property('node_js').that.eql([8, 10, 12, 14, 16]);
         });
     });
 });

--- a/test/system/travis-yml.test.js
+++ b/test/system/travis-yml.test.js
@@ -23,7 +23,7 @@ describe('travis.yml', function () {
     describe('strucure', function () {
         it('should have the language set to node', function () {
             expect(travisYAML).to.have.property('language').that.equal('node_js');
-            expect(travisYAML).to.have.property('node_js').that.eql([8, 10, 12, 14, 16]);
+            expect(travisYAML).to.have.property('node_js').that.eql([8, 10, 12, 14]);
         });
     });
 });

--- a/test/unit/description.test.js
+++ b/test/unit/description.test.js
@@ -65,7 +65,7 @@ describe('Description', function () {
                 type: 'text/markdown'
             });
 
-            expect(description.toString()).to.equal('Description\n');
+            expect(description.toString()).to.equal('<h1>Description</h1>\n');
         });
 
         it('should correctly handle HTML', function () {


### PR DESCRIPTION
Addresses https://github.com/advisories/GHSA-mjxr-4v3x-q3m4

Fix expected result, sanitize now replaces # with h1.

It appears that sanitize-html 2.X brings in postcss version that is no longer compatible with node 6. I am wondering if it is still necessary to support node 6 given the EOL date of April 2019.