### PR TITLE
Updated `Header.unparse` default behaviour

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -23,6 +23,8 @@ unreleased:
     - GH-1200 Dropped support for deprecated `VariableScope#variables` method
     - >-
       GH-1200 Dropped support for deprecated "json" `Variable#type`
+    - GH-1201 Updated `Header.unparse` default separator from "\n" to "\r\n"
+    - GH-1201 `Header.unparse` excludes disabled header by default
   chores:
     - GH-1200 Removed discontinued `Request#authorize` method
     - Added secure codecov publish script

--- a/examples/collection-v2.json
+++ b/examples/collection-v2.json
@@ -68,7 +68,7 @@
                     "originalRequest": "http://echo.getpostman.com/status/200",
                     "status": "200 OK",
                     "code": 200,
-                    "header": "Content-Type: application/json\nAuthorization: Hawk id=\"dh37fgj492je\", ts=\"1448549987\", nonce=\"eOJZCd\", mac=\"O2TFlvAlMvKVSKOzc6XkfU6+5285k5p3m5dAjxumo2k=\"\n",
+                    "header": "Content-Type: application/json\r\nAuthorization: Hawk id=\"dh37fgj492je\", ts=\"1448549987\", nonce=\"eOJZCd\", mac=\"O2TFlvAlMvKVSKOzc6XkfU6+5285k5p3m5dAjxumo2k=\"\r\n",
                     "cookie": [
                         {
                             "domain": ".httpbin.org",
@@ -143,7 +143,7 @@
                     "originalRequest": "http://echo.getpostman.com/post",
                     "status": "200 OK",
                     "code": 200,
-                    "header": "Content-Type: application/json\nAuthorization: Hawk id=\"dh37fgj492je\", ts=\"1448549987\", nonce=\"eOJZCd\", mac=\"O2TFlvAlMvKVSKOzc6XkfU6+5285k5p3m5dAjxumo2k=\"\n",
+                    "header": "Content-Type: application/json\r\nAuthorization: Hawk id=\"dh37fgj492je\", ts=\"1448549987\", nonce=\"eOJZCd\", mac=\"O2TFlvAlMvKVSKOzc6XkfU6+5285k5p3m5dAjxumo2k=\"\r\n",
                     "cookie": [
                         {
                             "domain": ".httpbin.org",

--- a/lib/collection/header-list.js
+++ b/lib/collection/header-list.js
@@ -2,8 +2,6 @@ var _ = require('../util').lodash,
     PropertyList = require('./property-list').PropertyList,
     Header = require('./header').Header,
 
-    E = '',
-    CRLF = '\r\n',
     PROP_NAME = '_postman_propertyName',
 
     HeaderList;
@@ -32,17 +30,7 @@ _.assign(HeaderList.prototype, /** @lends HeaderList.prototype */ {
     contentSize: function () {
         if (!this.count()) { return 0; }
 
-        var raw = this.reduce(function (acc, header) {
-            // unparse header only if it has a valid key and is not disabled
-            if (header && !header.disabled) {
-                // *( header-field CRLF )
-                acc += Header.unparseSingle(header) + CRLF;
-            }
-
-            return acc;
-        }, E);
-
-        return raw.length;
+        return Header.unparse(this).length;
     }
 });
 

--- a/lib/collection/header.js
+++ b/lib/collection/header.js
@@ -3,6 +3,7 @@ var util = require('../util'),
 
     E = '',
     SPC = ' ',
+    CRLF = '\r\n',
     HEADER_KV_SEPARATOR = ':',
 
     Property = require('./property').Property,
@@ -216,17 +217,24 @@ _.assign(Header, /** @lends Header */ {
     /**
      * Stringifies an Array or {@link PropertyList} of Headers into a single string.
      *
+     * @note Disabled headers are excluded.
+     *
      * @param {Array|PropertyList<Header>} headers
-     * @param {String=} separator - Specify a string for separating each header, by default, '\n', but sometimes,
-     * it might be more useful to use a carriage return ('\r\n')
-     * @returns {string}
+     * @param {String=} [separator='\r\n'] - Specify a string for separating each header
+     * @returns {String}
      */
-    unparse: function (headers, separator) {
+    unparse: function (headers, separator = CRLF) {
         if (!_.isArray(headers) && !PropertyList.isPropertyList(headers)) {
             return E;
         }
 
-        return headers.map(Header.unparseSingle).join(separator ? separator : '\n');
+        return headers.reduce(function (acc, header) {
+            if (header && !header.disabled) {
+                acc += Header.unparseSingle(header) + separator;
+            }
+
+            return acc;
+        }, E);
     },
 
     /**

--- a/test/unit/header-list.test.js
+++ b/test/unit/header-list.test.js
@@ -15,7 +15,7 @@ describe('HeaderList', function () {
 
     it('should be able to export headers to string', function () {
         var hl = new HeaderList(null, 'Accept: *\nContent-Type: text/html');
-        expect(hl.toString()).to.equal('Accept: *\nContent-Type: text/html');
+        expect(hl.toString()).to.equal('Accept: *\r\nContent-Type: text/html\r\n');
     });
 
     describe('.contentSize', function () {

--- a/test/unit/header.test.js
+++ b/test/unit/header.test.js
@@ -147,11 +147,11 @@ describe('Header', function () {
                 key: 'name2',
                 value: 'value2'
             }]);
-            expect(Header.unparse(list)).to.equal('name1: value1\nname2: value2');
+            expect(Header.unparse(list)).to.equal('name1: value1\r\nname2: value2\r\n');
         });
 
-        it('should honor the given separator "\\r\\n"', function () {
-            var raw = 'name1: value1\r\nname2: value2',
+        it('should honor the given separator "\\n"', function () {
+            var raw = 'name1: value1\nname2: value2\n',
                 list = new PropertyList(Header, {}, raw);
             expect(list.toJSON()).to.eql([{
                 key: 'name1',
@@ -160,7 +160,7 @@ describe('Header', function () {
                 key: 'name2',
                 value: 'value2'
             }]);
-            expect(Header.unparse(list, '\r\n')).to.equal(raw);
+            expect(Header.unparse(list, '\n')).to.equal(raw);
         });
     });
 


### PR DESCRIPTION
* excludes disabled headers by default
* default separator changed from "\n" to "\r\n"