### PR TITLE
Added Cred Card Number and CVV support

### DIFF
--- a/lib/superstring/dynamic-variables.js
+++ b/lib/superstring/dynamic-variables.js
@@ -311,6 +311,14 @@ var faker = require('faker/locale/en'),
             description: 'A random masked credit card number',
             generator: faker.finance.mask
         },
+        $randomCreditCardNumber: {
+            description: 'A random credit card number',
+            generator: faker.finance.creditCardNumber
+        },
+        $randomCreditCardCVV: {
+            description: 'A random credit card cvv',
+            generator: faker.finance.creditCardCVV
+        },
         $randomPrice: {
             description: 'A random price between 0.00 and 1000.00',
             generator: faker.finance.amount


### PR DESCRIPTION
At Faker.js has:

- faker.finance.creditCardNumber  -> **$randomCreditCardNumber**
- faker.finance.creditCardCVV -> **$randomCreditCardCVV**

postman-docs link:
https://github.com/postmanlabs/postman-docs/pull/3383