### PR TITLE
Fixed the method `getPathWithQuery` for disabled params

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+unreleased:
+  fixed bugs:
+    - >-
+      GH-1231 Fixed the method `getPathWithQuery` where disabled params
+      were resulting into `?` at the end of the url
+
 4.1.0:
   date: 2021-08-16
   new features:

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -310,7 +310,7 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
         var path = this.getPath(),
             queryString = this.getQueryString();
 
-        // check count first so that, we can ensure that ba `?` is always appended, even if a blank query string exists
+        // Check if the queryString exists to figure out if we need to add a `?` alongside the queryString
         if (queryString) {
             path += (QUERY_SEPARATOR + queryString);
         }

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -312,10 +312,10 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
 
         // check count first so that, we can ensure that ba `?` is always appended, even if a blank query string exists
         if (queryString) {
-            path += (QUERY_SEPARATOR + queryString)
+            path += (QUERY_SEPARATOR + queryString);
         }
 
-        return path
+        return path;
     },
 
     /**

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -307,14 +307,15 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
      * @example /something/postman?hi=notbye
      */
     getPathWithQuery () {
-        var path = this.getPath();
+        var path = this.getPath(),
+            queryString = this.getQueryString();
 
         // check count first so that, we can ensure that ba `?` is always appended, even if a blank query string exists
-        if (this.query.count()) {
-            path += (QUERY_SEPARATOR + this.getQueryString());
+        if (queryString) {
+            path += (QUERY_SEPARATOR + queryString)
         }
 
-        return path;
+        return path
     },
 
     /**

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -1520,8 +1520,8 @@ describe('Url', function () {
         it('should NOT add ? in-case the params have only disabled values', function () {
             var url = new Url({
                 host: 'example.com',
-                path: [ 'blah' ],
-                query: [ { key: 'user', value: 'x', disabled: true } ]
+                path: ['blah'],
+                query: [{ key: 'user', value: 'x', disabled: true }]
             });
 
             expect(url.getPathWithQuery()).to.equal('/blah');

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -1516,6 +1516,23 @@ describe('Url', function () {
 
             expect(url.query.toObject()).to.eql({ query: 'param', query2: 'param2' });
         });
+
+        it('should NOT add ? in-case the params have only disabled values', function () {
+            var url = new Url({
+                host: 'example.com',
+                path: [ 'blah' ],
+                query: [ { key: 'user', value: 'x', disabled: true } ]
+            });
+
+            expect(url.getPathWithQuery()).to.equal('/blah');
+        });
+
+        it('should add / in-case the path is not provided', function () {
+            var url = new Url('example.com');
+
+            // ref: https://datatracker.ietf.org/doc/html/rfc2616#section-3.2.3
+            expect(url.getPathWithQuery()).to.equal('/');
+        });
     });
 
     describe('Security', function () {


### PR DESCRIPTION
Fixed the scenario where disabled params were resulting into `?` at the end of the url