### PR TITLE
add types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Postman Inc.",
   "license": "Apache-2.0",
   "main": "index.js",
+  "types": "types/index.d.ts",
   "homepage": "https://github.com/postmanlabs/postman-collection#readme",
   "bugs": {
     "url": "https://github.com/postmanlabs/postman-collection/issues",


### PR DESCRIPTION
the types won't be picked up by typescript/npm without this, so users will end up installing the outdated `@types/postman-collection` package instead:

![image](https://user-images.githubusercontent.com/57028336/170174241-6c8633f7-f461-4269-8bfa-ffcc1186d87f.png)

artist's rendition of what the package will look like on npm after this PR is merged:

![image](https://user-images.githubusercontent.com/57028336/170174389-d726598e-f9d9-46fb-a252-68c5dcdc3f33.png)
