### PR TITLE
"Close @todo: Add non-enumerable getter and setter for metadata functionality"

### DIFF
--- a/lib/collection/property-base.js
+++ b/lib/collection/property-base.js
@@ -22,16 +22,39 @@ PropertyBase = function PropertyBase (definition) {
 
     // call the meta extraction functions to create the object where all keys that are prefixed with underscore can be
     // stored. more details on that can be retrieved from the propertyExtractMeta function itself.
-    // @todo: make this a closed function to do getter and setter which is non enumerable
-    var src = definition && definition.info || definition,
-        meta = _(src).pickBy(PropertyBase.propertyIsMeta).mapKeys(PropertyBase.propertyUnprefixMeta).value();
+    var _meta = {}; // variable to store metadata
 
-    if (_.keys(meta).length) {
-        this._ = _.isObject(this._) ?
-            /* istanbul ignore next */
-            _.mergeDefined(this._, meta) :
-            meta;
-    }
+    var extractAndSetMeta = function (definition) {
+        var src = definition && definition.info || definition;
+        var meta = _(src).pickBy(PropertyBase.propertyIsMeta).mapKeys(PropertyBase.propertyUnprefixMeta).value();
+
+        if (_.keys(meta).length) {
+            _meta = _.isObject(_meta) ? _.mergeDefined(_meta, meta) : meta;
+        }
+    };
+    
+    // calling function for Initial extraction and setting of meta
+    extractAndSetMeta(definition); 
+
+    // Getter method for metadata
+    Object.defineProperty(this, 'getMeta', {
+        enumerable: false,
+        configurable: true,
+        value: function () {
+            return _.cloneDeep(_meta);
+        }
+    });
+
+    // Setter method for metadata
+    Object.defineProperty(this, 'setMeta', {
+        enumerable: false,
+        configurable: true,
+        value: function (newMeta) {
+            if (_.isObject(newMeta)) {
+                _meta = _.mergeDefined(_meta, newMeta);
+            }
+        }
+    });
 };
 
 _.assign(PropertyBase.prototype, /** @lends PropertyBase.prototype */ {


### PR DESCRIPTION
### Description
This pull request addresses the following @todo:

@todo: Make this a closed function to do a getter and setter that is non-enumerable.

### Changes Made
Refactored the existing code to encapsulate the getter and setter functionality for metadata within a closed function. This ensures that the methods are non-enumerable and not included when iterating over object properties.