### PR TITLE
[APITEST-766] Added Packages to Collection Schema

### DIFF
--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -62,6 +62,12 @@ _.assign(Script.prototype, /** @lends Script.prototype */ {
          * @type {string}
          */
         this.type = options.type || 'text/javascript';
+
+        /**
+         * @arguments {Script.prototype}
+         * @type {Array<Object>}
+         */
+        this.packages = options.packages || [];
         _.has(options, 'src') && (
 
             /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2158,15 +2158,18 @@ declare module "postman-collection" {
          * @param [options.type] - Script type
          * @param [options.src] - Script source url
          * @param [options.exec] - Script to execute
+         * @param [options.packages] - List of packages to be preloaded
          */
         update(options?: {
             type?: string;
             src?: string;
             exec?: string[] | string;
+            packages?: Object[];
         }): void;
         type: string;
         src: Url;
         exec: string[];
+        packages: Object[];
         /**
          * Check whether an object is an instance of ItemGroup.
          * @param obj - -


### PR DESCRIPTION
This PR adds the concept of packages to the collection schema and the postman-collection entity.
In the events object, we have a Listen (String) and Script Object to encapsulate all the data related to a script.
Inside the Script Object, we have the following -
- type
- exec
- id

We are adding a fourth entity - **Packages**

Packages is an array of objects, each of which will contain the name of the package and the ID of the package. This enables us to correctly resolve the packages needed for the execution of the particular parent event.
The events object in the collection will now look something like this -
`{
...,
"events": [
            {
                "listen": "prerequest",
                "script": {
                    "exec": [
                        "console.log('x');"
                    ],
                    "type": "text/javascript",
                    "packages": [
                      {
                        id: "<packageid-1>"
                      },
                      {
                        id: "<packageid-2>"
                      }
                    ],
                    "id": "51f1d8c7-6006-43e8-90f6-846cc8144d7f"
                }
            }
        ],
...
}`

Implementation documents -
- Runtime/Sandbox Changes - https://postmanlabs.atlassian.net/wiki/x/DAB3HAE
- Resolver changes (runtime consumer side) - https://postmanlabs.atlassian.net/wiki/x/BgELHwE