### PR TITLE
Add key `packages` in Script

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,4 +1,6 @@
-develop:
+unreleased:
+  new features:
+    - GH-1356 Add new key `packages` to Script
   chores:
     - >-
       GH-1357 Fixed a bug where invalid JSDoc prevented generating docs and

--- a/examples/collection-v2.json
+++ b/examples/collection-v2.json
@@ -42,14 +42,22 @@
             "id": "my-global-script-1",
             "script": {
                 "type": "text/javascript",
-                "exec": "console.log(\"hello\");"
+                "exec": [
+                  "const package1 = pm.require(\"package1\");",
+                  "console.log(\"hello\", package1);"
+                ],
+                "packages": { "package1": { "id": "script-package-1" } }
             }
         },
         {
             "listen": "prerequest",
             "script": {
                 "type": "text/javascript",
-                "exec": "console.log(\"hello\");"
+                "exec": [
+                  "const package1 = pm.require(\"package1\");",
+                  "console.log(\"hello\", package1);"
+                ],
+                "packages": { "package1": { "id":"script-package-1" } }
             }
         }
     ],

--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -6,6 +6,12 @@ var _ = require('../util').lodash,
 
     SCRIPT_NEWLINE_PATTERN = /\r?\n/g;
 
+/**
+ * A map of package names to the IDs of the packages
+ *
+ * @typedef {Object.<string, { id: string }>} Packages
+ */
+
 _.inherit((
 
     /**
@@ -49,6 +55,7 @@ _.assign(Script.prototype, /** @lends Script.prototype */ {
      * @param {String} [options.type] Script type
      * @param {String} [options.src] Script source url
      * @param {String[]|String} [options.exec] Script to execute
+     * @param {Packages} [options.packages] Packages required by the script
      */
     update: function (options) {
         // no splitting is being done here, as string scripts are split right before assignment below anyway
@@ -62,6 +69,14 @@ _.assign(Script.prototype, /** @lends Script.prototype */ {
          * @type {string}
          */
         this.type = options.type || 'text/javascript';
+
+        /**
+         * The packages required by the script
+         *
+         * @type {Packages}
+         */
+        this.packages = options.packages;
+
         _.has(options, 'src') && (
 
             /**

--- a/test/unit/event-list.test.js
+++ b/test/unit/event-list.test.js
@@ -10,7 +10,8 @@ describe('EventList', function () {
             id: 'my-global-script-1',
             script: {
                 type: 'text/javascript',
-                exec: 'console.log("hello");'
+                exec: 'console.log("hello");',
+                packages: [{ id: 'script-package-1', name: 'package1' }]
             }
         }];
 
@@ -35,7 +36,8 @@ describe('EventList', function () {
                     script: {
                         id: 'test-script-1',
                         type: 'text/javascript',
-                        exec: 'console.log("hello");'
+                        exec: 'console.log("hello");',
+                        packages: { package1: { id: 'script-package-1' } }
                     }
                 }]),
                 eventListJSON;
@@ -46,7 +48,8 @@ describe('EventList', function () {
                 script: {
                     id: 'test-script-1',
                     type: 'text/javascript',
-                    exec: ['console.log("hello");']
+                    exec: ['console.log("hello");'],
+                    packages: { package1: { id: 'script-package-1' } }
                 }
             }]);
 
@@ -63,7 +66,8 @@ describe('EventList', function () {
                 script: {
                     id: 'test-script-1',
                     type: 'text/javascript',
-                    exec: ['console.log("hello");']
+                    exec: ['console.log("hello");'],
+                    packages: { package1: { id: 'script-package-1' } }
                 }
             });
 

--- a/test/unit/event.test.js
+++ b/test/unit/event.test.js
@@ -11,7 +11,8 @@ describe('Event', function () {
         id: 'my-global-script-1',
         script: {
             type: 'text/javascript',
-            exec: 'console.log("hello");'
+            exec: 'console.log("hello");',
+            packages: {}
         }
     };
 
@@ -52,6 +53,7 @@ describe('Event', function () {
                     expect(postmanEvent).to.have.property('script').that.is.an('object');
                     expect(postmanEvent.script).to.have.property('type', 'text/javascript');
                     expect(postmanEvent.script).to.have.property('exec').that.is.an('array');
+                    expect(postmanEvent.script).to.have.property('packages').that.is.an('object');
                 });
             });
 
@@ -120,7 +122,8 @@ describe('Event', function () {
             expect(eventJSON).to.have.property('script').that.has.property('id');
             expect(eventJSON.script).to.deep.include({
                 type: 'text/javascript',
-                exec: ['console.log("hello");']
+                exec: ['console.log("hello");'],
+                packages: {}
             });
         });
 
@@ -132,7 +135,8 @@ describe('Event', function () {
             expect(beforeJSON).to.have.property('script').that.has.property('id');
             expect(beforeJSON.script).to.deep.include({
                 type: 'text/javascript',
-                exec: ['console.log("hello");']
+                exec: ['console.log("hello");'],
+                packages: {}
             });
 
             event.update({ script: { id: 'my-new-script' } });
@@ -141,6 +145,27 @@ describe('Event', function () {
             expect(beforeJSON.script.id).to.not.equal(afterJSON.script.id);
             expect(afterJSON.script).to.have.property('id', 'my-new-script');
             expect(afterJSON.script.exec).to.be.undefined;
+        });
+
+        it('should not add packages key if not present', function () {
+            var rawEvent = {
+                    listen: 'test',
+                    id: 'my-global-script-1',
+                    script: {
+                        type: 'text/javascript',
+                        exec: 'console.log("hello");'
+                    }
+                },
+                event = new Event(rawEvent),
+                beforeJSON = event.toJSON(),
+                afterJSON;
+
+            expect(beforeJSON.script).to.not.have.property('packages');
+
+            event.update({ script: { exec: 'console.log("updated");' } });
+            afterJSON = event.toJSON();
+
+            expect(afterJSON.script).to.not.have.property('packages');
         });
     });
 });

--- a/test/unit/script.test.js
+++ b/test/unit/script.test.js
@@ -64,7 +64,7 @@ describe('Script', function () {
                     var source = script.toSource();
 
                     expect(source).to.be.a('string');
-                    expect(source).to.equal(rawScript.exec);
+                    expect(source).to.equal(rawScript.exec.join('\n'));
                 });
             });
         });
@@ -201,7 +201,7 @@ describe('Script', function () {
 
             expect(jsonified).to.deep.include({
                 type: rawScript.type,
-                exec: rawScript.exec.split('\n')
+                exec: rawScript.exec
             });
             expect(jsonified.src).to.eql(rawScript.src);
         });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2147,6 +2147,13 @@ declare module "postman-collection" {
     }
 
     /**
+     * A map of package names to the IDs of the packages
+     */
+    export type Packages = {
+        [key: string]: { id: string; };
+    };
+
+    /**
      * Postman scripts that are executed upon events on a collection  / request such as test and pre request.
      * @param options - -
      */
@@ -2162,13 +2169,19 @@ declare module "postman-collection" {
          * @param [options.type] - Script type
          * @param [options.src] - Script source url
          * @param [options.exec] - Script to execute
+         * @param [options.packages] - Packages required by the script
          */
         update(options?: {
             type?: string;
             src?: string;
             exec?: string[] | string;
+            packages?: Packages;
         }): void;
         type: string;
+        /**
+         * The packages required by the script
+         */
+        packages: Packages;
         src: Url;
         exec: string[];
         /**


### PR DESCRIPTION
Picked changes from https://github.com/postmanlabs/postman-collection/pull/1352 by @aditya-baradwaj 

---

**We are adding a key `packages` inside `Script`.**

- `packages` is an object, with name of the package as the key, and value being an object that contains the `id` of the package.
- This key is optional. If this key is not already present, it will **NOT** be added with a default value.

```json
"script": {
    "id": "51f1d8c7-6006-43e8-90f6-846cc8144d7f",
    "exec": [
        "console.log('x');"
    ],
    "type": "text/javascript",
    "packages": {
        "package1": {
            "id": "9e85cce9-389d-43f4-8fa1-4c4340585521"
        },
        "package2": {
            "id": "a09d471f-ec97-47fa-85fe-e59d9098dad2"
        }
    }
}
```