### PR TITLE
Fix errors in generating docs and types

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,10 @@
+develop:
+  chores:
+    - >-
+      GH-1357 Fixed a bug where invalid JSDoc prevented generating docs and
+      types
+    - GH-1357 Update types for `getPath`
+
 4.3.0:
   date: 2023-11-18
   new features:

--- a/lib/collection/property.js
+++ b/lib/collection/property.js
@@ -16,8 +16,8 @@ var _ = require('../util').lodash,
  *
  * @private
  * @param {*} value Any JS variable within which we are trying to discover {{variables}}
- * @param {[Object]} seen Set of objects traversed before to avoid infinite recursion
- * @param {[Object]} result Set of variables to accumulate result in the recursive call
+ * @param {Set.<Object>} seen Set of objects traversed before to avoid infinite recursion
+ * @param {Set.<Object>} result Set of variables to accumulate result in the recursive call
  * @returns {Object} Set of variables
  */
 function _findSubstitutions (value, seen = new Set(), result = new Set()) {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-collection 4.0.2
+// Type definitions for postman-collection 4.3.0
 // Project: https://github.com/postmanlabs/postman-collection
 // Definitions by: PostmanLabs
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -1100,6 +1100,10 @@ declare module "postman-collection" {
          * @param [options] - -
          */
         authorizeRequestUsing(type: string | RequestAuth.definition, options?: VariableList): void;
+        /**
+         * Returns the path of the item
+         */
+        getPath(): string[];
         /**
          * Check whether an object is an instance of PostmanItem.
          * @param obj - -


### PR DESCRIPTION
There was an error on `build-docs` and `build-types` scripts. This PR fixes it.

```
Generating documentation...
ERROR: Unable to parse a tag's type expression for source file /Users/coditva/Code/postmanlabs/postman-collection/lib/collection/property.js in line 13 with tag title "param" and text "{[Object]} seen Set of objects traversed before to avoid infinite recursion": Invalid type expression "[Object]": Expected "!", "$", "'", "(", "*", ".", "...", "0", "?", "@", "Function", "\"", "\\", "_", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete", "do", "else", "enum", "export", "extends", "false", "finally", "for", "function", "if", "implements", "import", "in", "instanceof", "interface", "let", "new", "null", "package", "private", "protected", "public", "return", "static", "super", "switch", "this", "throw", "true", "try", "typeof", "undefined", "var", "void", "while", "with", "yield", "{", Unicode letter number, Unicode lowercase letter, Unicode modifier letter, Unicode other letter, Unicode titlecase letter, Unicode uppercase letter, or [1-9] but "[" found.
ERROR: Unable to parse a tag's type expression for source file /Users/coditva/Code/postmanlabs/postman-collection/lib/collection/property.js in line 13 with tag title "param" and text "{[Object]} result Set of variables to accumulate result in the recursive call": Invalid type expression "[Object]": Expected "!", "$", "'", "(", "*", ".", "...", "0", "?", "@", "Function", "\"", "\\", "_", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete", "do", "else", "enum", "export", "extends", "false", "finally", "for", "function", "if", "implements", "import", "in", "instanceof", "interface", "let", "new", "null", "package", "private", "protected", "public", "return", "static", "super", "switch", "this", "throw", "true", "try", "typeof", "undefined", "var", "void", "while", "with", "yield", "{", Unicode letter number, Unicode lowercase letter, Unicode modifier letter, Unicode other letter, Unicode titlecase letter, Unicode uppercase letter, or [1-9] but "[" found.
ERROR: Unable to parse a tag's type expression for source file /Users/coditva/Code/postmanlabs/postman-collection/lib/collection/property.js in line 23 with tag title "param" and text "{[Object]} seen Set of objects traversed before to avoid infinite recursion": Invalid type expression "[Object]": Expected "!", "$", "'", "(", "*", ".", "...", "0", "?", "@", "Function", "\"", "\\", "_", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete", "do", "else", "enum", "export", "extends", "false", "finally", "for", "function", "if", "implements", "import", "in", "instanceof", "interface", "let", "new", "null", "package", "private", "protected", "public", "return", "static", "super", "switch", "this", "throw", "true", "try", "typeof", "undefined", "var", "void", "while", "with", "yield", "{", Unicode letter number, Unicode lowercase letter, Unicode modifier letter, Unicode other letter, Unicode titlecase letter, Unicode uppercase letter, or [1-9] but "[" found.
ERROR: Unable to parse a tag's type expression for source file /Users/coditva/Code/postmanlabs/postman-collection/lib/collection/property.js in line 23 with tag title "param" and text "{[Object]} result Set of variables to accumulate result in the recursive call": Invalid type expression "[Object]": Expected "!", "$", "'", "(", "*", ".", "...", "0", "?", "@", "Function", "\"", "\\", "_", "break", "case", "catch", "class", "const", "continue", "debugger", "default", "delete", "do", "else", "enum", "export", "extends", "false", "finally", "for", "function", "if", "implements", "import", "in", "instanceof", "interface", "let", "new", "null", "package", "private", "protected", "public", "return", "static", "super", "switch", "this", "throw", "true", "try", "typeof", "undefined", "var", "void", "while", "with", "yield", "{", Unicode letter number, Unicode lowercase letter, Unicode modifier letter, Unicode other letter, Unicode titlecase letter, Unicode uppercase letter, or [1-9] but "[" found.
```