### PR TITLE
fix the randomAvatar dynamic variable url returning 404 in faker.js

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,8 +1,6 @@
 unreleased:
- fixed-bug:
-    - >-
-      GH-1366 Fixed a bug where $randomAvatarImage was returning an invalid URL.
-
+  fixed bugs:
+    - GH-1366 Fixed a bug where $randomAvatarImage was returning an invalid URL
 
 4.4.0:
   date: 2024-02-28

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,9 @@
+unreleased:
+ fixed-bug:
+    - >-
+      GH-1366 Fixed a bug where $randomAvatarImage was returning an invalid URL.
+
+
 4.4.0:
   date: 2024-02-28
   new features:

--- a/lib/superstring/dynamic-variables.js
+++ b/lib/superstring/dynamic-variables.js
@@ -75,6 +75,28 @@ var faker = require('@faker-js/faker/locale/en'),
         '/var/yp'
     ],
 
+    /**
+     * Copied over from: https://github.com/faker-js/faker/blob/next/src/modules/image/index.ts#L27
+     * Generates a random avatar from GitHub.
+     *
+     * @example 'https://avatars.githubusercontent.com/u/97165289'
+     */
+    avatarGitHub = () => {
+        return `https://avatars.githubusercontent.com/u/${faker.datatype.number(100000000)}`;
+    },
+
+    /**
+     * Copied over from: https://github.com/faker-js/faker/blob/next/src/modules/image/index.ts#L27
+     * Generates a random avatar from
+     * `https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar`.
+     *
+     * @example 'https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/170.jpg'
+     */
+    avatarLegacy = () => {
+        // eslint-disable-next-line max-len
+        return `https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/${faker.datatype.number(1249)}.jpg`;
+    },
+
     // generators for $random* variables
     dynamicGenerators = {
         $guid: {
@@ -371,7 +393,17 @@ var faker = require('@faker-js/faker/locale/en'),
 
         $randomAvatarImage: {
             description: 'A random avatar image',
-            generator: faker.image.avatar
+            generator: () => {
+                // We have overridden the avatar generator to be similar to current
+                // latest version (v9) of faker.js. We don't want to upgrade to the latest
+                // version of faker.js as it is significantly big in size.
+                const avatarMethod = faker.random.arrayElement([
+                    avatarLegacy,
+                    avatarGitHub
+                ]);
+
+                return avatarMethod();
+            }
         },
         $randomImageUrl: {
             description: 'A URL for a random image',

--- a/lib/superstring/dynamic-variables.js
+++ b/lib/superstring/dynamic-variables.js
@@ -75,28 +75,6 @@ var faker = require('@faker-js/faker/locale/en'),
         '/var/yp'
     ],
 
-    /**
-     * Copied over from: https://github.com/faker-js/faker/blob/next/src/modules/image/index.ts#L27
-     * Generates a random avatar from GitHub.
-     *
-     * @example 'https://avatars.githubusercontent.com/u/97165289'
-     */
-    avatarGitHub = () => {
-        return `https://avatars.githubusercontent.com/u/${faker.datatype.number(100000000)}`;
-    },
-
-    /**
-     * Copied over from: https://github.com/faker-js/faker/blob/next/src/modules/image/index.ts#L27
-     * Generates a random avatar from
-     * `https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar`.
-     *
-     * @example 'https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/170.jpg'
-     */
-    avatarLegacy = () => {
-        // eslint-disable-next-line max-len
-        return `https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/${faker.datatype.number(1249)}.jpg`;
-    },
-
     // generators for $random* variables
     dynamicGenerators = {
         $guid: {
@@ -394,15 +372,12 @@ var faker = require('@faker-js/faker/locale/en'),
         $randomAvatarImage: {
             description: 'A random avatar image',
             generator: () => {
-                // We have overridden the avatar generator to be similar to current
-                // latest version (v9) of faker.js. We don't want to upgrade to the latest
-                // version of faker.js as it is significantly big in size.
-                const avatarMethod = faker.random.arrayElement([
-                    avatarLegacy,
-                    avatarGitHub
+                // ref: https://github.com/faker-js/faker/blob/v8.4.1/src/modules/image/index.ts#L61
+                return faker.random.arrayElement([
+                    // eslint-disable-next-line max-len
+                    `https://cloudflare-ipfs.com/ipfs/Qmd3W5DuhgHirLHGVixi6V76LhCkZUz6pnFt5AJBiyvHye/avatar/${faker.datatype.number(1249)}.jpg`,
+                    `https://avatars.githubusercontent.com/u/${faker.datatype.number(100000000)}`
                 ]);
-
-                return avatarMethod();
             }
         },
         $randomImageUrl: {

--- a/test/unit/dynamic-variables.test.js
+++ b/test/unit/dynamic-variables.test.js
@@ -101,8 +101,8 @@ describe('Dynamic variable', function () {
         it('$randomAvatarImage returns a random avatar image', function () {
             var avatarImage = dynamicVariables.$randomAvatarImage.generator();
 
-            expect(avatarImage).to.not.be.undefined;
-            expect(avatarImage).to.not.be.null;
+            expect(avatarImage).to.be.a('string')
+                .and.match(/^https:\/\/(avatars\.githubusercontent\.com|cloudflare-ipfs\.com)\/.+/);
         });
     });
 });

--- a/test/unit/dynamic-variables.test.js
+++ b/test/unit/dynamic-variables.test.js
@@ -97,5 +97,12 @@ describe('Dynamic variable', function () {
             expect(directoryPath).to.not.be.undefined;
             expect(directoryPath).to.not.be.null;
         });
+
+        it('$randomAvatarImage returns a random avatar image', function () {
+            var avatarImage = dynamicVariables.$randomAvatarImage.generator();
+
+            expect(avatarImage).to.not.be.undefined;
+            expect(avatarImage).to.not.be.null;
+        });
     });
 });


### PR DESCRIPTION
The URL returned from faker v5.5.3 is not correct for avatars, we are overriding the function to return correct url as per latest faker js version.

We don't want to upgrade the version due to the size of the latest version.