### PR TITLE
Optimize variable replacement RegEx

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,5 +1,6 @@
 unreleased:
   fixed bugs:
+    - GH-1394 Fixed QueryParam normalization regex
     - >-
       Fixed a bug where `PropertyBase.parent` used to return grandparent for
       non-list parent

--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -1,6 +1,7 @@
 var _ = require('../util').lodash,
 
     Property = require('./property').Property,
+    Substitutor = require('../superstring').Substitutor,
     PropertyList = require('./property-list').PropertyList,
 
     E = '',
@@ -12,7 +13,7 @@ var _ = require('../util').lodash,
     REGEX_HASH = /#/g,
     REGEX_EQUALS = /=/g, // eslint-disable-line no-div-regex
     REGEX_AMPERSAND = /&/g,
-    REGEX_EXTRACT_VARS = /{{[^{}]*}}/g,
+    REGEX_EXTRACT_VARS = Substitutor.REGEX_EXTRACT_VARS,
 
     QueryParam,
 

--- a/lib/collection/query-param.js
+++ b/lib/collection/query-param.js
@@ -12,7 +12,7 @@ var _ = require('../util').lodash,
     REGEX_HASH = /#/g,
     REGEX_EQUALS = /=/g, // eslint-disable-line no-div-regex
     REGEX_AMPERSAND = /&/g,
-    REGEX_EXTRACT_VARS = /{{[^{}]*[&#=][^{}]*}}/g,
+    REGEX_EXTRACT_VARS = /{{[^{}]*}}/g,
 
     QueryParam,
 

--- a/lib/superstring/index.js
+++ b/lib/superstring/index.js
@@ -163,7 +163,7 @@ _.assign(Substitutor, /** @lends Substitutor */ {
      * @readOnly
      * @type {RegExp}
      */
-    REGEX_EXTRACT_VARS: /\{\{([^{}]*?)}}/g,
+    REGEX_EXTRACT_VARS: /{{([^{}]*?)}}/g,
 
     /**
      * Defines the number of times the variable substitution mechanism will repeat until all tokens are resolved


### PR DESCRIPTION
The older RegEx `{{[^{}]*[&#=][^{}]*}}` had a possibility of a ReDOS attack due to having polynomial complexity. The new RegEx `{{[^{}]*}}` encodes all variables before parsing unlike the older one which only encoded variables containing special characters.

The complexity can be checked and compared at: https://devina.io/redos-checker

Related PR: https://github.com/postmanlabs/postman-url-encoder/pull/284