### PR TITLE
Fixed a case where url.getPath interface was throwing typeError

### DIFF
--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -285,9 +285,9 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
     getPath (unresolved) {
         // for unresolved case, this is super simple as that is how raw data is stored
         if (unresolved) {
-            const path = this.path ? this.path.join(PATH_SEPARATOR) : '';
-
-            return PATH_SEPARATOR + path;
+            return PATH_SEPARATOR + (
+                this.path ? this.path.join(PATH_SEPARATOR) : E
+            );
         }
 
         var self = this,

--- a/lib/collection/url.js
+++ b/lib/collection/url.js
@@ -285,7 +285,9 @@ _.assign(Url.prototype, /** @lends Url.prototype */ {
     getPath (unresolved) {
         // for unresolved case, this is super simple as that is how raw data is stored
         if (unresolved) {
-            return PATH_SEPARATOR + this.path.join(PATH_SEPARATOR);
+            const path = this.path ? this.path.join(PATH_SEPARATOR) : '';
+
+            return PATH_SEPARATOR + path;
         }
 
         var self = this,

--- a/test/unit/url.test.js
+++ b/test/unit/url.test.js
@@ -1700,6 +1700,12 @@ describe('Url', function () {
                 expect(url.toString()).to.eql('https://postman-echo.com////////get/');
             });
 
+            it('getPath->unresolved should handle empty path properly', function () {
+                var url = new Url('{{host}}');
+
+                expect(url.getPath(true)).to.be.equal('/');
+            });
+
             it('should parse string path properly for JSON representation', function () {
                 var url = new Url({
                     protocol: 'http',


### PR DESCRIPTION
Fixes #1407 

In the `url.getPath` interface when the interface was supposed to return the `unresolved` path, there was an unsafe access being made for `.join` on the `this.path` attribute. 

For urls which doesn't have `/` in them, e.g `{{baseUrl}}` this kind of a url, the `path` attribute is `undefined`. Hence `this.path.join` throws a type error.

The change fixes this unsafe access by defaulting `path` to an empty string when `this.path` is `undefined`.

