### PR TITLE
refactor(): use mime in stead of mime-types so we don't rely on NodeJS built-in modules

### DIFF
--- a/lib/content-info/index.js
+++ b/lib/content-info/index.js
@@ -1,7 +1,7 @@
 var util = require('../util'),
     _ = util.lodash,
     fileType = require('file-type'),
-    mimeType = require('mime-types'),
+    mime = require('mime'),
     mimeFormat = require('mime-format'),
 
     /**
@@ -285,7 +285,7 @@ var util = require('../util'),
             mimeType: normalized.type, // sanitized mime type base
             mimeFormat: normalized.format, // format specific to the type returned
             charset: normalized.charset || CHARSET_UTF8,
-            extension: detectedExtension || mimeType.extension(normalized.source) || E
+            extension: detectedExtension || mime.getExtension(normalized.source) || E
         };
     },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
         "iconv-lite": "0.6.3",
         "liquid-json": "0.3.1",
         "lodash": "4.17.21",
+        "mime": "3.0.0",
         "mime-format": "2.0.2",
-        "mime-types": "2.1.35",
         "postman-url-encoder": "3.0.8",
         "semver": "7.7.1",
         "uuid": "8.3.2"
@@ -6749,6 +6749,19 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/karma/node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/karma/node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -7158,21 +7171,22 @@
       "dev": true
     },
     "node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "dev": true,
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
       "bin": {
         "mime": "cli.js"
       },
       "engines": {
-        "node": ">=4.0.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -7189,6 +7203,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "liquid-json": "0.3.1",
     "lodash": "4.17.21",
     "mime-format": "2.0.2",
-    "mime-types": "2.1.35",
+    "mime": "3.0.0",
     "postman-url-encoder": "3.0.8",
     "semver": "7.7.1",
     "uuid": "8.3.2"


### PR DESCRIPTION
This PR replaces `mime-types` with `mime@3` in order to be able to load `postman-collection` in the browser without polyfills.

`mime-types` has a dependency on `node:path`: https://github.com/jshttp/mime-types/blob/master/index.js#L16 