### PR TITLE
Add `requests` key to event scripts

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+unreleased:
+  new features:
+    - GH-1418 Add new key `requests` to Script
+
 5.1.1:
   date: 2025-09-05
   chores:

--- a/examples/collection-v2.json
+++ b/examples/collection-v2.json
@@ -44,9 +44,11 @@
                 "type": "text/javascript",
                 "exec": [
                   "const package1 = pm.require(\"package1\");",
-                  "console.log(\"hello\", package1);"
+                  "console.log(\"hello\", package1);",
+                  "const response = await pm.execution.runRequest(\"request-id-1\");"
                 ],
-                "packages": { "package1": { "id": "script-package-1" } }
+                "packages": { "package1": { "id": "script-package-1" } },
+                "requests": { "request-id-1": { "id": "request-id-1", "name": "collection request" } }
             }
         },
         {
@@ -55,9 +57,11 @@
                 "type": "text/javascript",
                 "exec": [
                   "const package1 = pm.require(\"package1\");",
-                  "console.log(\"hello\", package1);"
+                  "console.log(\"hello\", package1);",
+                  "const response = await pm.execution.runRequest(\"request-id-1\");"
                 ],
-                "packages": { "package1": { "id":"script-package-1" } }
+                "packages": { "package1": { "id":"script-package-1" } },
+                "requests": { "request-id-1": { "id": "request-id-1", "name": "collection request" } }
             }
         }
     ],

--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -12,6 +12,12 @@ var _ = require('../util').lodash,
  * @typedef {Object.<string, { id: string }>} Packages
  */
 
+/**
+ * A map of IDs to the names, location and other metadata and of the requests they refer to
+ *
+ * @typedef {{ [id: string]: { name: string } & Record<string, any>}} Requests
+ */
+
 _.inherit((
 
     /**
@@ -76,6 +82,13 @@ _.assign(Script.prototype, /** @lends Script.prototype */ {
          * @type {Packages}
          */
         this.packages = options.packages;
+
+        /**
+         * The requests referenced by the script
+         *
+         * @type {Requests}
+         */
+        this.requests = options.requests || {};
 
         _.has(options, 'src') && (
 

--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -16,7 +16,7 @@ var _ = require('../util').lodash,
  * A map of IDs to the names, location and other metadata and of the requests they refer to
  *
  * @typedef {Object.<string, {
- *  id: string, name: string, location: string[], workspace: string, collection: string
+ *  location: string[], workspace: string, collection: string
  * }>} Requests
  */
 

--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -15,7 +15,9 @@ var _ = require('../util').lodash,
 /**
  * A map of IDs to the names, location and other metadata and of the requests they refer to
  *
- * @typedef {Object.<string, { id: string, name: string }>} Requests
+ * @typedef {Object.<string, {
+ *  id: string, name: string, location: string[], workspace: string, collection: string
+ * }>} Requests
  */
 
 _.inherit((

--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -15,7 +15,7 @@ var _ = require('../util').lodash,
 /**
  * A map of IDs to the names, location and other metadata and of the requests they refer to
  *
- * @typedef {{ [id: string]: { name: string } & Record<string, any>}} Requests
+ * @typedef {Object.<string, { id: string, name: string }>} Requests
  */
 
 _.inherit((
@@ -62,6 +62,7 @@ _.assign(Script.prototype, /** @lends Script.prototype */ {
      * @param {String} [options.src] Script source url
      * @param {String[]|String} [options.exec] Script to execute
      * @param {Packages} [options.packages] Packages required by the script
+     * @param {Requests} [options.requests] Requests referenced by the script
      */
     update: function (options) {
         // no splitting is being done here, as string scripts are split right before assignment below anyway

--- a/lib/collection/script.js
+++ b/lib/collection/script.js
@@ -89,7 +89,7 @@ _.assign(Script.prototype, /** @lends Script.prototype */ {
          *
          * @type {Requests}
          */
-        this.requests = options.requests || {};
+        this.requests = options.requests;
 
         _.has(options, 'src') && (
 

--- a/test/unit/event.test.js
+++ b/test/unit/event.test.js
@@ -167,6 +167,27 @@ describe('Event', function () {
 
             expect(afterJSON.script).to.not.have.property('packages');
         });
+
+        it('should not add requests key if not present', function () {
+            var rawEvent = {
+                    listen: 'test',
+                    id: 'my-global-script-1',
+                    script: {
+                        type: 'text/javascript',
+                        exec: 'console.log("hello");'
+                    }
+                },
+                event = new Event(rawEvent),
+                beforeJSON = event.toJSON(),
+                afterJSON;
+
+            expect(beforeJSON.script).to.not.have.property('requests');
+
+            event.update({ script: { exec: 'console.log("updated");' } });
+            afterJSON = event.toJSON();
+
+            expect(afterJSON.script).to.not.have.property('requests');
+        });
     });
 
     describe('isEvent', function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2182,7 +2182,7 @@ declare module "postman-collection" {
      * A map of IDs to the names, location and other metadata and of the requests they refer to
      */
     export type Requests = {
-        [key: string]: { id: string; name: string; };
+        [key: string]: { id: string; name: string; location: string[]; workspace: string; collection: string; };
     };
 
     /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2182,7 +2182,7 @@ declare module "postman-collection" {
      * A map of IDs to the names, location and other metadata and of the requests they refer to
      */
     export type Requests = {
-        [key: string]: { id: string; name: string; location: string[]; workspace: string; collection: string; };
+        [key: string]: { location: string[]; workspace: string; collection: string; };
     };
 
     /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-collection 4.4.1
+// Type definitions for postman-collection 5.1.1
 // Project: https://github.com/postmanlabs/postman-collection
 // Definitions by: PostmanLabs
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -1554,6 +1554,7 @@ declare module "postman-collection" {
          *     "match": "http+https://example.com/*",
          *     "host": "proxy.com",
          *     "port": "8080",
+         *     "protocol": "http",
          *     "tunnel": true,
          *     "disabled": false,
          *     "authenticate": true,
@@ -1563,6 +1564,7 @@ declare module "postman-collection" {
          * @property [match = 'http+https://*\/*'] - The match for which the proxy needs to be configured.
          * @property [host = ''] - The proxy server url.
          * @property [port = 8080] - The proxy server port number.
+         * @property [protocol = 'http'] - The proxy protocol. Allowed: 'http', 'socks4', 'socks4a', 'socks5', 'socks5h'.
          * @property [tunnel = false] - The tunneling option for the proxy request.
          * @property [disabled = false] - To override the proxy for the particular url, you need to provide true.
          * @property [authenticate = false] - To enable authentication for the proxy, you need to provide true.
@@ -1573,6 +1575,7 @@ declare module "postman-collection" {
             match?: string;
             host?: string;
             port?: number;
+            protocol?: string;
             tunnel?: boolean;
             disabled?: boolean;
             authenticate?: boolean;
@@ -1592,6 +1595,7 @@ declare module "postman-collection" {
      *          host: 'proxy.com',
      *          match: 'http+https://example.com/*',
      *          port: 8080,
+     *          protocol: 'http',
      *          tunnel: true,
      *          disabled: false,
      *          authenticate: true,
@@ -1634,6 +1638,10 @@ declare module "postman-collection" {
          * Proxy auth password
          */
         static password: string;
+        /**
+         * The proxy protocol type. Allowed values: 'http', 'socks4','socks4a', 'socks5', 'socks5h'.
+         */
+        static protocol: string;
         /**
          * Updates the properties of the proxy object based on the options provided.
          * @param options - The proxy object structure.
@@ -2171,6 +2179,13 @@ declare module "postman-collection" {
     };
 
     /**
+     * A map of IDs to the names, location and other metadata and of the requests they refer to
+     */
+    export type Requests = {
+        [key: string]: { id: string; name: string; };
+    };
+
+    /**
      * Postman scripts that are executed upon events on a collection  / request such as test and pre request.
      * @param options - -
      */
@@ -2187,18 +2202,24 @@ declare module "postman-collection" {
          * @param [options.src] - Script source url
          * @param [options.exec] - Script to execute
          * @param [options.packages] - Packages required by the script
+         * @param [options.requests] - Requests referenced by the script
          */
         update(options?: {
             type?: string;
             src?: string;
             exec?: string[] | string;
             packages?: Packages;
+            requests?: Requests;
         }): void;
         type: string;
         /**
          * The packages required by the script
          */
         packages: Packages;
+        /**
+         * The requests referenced by the script
+         */
+        requests: Requests;
         src: Url;
         exec: string[];
         /**


### PR DESCRIPTION
Adds a `requests` key to collection request events.

This allows for quick lookup and retention of requests referenced inside a script.