### PR TITLE
Add `secret` and `source` property to Variable

### DIFF
--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,6 +1,7 @@
 unreleased:
   new features:
     - Add `secret` property to `Variable`
+    - Add ability to set secret variables using `VariableScope.set()` method
 
 5.2.1:
   date: 2026-02-04

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -1,3 +1,7 @@
+unreleased:
+  new features:
+    - Add `secret` property to `Variable`
+
 5.2.1:
   date: 2026-02-04
   chores:

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -2,6 +2,7 @@ unreleased:
   new features:
     - Add `secret` property to `Variable`
     - Add ability to set secret variables using `VariableScope.set()` method
+    - Add ability to track secret variables in mutations
 
 5.2.1:
   date: 2026-02-04

--- a/CHANGELOG.yaml
+++ b/CHANGELOG.yaml
@@ -3,6 +3,7 @@ unreleased:
     - Add `secret` property to `Variable`
     - Add ability to set secret variables using `VariableScope.set()` method
     - Add ability to track secret variables in mutations
+    - Add `source` property in variables to resolve secrets
 
 5.2.1:
   date: 2026-02-04

--- a/lib/collection/mutation-tracker.js
+++ b/lib/collection/mutation-tracker.js
@@ -21,7 +21,8 @@ var _ = require('../util').lodash,
      * @returns {Boolean}
      */
     isPrimitiveMutation = function (mutation) {
-        return mutation && mutation.length <= 2;
+        // Primitive mutations can have 1-3 elements: [key], [key, value], [key, value, metadata]
+        return mutation && mutation.length <= 3;
     },
 
     /**
@@ -53,10 +54,14 @@ var _ = require('../util').lodash,
  * This captures the instruction and the parameters of the instruction so that it can be replayed on a different object.
  * Mutations can be any change on an object. For example setting a key or unsetting a key.
  *
- * For example, the mutation to set `name` on an object to 'Bruce Wayne' would look like ['name', 'Bruce Wayne']. Where
- * the first item is the key path and second item is the value. To add a property `punchLine` to the object it would be
- * the same as updating the property i.e. ['punchLine', 'I\'m Batman']. To remove a property `age` the mutation would
- * look like ['age'].
+ * Mutation formats:
+ * - SET without metadata: ['key', 'value']
+ * - SET with metadata: ['key', 'value', { metadata }]
+ * - UNSET: ['key']
+ *
+ * For example, the mutation to set `name` on an object to 'Bruce Wayne' would look like ['name', 'Bruce Wayne'].
+ * To set a variable with secret flag: ['password', 'secret123', { secret: true }].
+ * To remove a property `age` the mutation would look like ['age'].
  *
  * This format of representing changes is derived from
  * {@link http://json-delta.readthedocs.io/en/latest/philosophy.html}.
@@ -65,6 +70,10 @@ var _ = require('../util').lodash,
  * instruction. For more complex mutation the instruction would have to be explicitly stated.
  *
  * @typedef {Array} MutationTracker.mutation
+ * @example
+ * ['password', 'secret123', { secret: true }]  // SET with metadata
+ * ['userId', '42']                             // SET without metadata
+ * ['tempKey']                                  // UNSET
  */
 
 /**

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -243,8 +243,8 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
             options = { type: options };
         }
 
-        _.has(options, 'type') && _.isString(options.type) && (update.type = options.type);
-        _.has(options, 'secret') && _.isBoolean(options.secret) && (update.secret = options.secret);
+        _.isString(options.type) && (update.type = options.type);
+        _.isBoolean(options.secret) && (update.secret = options.secret);
 
         // If a variable by the name key exists, update it's value and return.
         // @note adds new variable if existing is disabled. Disabled variables are not updated.

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -16,6 +16,16 @@ var _ = require('../util').lodash,
         UNSET: 'unset'
     },
 
+    /**
+     * Properties that should be tracked in mutations when set on variables.
+     * Add new properties here to have them automatically tracked and replayed.
+     *
+     * @private
+     * @constant
+     * @type {Array}
+     */
+    TRACKED_PROPERTIES = ['secret'],
+
     VariableScope;
 
 /**
@@ -243,8 +253,8 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
             options = { type: options };
         }
 
-        _.isString(options.type) && (update.type = options.type);
-        _.isBoolean(options.secret) && (update.secret = options.secret);
+        options && _.isString(options.type) && (update.type = options.type);
+        options && _.isBoolean(options.secret) && (update.secret = options.secret);
 
         // If a variable by the name key exists, update it's value and return.
         // @note adds new variable if existing is disabled. Disabled variables are not updated.
@@ -256,7 +266,10 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
         }
 
         // track the change if mutation tracking is enabled
-        this._postman_enableTracking && this.mutations.track(MUTATIONS.SET, key, value);
+        // include tracked properties in mutations so they are preserved during replay
+        if (this._postman_enableTracking) {
+            this.mutations.track(MUTATIONS.SET, key, value, _.pick(options, TRACKED_PROPERTIES));
+        }
     },
 
     /**
@@ -377,13 +390,14 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      * @param {String} instruction Instruction identifying the type of the mutation, e.g. `set`, `unset`
      * @param {String} key -
      * @param {*} value -
+     * @param {Object} [metadata] - Optional metadata object (e.g., { secret: true })
      */
-    applyMutation: function (instruction, key, value) {
+    applyMutation: function (instruction, key, value, metadata) {
         // we know that `set` and `unset` are the only supported instructions
         // and we know the parameter signature of both is the same as the items in a mutation
         /* istanbul ignore else */
         if (this[instruction]) {
-            this[instruction](key, value);
+            this[instruction](key, value, metadata);
         }
     },
 

--- a/lib/collection/variable-scope.js
+++ b/lib/collection/variable-scope.js
@@ -226,16 +226,25 @@ _.assign(VariableScope.prototype, /** @lends VariableScope.prototype */ {
      *
      * @param {String} key - The name of the variable to set.
      * @param {*} value - The value of the variable to be set.
-     * @param {Variable.types} [type] - Optionally, the value of the variable can be set to a type
+     * @param {Variable.types|Object} [options] - Optional configuration for the variable.
+     * Can be a string (e.g., 'string', 'number') or an object with properties:
+     * - `type` {String} - The variable type
+     * - `secret` {Boolean} - Whether the variable contains secret/sensitive data
      */
-    set: function (key, value, type) {
+    set: function (key, value, options) {
         const _key = (this.prefix || '') + key;
         var variable = this.values.oneNormalizedVariable(_key),
 
             // create an object that will be used as setter
             update = { key: _key, value: value };
 
-        _.isString(type) && (update.type = type);
+        // handle third parameter - can be a string (type) or object ({ type, secret })
+        if (_.isString(options)) {
+            options = { type: options };
+        }
+
+        _.has(options, 'type') && _.isString(options.type) && (update.type = options.type);
+        _.has(options, 'secret') && _.isBoolean(options.secret) && (update.secret = options.secret);
 
         // If a variable by the name key exists, update it's value and return.
         // @note adds new variable if existing is disabled. Disabled variables are not updated.

--- a/lib/collection/variable.js
+++ b/lib/collection/variable.js
@@ -9,7 +9,89 @@ var _ = require('../util').lodash,
     Variable;
 
 /**
- * The object representation of a Variable consists the variable value and type. It also optionally includes the `id`
+ * Postman integration - local vault.
+ *
+ * @typedef {Object} Variable.sourcePostmanLocal
+ * @property {"postman"} provider
+ * @property {Object} postman
+ * @property {"local"} postman.type
+ * @property {string} postman.secretId
+ * @property {string=} [postman.vaultId]
+ */
+
+/**
+ * Postman integration - cloud vault.
+ *
+ * @typedef {Object} Variable.sourcePostmanCloud
+ * @property {"postman"} provider
+ * @property {Object} postman
+ * @property {"cloud"} postman.type
+ * @property {string} postman.secretId
+ * @property {string} postman.vaultId
+ */
+
+/**
+ * @typedef {Variable.sourcePostmanLocal|Variable.sourcePostmanCloud} Variable.sourcePostman
+ */
+
+/**
+ * Azure Key Vault integration.
+ *
+ * @typedef {Object} Variable.sourceAzure
+ * @property {"azure"} provider
+ * @property {Object} azure
+ * @property {string} azure.secretId
+ */
+
+/**
+ * 1Password integration.
+ *
+ * @typedef {Object} Variable.sourceOnePassword
+ * @property {"1password"} provider
+ * @property {Object} 1password
+ * @property {string} 1password.secretReference
+ */
+
+/**
+ * AWS Secrets Manager integration.
+ *
+ * @typedef {Object} Variable.sourceAws
+ * @property {"aws"} provider
+ * @property {Object} aws
+ * @property {string} aws.secretArn
+ * @property {string=} [aws.roleArn]
+ * @property {string=} [aws.version]
+ * @property {"plaintext"|"json"=} [aws.format]
+ */
+
+/**
+ * HashiCorp Vault integration.
+ *
+ * @typedef {Object} Variable.sourceHashiCorp
+ * @property {"hashicorp"} provider
+ * @property {Object} hashicorp
+ * @property {string} hashicorp.engine
+ * @property {string} hashicorp.path
+ * @property {string} hashicorp.key
+ * @property {string=} [hashicorp.version]
+ */
+
+/**
+ * Source object for external secret resolution. The structure depends on the `provider` field.
+ * Resolver lookup is keyed by `provider`
+ * (for example: "postman", "azure", "1password", "aws", "hashicorp").
+ *
+ * @typedef {
+ *   Variable.sourcePostman |
+ *   Variable.sourceAzure |
+ *   Variable.sourceOnePassword |
+ *   Variable.sourceAws |
+ *   Variable.sourceHashiCorp
+ * } Variable.source
+ */
+
+/**
+ * The object representation of a Variable consists of the variable value and type. It may also include the `id`
  * and a friendly `name` of the variable. The `id` and the `name` of a variable is usually managed and used when a
  * variable is made part of a {@link VariableList} instance.
  *
@@ -20,13 +102,31 @@ var _ = require('../util').lodash,
  * @property {Boolean=} [system] - Indicates whether this is a system variable.
  * @property {Boolean=} [secret] - Indicates whether this variable contains secret/sensitive data.
  * @property {Boolean=} [disabled] - Indicates whether this variable is disabled.
+ * @property {Variable.source=} [source] - Optional source object for external secret resolution. Contains metadata
+ * on how to resolve the variable value from an external source. The structure depends on the source `provider` field.
  *
- * @example
+ * @example Default variable
  * {
  *     "id": "my-var-1",
  *     "name": "MyFirstVariable",
  *     "value": "Hello World",
  *     "type": "string"
+ * }
+ *
+ * @example Secret variable - Postman local vault
+ * {
+ *     "id": "my-secret-var",
+ *     "key": "apiKey",
+ *     "value": "",
+ *     "type": "secret",
+ *     "source": {
+ *         "provider": "postman",
+ *         "postman": {
+ *             "type": "local",
+ *             "secretId": "ID_OF_THE_SECRET"
+ *             "vaultId": "ID_OF_THE_VAULT"
+ *         }
+ *     }
  * }
  */
 _.inherit((
@@ -58,7 +158,14 @@ _.inherit((
             /**
              * @type {*}
              */
-            value: undefined
+            value: undefined,
+
+            /**
+             * Optional source object for external secret resolution.
+             *
+             * @type {Variable.source}
+             */
+            source: undefined
         });
 
         if (!_.isNil(definition)) {
@@ -212,6 +319,7 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
         _.has(options, 'secret') && (this.secret = options.secret);
         _.has(options, 'disabled') && (this.disabled = options.disabled);
         _.has(options, 'description') && (this.describe(options.description));
+        _.has(options, 'source') && (this.source = options.source);
     }
 });
 

--- a/lib/collection/variable.js
+++ b/lib/collection/variable.js
@@ -17,6 +17,9 @@ var _ = require('../util').lodash,
  * @property {*=} [value] - The value of the variable that will be stored and will be typecast to the `type`
  * set in the variable or passed along in this parameter.
  * @property {String=} [type] - The type of this variable from the list of types defined at {@link Variable.types}.
+ * @property {Boolean=} [system] - Indicates whether this is a system variable.
+ * @property {Boolean=} [secret] - Indicates whether this variable contains secret/sensitive data.
+ * @property {Boolean=} [disabled] - Indicates whether this variable is disabled.
  *
  * @example
  * {
@@ -206,6 +209,7 @@ _.assign(Variable.prototype, /** @lends Variable.prototype */ {
         _.has(options, 'type') && this.valueType(options.type, _.has(options, 'value'));
         _.has(options, 'value') && this.set(options.value);
         _.has(options, 'system') && (this.system = options.system);
+        _.has(options, 'secret') && (this.secret = options.secret);
         _.has(options, 'disabled') && (this.disabled = options.disabled);
         _.has(options, 'description') && (this.describe(options.description));
     }

--- a/test/unit/mutation-tracker.test.js
+++ b/test/unit/mutation-tracker.test.js
@@ -163,10 +163,18 @@ describe('MutationTracker', function () {
         it('should not track invalid mutation format', function () {
             var tracker = new MutationTracker();
 
-            // expected signature is two parameters
-            tracker.track('set', 'foo', 'bar', 'baz');
+            tracker.track('set', 'foo', 'bar', 'baz', 'qux');
 
             expect(tracker.count()).to.eql(0);
+        });
+
+        it('should track mutations with metadata (3 parameters)', function () {
+            var tracker = new MutationTracker();
+
+            // new format supports three parameters: key, value, metadata
+            tracker.track('set', 'foo', 'bar', { secret: true });
+
+            expect(tracker.count()).to.eql(1);
         });
 
         it('should not track mutation with no instruction', function () {

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -1532,6 +1532,59 @@ describe('VariableScope', function () {
             expect(scope1.values).to.eql(scope2.values);
         });
 
+        it('should track and replay secret variables', function () {
+            var initialState = {
+                    values: [{
+                        key: 'foo',
+                        value: 'foo'
+                    }]
+                },
+                scope1 = new VariableScope(initialState),
+                scope2 = new VariableScope(initialState),
+                variable1,
+                variable2;
+
+            scope1.enableTracking();
+
+            // set a secret variable
+            scope1.set('password', 'secret123', { secret: true });
+            // set a variable with type and secret (only secret is tracked)
+            scope1.set('apiKey', '12345', { type: 'string', secret: true });
+            // set a regular variable (no secret)
+            scope1.set('userId', '42', { type: 'number' });
+
+            // replay mutations on a different object
+            scope1.mutations.applyOn(scope2);
+
+            // verify password has secret flag
+            variable1 = scope1.values.oneNormalizedVariable('password');
+            variable2 = scope2.values.oneNormalizedVariable('password');
+            expect(variable1.secret).to.be.true;
+            expect(variable2.secret).to.be.true;
+            expect(variable1.get()).to.equal('secret123');
+            expect(variable2.get()).to.equal('secret123');
+
+            // verify apiKey has secret (but type is not preserved via mutation)
+            variable1 = scope1.values.oneNormalizedVariable('apiKey');
+            variable2 = scope2.values.oneNormalizedVariable('apiKey');
+            expect(variable1.secret).to.be.true;
+            expect(variable2.secret).to.be.true;
+            expect(variable1.type).to.equal('string');
+            // type is not tracked in mutations, so scope2 will have default 'any' type
+            expect(variable2.type).to.equal('any');
+            expect(variable1.get()).to.equal('12345');
+            expect(variable2.get()).to.equal('12345');
+
+            // verify userId has no secret
+            variable1 = scope1.values.oneNormalizedVariable('userId');
+            variable2 = scope2.values.oneNormalizedVariable('userId');
+            expect(variable1.secret).to.be.undefined;
+            expect(variable2.secret).to.be.undefined;
+            expect(variable1.get()).to.equal(42);
+            // type is not tracked, so scope2 gets the raw value without type casting
+            expect(variable2.get()).to.equal('42');
+        });
+
         it('should be serialized', function () {
             var scope = new VariableScope(),
                 serialized,

--- a/test/unit/variable-scope.test.js
+++ b/test/unit/variable-scope.test.js
@@ -530,6 +530,74 @@ describe('VariableScope', function () {
                 scope.set('var-1', 'new-var-1-value');
                 expect(scope.get('var-1')).to.equal('new-var-1-value');
             });
+
+            it('should set secret property when passed as object', function () {
+                var scope = new VariableScope({
+                        values: [{
+                            key: 'var-1',
+                            value: 'var-1-value'
+                        }]
+                    }),
+                    variable;
+
+                scope.set('var-1', 'secret-value', { secret: true });
+
+                variable = scope.values.oneNormalizedVariable('var-1');
+
+                expect(variable.get()).to.equal('secret-value');
+                expect(variable.secret).to.be.true;
+            });
+
+            it('should set secret and type when passed as object', function () {
+                var scope = new VariableScope({
+                        values: [{
+                            key: 'var-1',
+                            value: 'var-1-value'
+                        }]
+                    }),
+                    variable;
+
+                scope.set('var-1', '3.142', { type: 'number', secret: true });
+
+                variable = scope.values.oneNormalizedVariable('var-1');
+
+                expect(variable.get()).to.equal(3.142);
+                expect(variable.secret).to.be.true;
+            });
+
+            it('should create new secret variable when passed as object', function () {
+                var scope = new VariableScope({
+                        values: [{
+                            key: 'var-1',
+                            value: 'var-1-value'
+                        }]
+                    }),
+                    variable;
+
+                scope.set('secret-var', 'secret-value', { secret: true });
+
+                variable = scope.values.oneNormalizedVariable('secret-var');
+
+                expect(variable.get()).to.equal('secret-value');
+                expect(variable.secret).to.be.true;
+            });
+
+            it('should maintain backward compatibility with string type parameter', function () {
+                var scope = new VariableScope({
+                        values: [{
+                            key: 'var-1',
+                            value: 'var-1-value'
+                        }]
+                    }),
+                    variable;
+
+                scope.set('var-1', 3.142, 'number');
+
+                variable = scope.values.oneNormalizedVariable('var-1');
+
+                expect(variable.get()).to.equal(3.142);
+                expect(variable.secret).to.be.undefined;
+            });
         });
 
         describe('unset', function () {

--- a/test/unit/variable.test.js
+++ b/test/unit/variable.test.js
@@ -40,6 +40,35 @@ describe('Variable', function () {
         expect(v.system).to.be.false;
     });
 
+    it('should initialize variable with correct secret value', function () {
+        let v = new Variable();
+
+        expect(v.secret).to.be.undefined;
+
+        v = new Variable({
+            secret: true
+        });
+        expect(v.secret).to.be.true;
+
+        v = new Variable({
+            secret: false
+        });
+        expect(v.secret).to.be.false;
+    });
+
+    it('should update the secret property of a variable', function () {
+        let v = new Variable();
+
+        v.update({ secret: true });
+        expect(v.secret).to.be.true;
+
+        v = new Variable({
+            secret: true
+        });
+        v.update({ secret: false });
+        expect(v.secret).to.be.false;
+    });
+
     it('should update the description property of a variable', function () {
         let v = new Variable();
 

--- a/test/unit/variable.test.js
+++ b/test/unit/variable.test.js
@@ -69,6 +69,47 @@ describe('Variable', function () {
         expect(v.secret).to.be.false;
     });
 
+    it('should initialize variable with correct source value', function () {
+        let v = new Variable();
+
+        expect(v.source).to.be.undefined;
+
+        v = new Variable({
+            source: {
+                provider: 'postman',
+                postman: {
+                    type: 'local',
+                    secretId: '123',
+                    vaultId: '456'
+                }
+            }
+        });
+        expect(v.source).to.deep.include({
+            provider: 'postman',
+            postman: {
+                type: 'local',
+                secretId: '123',
+                vaultId: '456'
+            }
+        });
+    });
+
+    it('should update the source property of a variable', function () {
+        let v = new Variable();
+
+        expect(v.source).to.be.undefined;
+
+        v.update({ source: { provider: 'postman', postman: { type: 'local', secretId: '123', vaultId: '456' } } });
+        expect(v.source).to.deep.include({
+            provider: 'postman',
+            postman: {
+                type: 'local',
+                secretId: '123',
+                vaultId: '456'
+            }
+        });
+    });
+
     it('should update the description property of a variable', function () {
         let v = new Variable();
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-collection 5.1.1
+// Type definitions for postman-collection 5.2.1
 // Project: https://github.com/postmanlabs/postman-collection
 // Definitions by: PostmanLabs
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -2478,10 +2478,16 @@ declare module "postman-collection" {
          * @property [value] - The value of the variable that will be stored and will be typecast to the `type`
          * set in the variable or passed along in this parameter.
          * @property [type] - The type of this variable from the list of types defined at Variable.types.
+         * @property [system] - Indicates whether this is a system variable.
+         * @property [secret] - Indicates whether this variable contains secret/sensitive data.
+         * @property [disabled] - Indicates whether this variable is disabled.
          */
         type definition = {
             value?: any;
             type?: string;
+            system?: boolean;
+            secret?: boolean;
+            disabled?: boolean;
         };
         /**
          * The possible supported types of a variable is defined here. The keys defined here are the possible values of

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2476,15 +2476,103 @@ declare module "postman-collection" {
 
     export namespace Variable {
         /**
-         * The object representation of a Variable consists the variable value and type. It also optionally includes the `id`
+         * Postman integration - local vault.
+         */
+        type sourcePostmanLocal = {
+            provider: "postman";
+            postman: {
+                type: "local";
+                secretId: string;
+                vaultId?: string;
+            };
+        };
+        /**
+         * Postman integration - cloud vault.
+         */
+        type sourcePostmanCloud = {
+            provider: "postman";
+            postman: {
+                type: "cloud";
+                secretId: string;
+                vaultId: string;
+            };
+        };
+        type sourcePostman = Variable.sourcePostmanLocal | Variable.sourcePostmanCloud;
+        /**
+         * Azure Key Vault integration.
+         */
+        type sourceAzure = {
+            provider: "azure";
+            azure: {
+                secretId: string;
+            };
+        };
+        /**
+         * 1Password integration.
+         */
+        type sourceOnePassword = {
+            provider: "1password";
+            "1password": {
+                secretReference: string;
+            };
+        };
+        /**
+         * AWS Secrets Manager integration.
+         */
+        type sourceAws = {
+            provider: "aws";
+            aws: {
+                secretArn: string;
+                roleArn?: string;
+                version?: string;
+                format?: "plaintext" | "json";
+            };
+        };
+        /**
+         * HashiCorp Vault integration.
+         */
+        type sourceHashiCorp = {
+            provider: "hashicorp";
+            hashicorp: {
+                engine: string;
+                path: string;
+                key: string;
+                version?: string;
+            };
+        };
+        /**
+         * Source object for external secret resolution. The structure depends on the `provider` field.
+         * Resolver lookup is keyed by `provider`
+         * (for example: "postman", "azure", "1password", "aws", "hashicorp").
+         */
+        type source = Variable.sourcePostman | Variable.sourceAzure | Variable.sourceOnePassword | Variable.sourceAws | Variable.sourceHashiCorp;
+        /**
+         * The object representation of a Variable consists of the variable value and type. It may also include the `id`
          * and a friendly `name` of the variable. The `id` and the `name` of a variable is usually managed and used when a
          * variable is made part of a VariableList instance.
          * @example
+         * Default variable
          * {
          *     "id": "my-var-1",
          *     "name": "MyFirstVariable",
          *     "value": "Hello World",
          *     "type": "string"
+         * }
+         * @example
+         * Secret variable - Postman local vault
+         * {
+         *     "id": "my-secret-var",
+         *     "key": "apiKey",
+         *     "value": "",
+         *     "type": "secret",
+         *     "source": {
+         *         "provider": "postman",
+         *         "postman": {
+         *             "type": "local",
+         *             "secretId": "ID_OF_THE_SECRET"
+         *             "vaultId": "ID_OF_THE_VAULT"
+         *         }
+         *     }
          * }
          * @property [value] - The value of the variable that will be stored and will be typecast to the `type`
          * set in the variable or passed along in this parameter.
@@ -2492,6 +2580,8 @@ declare module "postman-collection" {
          * @property [system] - Indicates whether this is a system variable.
          * @property [secret] - Indicates whether this variable contains secret/sensitive data.
          * @property [disabled] - Indicates whether this variable is disabled.
+         * @property [source] - Optional source object for external secret resolution. Contains metadata
+         * on how to resolve the variable value from an external source. The structure depends on the source `provider` field.
          */
         type definition = {
             value?: any;
@@ -2499,6 +2589,7 @@ declare module "postman-collection" {
             system?: boolean;
             secret?: boolean;
             disabled?: boolean;
+            source?: Variable.source;
         };
         /**
          * The possible supported types of a variable is defined here. The keys defined here are the possible values of
@@ -2550,6 +2641,10 @@ declare module "postman-collection" {
         constructor(definition?: Variable.definition);
         type: Variable.types;
         value: any;
+        /**
+         * Optional source object for external secret resolution.
+         */
+        source: Variable.source;
         /**
          * The name of the variable. This is used for referencing this variable from other locations and scripts
          */
@@ -2722,7 +2817,7 @@ declare module "postman-collection" {
          */
         static readonly PROTOCOL_DELIMITER: string;
         /**
-         * String representation for matching all urls - 
+         * String representation for matching all urls -
          */
         static readonly MATCH_ALL_URLS: string;
     }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1122,16 +1122,24 @@ declare module "postman-collection" {
          * This captures the instruction and the parameters of the instruction so that it can be replayed on a different object.
          * Mutations can be any change on an object. For example setting a key or unsetting a key.
          *
-         * For example, the mutation to set `name` on an object to 'Bruce Wayne' would look like ['name', 'Bruce Wayne']. Where
-         * the first item is the key path and second item is the value. To add a property `punchLine` to the object it would be
-         * the same as updating the property i.e. ['punchLine', 'I\'m Batman']. To remove a property `age` the mutation would
-         * look like ['age'].
+         * Mutation formats:
+         * - SET without metadata: ['key', 'value']
+         * - SET with metadata: ['key', 'value', { metadata }]
+         * - UNSET: ['key']
+         *
+         * For example, the mutation to set `name` on an object to 'Bruce Wayne' would look like ['name', 'Bruce Wayne'].
+         * To set a variable with secret flag: ['password', 'secret123', { secret: true }].
+         * To remove a property `age` the mutation would look like ['age'].
          *
          * This format of representing changes is derived from
          * http://json-delta.readthedocs.io/en/latest/philosophy.html.
          *
          * The `set` and `unset` are primitive instructions and can be derived from the mutation without explicitly stating the
          * instruction. For more complex mutation the instruction would have to be explicitly stated.
+         * @example
+         * ['password', 'secret123', { secret: true }]  // SET with metadata
+         * ['userId', '42']                             // SET without metadata
+         * ['tempKey']                                  // UNSET
          */
         type mutation = any[];
         /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2424,9 +2424,12 @@ declare module "postman-collection" {
          * Creates a new variable, or updates an existing one.
          * @param key - The name of the variable to set.
          * @param value - The value of the variable to be set.
-         * @param [type] - Optionally, the value of the variable can be set to a type
+         * @param [options] - Optional configuration for the variable.
+         * Can be a string (e.g., 'string', 'number') or an object with properties:
+         * - `type` {String} - The variable type
+         * - `secret` {Boolean} - Whether the variable contains secret/sensitive data
          */
-        set(key: string, value: any, type?: Variable.types): void;
+        set(key: string, value: any, options?: Variable.types | any): void;
         /**
          * Removes the variable with the specified name.
          * @param key - -


### PR DESCRIPTION
- Introduces a new `secret` boolean property to mark variables as containing sensitive data. 
- Enhances `VariableScope.set()` to support setting the secret property via object configuration.
- Introduce `source` propertry in variables to resolve secrets