### PR TITLE
feat: parse and preserve custom HTTP methods in example responses

### DIFF
--- a/lib/collection/item.js
+++ b/lib/collection/item.js
@@ -130,7 +130,7 @@ _.inherit((
              *
              * @type {PropertyList<Response>}
              */
-            responses: new PropertyList(Response, this, definition && definition.response),
+            responses: new PropertyList(Response, this, definition && (definition.responses || definition.response)),
 
             /**
              * Events are a set of of {@link Script}s that are executed when certain activities are triggered on an

--- a/lib/collection/response.js
+++ b/lib/collection/response.js
@@ -174,6 +174,8 @@ var util = require('../util'),
  * @property {String} [body]
  * @property {Buffer|ArrayBuffer} [stream]
  * @property {Number} responseTime
+ * @property {Request.definition} [originalRequest]
+ * @property {Request.definition} [request]
  *
  * @todo pluralise `header`, `cookie`
  */
@@ -210,7 +212,8 @@ _.assign(Response.prototype, /** @lends Response.prototype */ {
             /**
              * @type {Request}
              */
-            originalRequest: options.originalRequest ? new Request(options.originalRequest) : undefined,
+            originalRequest: (options.originalRequest || options.request) ?
+                new Request(options.originalRequest || options.request) : undefined,
 
             /**
              * @type {String}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "mime": "3.0.0",
         "mime-format": "2.0.2",
         "postman-url-encoder": "3.0.8",
-        "semver": "7.7.1",
+        "semver": "7.8.5",
         "uuid": "8.3.2"
       },
       "devDependencies": {
@@ -44,7 +44,7 @@
         "karma-chrome-launcher": "^3.2.0",
         "karma-mocha": "^2.0.1",
         "karma-mocha-reporter": "^2.2.5",
-        "mocha": "^11.1.0",
+        "mocha": "^11.8.0",
         "nyc": "^17.1.0",
         "parse-gitignore": "^2.0.0",
         "postman-jsdoc-theme": "^0.0.3",
@@ -1265,15 +1265,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ansi-colors": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
-      "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/ansi-regex": {
@@ -3341,10 +3332,11 @@
       "dev": true
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
+      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
       "dev": true,
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -7295,29 +7287,30 @@
       "dev": true
     },
     "node_modules/mocha": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.1.0.tgz",
-      "integrity": "sha512-8uJR5RTC2NgpY3GrYcgpZrsEd9zKbPDpob1RezyR2upGHRQtHWofmzTMzTMSV6dru3tj5Ukt0+Vnq1qhFEEwAg==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-11.8.0.tgz",
+      "integrity": "sha512-VyCeUdGN3A9lmCTTgG4yuvY9ixxaDk+xt2R/7/+1AP6EqNG+G9OKkzBwhVtVYoNX8YsxNSgAl8mOv3IAeOpFbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-colors": "^4.1.3",
         "browser-stdout": "^1.3.1",
-        "chokidar": "^3.5.3",
+        "chokidar": "^4.0.1",
         "debug": "^4.3.5",
-        "diff": "^5.2.0",
+        "diff": "^7.0.0",
         "escape-string-regexp": "^4.0.0",
         "find-up": "^5.0.0",
         "glob": "^10.4.5",
         "he": "^1.2.0",
+        "is-path-inside": "^3.0.3",
         "js-yaml": "^4.1.0",
         "log-symbols": "^4.1.0",
-        "minimatch": "^5.1.6",
+        "minimatch": "^9.0.5",
         "ms": "^2.1.3",
+        "picocolors": "^1.1.1",
         "serialize-javascript": "^6.0.2",
         "strip-json-comments": "^3.1.1",
         "supports-color": "^8.1.1",
-        "workerpool": "^6.5.1",
+        "workerpool": "^9.2.0",
         "yargs": "^17.7.2",
         "yargs-parser": "^21.1.1",
         "yargs-unparser": "^2.0.0"
@@ -7341,13 +7334,29 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/mocha/node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/mocha/node_modules/cliui": {
@@ -7448,22 +7457,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/mocha/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -7505,16 +7498,19 @@
       }
     },
     "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/mocha/node_modules/ms": {
@@ -7560,6 +7556,20 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/mocha/node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/mocha/node_modules/signal-exit": {
@@ -9263,9 +9273,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/semver": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -11027,10 +11037,11 @@
       }
     },
     "node_modules/workerpool": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.5.1.tgz",
-      "integrity": "sha512-Fs4dNYcsdpYSAfVxhnl1L5zTksjvOJxtC5hzMNl+1t9B8hTJTdKDyZ5ju7ztgPy+ft9tBFXoOlDNiOT9WUXZlA==",
-      "dev": true
+      "version": "9.3.4",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-9.3.4.tgz",
+      "integrity": "sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "mime": "3.0.0",
     "mime-format": "2.0.2",
     "postman-url-encoder": "3.0.8",
-    "semver": "7.7.1",
+    "semver": "7.8.5",
     "uuid": "8.3.2"
   },
   "devDependencies": {
@@ -67,7 +67,7 @@
     "karma-chrome-launcher": "^3.2.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
-    "mocha": "^11.1.0",
+    "mocha": "^11.8.0",
     "nyc": "^17.1.0",
     "parse-gitignore": "^2.0.0",
     "postman-jsdoc-theme": "^0.0.3",

--- a/test/unit/item.test.js
+++ b/test/unit/item.test.js
@@ -51,6 +51,29 @@ describe('Item', function () {
 
             expect(item.toJSON()).to.eql(itemDefinition);
         });
+
+        it('should handle responses property and preserve custom HTTP methods on example responses', function () {
+            var itemDefinition = {
+                    name: 'WebDAV Item',
+                    request: {
+                        method: 'PROPFIND',
+                        url: 'https://postman-echo.com/webdav'
+                    },
+                    responses: [{
+                        name: '207 Multi-Status',
+                        code: 207,
+                        request: {
+                            method: 'PROPFIND',
+                            url: 'https://postman-echo.com/webdav'
+                        }
+                    }]
+                },
+                item = new Item(itemDefinition);
+
+            expect(item.responses.count()).to.equal(1);
+            expect(item.responses.idx(0).originalRequest.method).to.equal('PROPFIND');
+            expect(item.toJSON().response[0].originalRequest.method).to.equal('PROPFIND');
+        });
     });
 
     describe('sanity', function () {

--- a/test/unit/response.test.js
+++ b/test/unit/response.test.js
@@ -566,6 +566,41 @@ describe('Response', function () {
                 cookie: []
             });
         });
+
+        it('should correctly parse request definition and preserve custom HTTP methods', function () {
+            var response = new Response({
+                    name: 'custom method response',
+                    request: {
+                        url: 'https://postman-echo.com/resource',
+                        method: 'PROPFIND',
+                        header: [{ key: 'Depth', value: '1' }]
+                    },
+                    code: 207,
+                    body: '<multistatus></multistatus>'
+                }),
+                responseJson = response.toJSON();
+
+            expect(response.originalRequest).to.be.ok;
+            expect(response.originalRequest.method).to.equal('PROPFIND');
+            expect(response.originalRequest.headers.get('Depth')).to.equal('1');
+            expect(responseJson.originalRequest.method).to.equal('PROPFIND');
+            expect(responseJson.code).to.equal(207);
+        });
+
+        it('should preserve custom HTTP methods in originalRequest', function () {
+            var response = new Response({
+                name: 'custom method in originalRequest',
+                originalRequest: {
+                    url: 'https://postman-echo.com/resource',
+                    method: 'LOCK'
+                },
+                code: 200
+            });
+
+            expect(response.originalRequest).to.be.ok;
+            expect(response.originalRequest.method).to.equal('LOCK');
+            expect(response.toJSON().originalRequest.method).to.equal('LOCK');
+        });
     });
 
     describe('timingPhases', function () {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for postman-collection 5.2.1
+// Type definitions for postman-collection 5.3.1
 // Project: https://github.com/postmanlabs/postman-collection
 // Definitions by: PostmanLabs
 // Definitions: https://github.com/DefinitelyTyped/DefinitelyTyped
@@ -2025,6 +2025,8 @@ declare module "postman-collection" {
             body?: string;
             stream?: Buffer | ArrayBuffer;
             responseTime: number;
+            originalRequest?: Request.definition;
+            request?: Request.definition;
         };
         /**
          * @property body - size of the response body in bytes
@@ -2512,7 +2514,7 @@ declare module "postman-collection" {
          */
         type sourceOnePassword = {
             provider: "1password";
-            "1password": {
+            1password: {
                 secretReference: string;
             };
         };
@@ -2817,7 +2819,7 @@ declare module "postman-collection" {
          */
         static readonly PROTOCOL_DELIMITER: string;
         /**
-         * String representation for matching all urls -
+         * String representation for matching all urls - 
          */
         static readonly MATCH_ALL_URLS: string;
     }


### PR DESCRIPTION
## Summary
- Ensure example response objects in `Response` parse and preserve request definitions and custom HTTP methods when instantiated via `originalRequest` or `request` property.
- Support both `responses` and `response` properties in `Item` definitions.
- Update `semver` and `mocha` dependencies to address vulnerability patches.
- Update TypeScript type definitions (`types/index.d.ts`).

Fixes #1419